### PR TITLE
fix: move lint extend react-app to eslintrc. comment out due to failing rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,5 @@
 *.opts
 *.scss
 *.snap
+*.svg
 node_modules/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,8 @@ globals:
 
 parser: 'babel-eslint'
 
+#extends: 'react-app'
+
 plugins:
     - jsx-a11y
     - loosely-restrict-imports

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "start-js": "node scripts/start.js",
     "start": "node scripts/start.js",
     "test": "node scripts/test.js",
+    "test:dev": "jest",
+    "test:coverage": "node scripts/test.js --coverage",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive"
   },
   "dependencies": {
@@ -146,8 +148,5 @@
       "jsx",
       "node"
     ]
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "start-js": "node scripts/start.js",
     "start": "node scripts/start.js",
     "test": "node scripts/test.js",
-    "test:dev": "jest",
-    "test:coverage": "node scripts/test.js --coverage",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive"
   },
   "dependencies": {


### PR DESCRIPTION
once a .eslintrc was made available, it invalidated

```
"eslintConfig": {	
     "extends": "react-app"	
   }
```
in the package.json.  

Moved the extension to eslintrc, where i found out that rules under this extension are failing (and have always been - lint was never a limiting factor to the repo before), so it is commented out for now, like other failing rules that need to be addressed.