### PR TITLE
fix:  manually bump version to stop stdversion failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-react",
-  "version": "0.0.14",
+  "version": "0.0.15-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-react",
-  "version": "0.0.14",
+  "version": "0.0.15-rc.0",
   "private": false,
   "license": "Apache-2.0",
   "homepage": "http://sap.github.io/fundamental-react",


### PR DESCRIPTION
Manually bump package version to aid in debugging - prevent standard-version failure (tag already exists in npm). 