### PR TITLE
feat: automate versioning and publish via travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ git:
 branches:
   only:
   - develop
-  - "/^feature\\/.*$/"
-  - "/^fix\\/.*$/"
+  - master
+  - "/^feature\/.*$/"
+  - "/^feat\/.*$/"
+  - "/^fix\/.*$/"
 jobs:
   include:
     - stage: "Fundamental-react: Lint"
@@ -20,3 +22,11 @@ notifications:
   email:
     on_failure: always
     on_success: change
+before_deploy:
+- bash ./ci-scripts/setup_npm.sh
+deploy:
+  - provider: script
+    script: bash ./ci-scripts/publish.sh $TRAVIS_BRANCH $TRAVIS_BUILD_NUMBER
+    on:
+      branch: master
+    skip_cleanup: true

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+git config --global user.email "travis@travisci.org"
+git config --global user.name "travis"
+
+git checkout master
+npm install
+npm run build
+
+# update the package verion and commit to the git repository
+npm run std-version
+
+# pushes changes to master
+git push --quiet --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" "$TRAVIS_BRANCH" > /dev/null 2>&1;
+
+# commit changes made by standard-version to develop branch
+git checkout develop
+git merge master
+git commit -a -m "chore: merge master into develop [ci skip]"
+git push --quiet --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" develop > /dev/null 2>&1;
+
+# publish master to npm
+git checkout master
+npm publish

--- a/ci-scripts/setup_npm.sh
+++ b/ci-scripts/setup_npm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+
+echo "//registry.npmjs.org/:username=${NPM_USERNAME}" >> ~/.npmrc
+echo "//registry.npmjs.org/:email=${NPM_EMAIL}" >> ~/.npmrc
+echo "//registry.npmjs.org/:_password=${NPM_PASSWORD}" > ~/.npmrc
+echo "//registry.npmjs.org/:_authToken=${AUTH_TOKEN}" >> ~/.npmrc

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "predeploy": "npm run build",
         "start-js": "node scripts/start.js",
         "start": "node scripts/start.js",
+        "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
         "test:coverage": "jest --coverage",
         "test:dev": "jest",
         "test": "node scripts/test.js",


### PR DESCRIPTION
Hello 👋 

I've been working on automating versioning and publishing via the travis build.

@droshev Could you add the following environmental variables to travis here: https://travis-ci.org/SAP/fundamental-react/settings
* `GH_TOKEN` (Github access token for publishing back to the repo - we use a build account)
* `NPM_EMAIL`  
* `NPM_USERNAME`
* `AUTH_TOKEN`  (access token from npm account)
* `NPM_PASSWORD`

How this works: 

Every time we merge `develop` into `master`, the [standard-version](https://github.com/conventional-changelog/standard-version) package will automatically bump the version in `package.json` and `package-lock.json` as well as update the `CHANGELOG.md` with commit information. The commit message will be `chore(release): version x.x.x build x [ci skip] `. 
Standard-version bumps the major, minor or patch version by looking for keywords in the pull request message. To bump the patch version, include `fix`, minor: `feat`, major: `BREAKING CHANGE`, to make changes without bumping any versions, use `chore`. 

Once this is complete, the script in `publish.sh` will merge these changes back into the `develop` branch to avoid later merge conflicts.

Finally, the master branch will be published to npm. 

See a working example of this here (if looking at the CHANGELOG, only version after 1.23.0 are valid): https://github.com/jbadan/travis-deployment-test

travis builds here: https://travis-ci.org/jbadan/travis-deployment-test/builds

Changes to current workflow: 

The only change needed is to add "fix", "feat", "BREAKING CHANGE" or "chore" to the pull request message when merging `develop` into `master`. If these are not present, standard-version will default to bumping the minor version.