### PR TITLE
fix: add fundamental bot to release script

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # publish releases (already tagged by publish_release.sh)
-if [[ "$TRAVIS_COMMIT_MESSAGE" =~ chore\(release\):\sversion\s[0-9]+\.[0-9]+\.[0-9]+$.* ]]; then
+if [[ "$TRAVIS_COMMIT_MESSAGE" =~ chore\(release\):[[:space:]]version[[:space:]][0-9]+\.[0-9]+\.[0-9]+$.* ]]; then
     npm publish
 # bump and publish rc
 else

--- a/ci-scripts/publish_release.sh
+++ b/ci-scripts/publish_release.sh
@@ -25,8 +25,14 @@ hash_upstream=$(git rev-parse $git_branch@{upstream})
 
 set -o errexit
 
+githubEmail=`git config --get user.email`
+githubName=`git config --get user.name`
+
 git config --global user.email "fundamental@sap.com"
 git config --global user.name "fundamental-bot"
 
 npm run std-version:release
 git push --follow-tags origin
+
+git config --global user.email "$githubEmail"
+git config --global user.name "$githubName"

--- a/ci-scripts/publish_release.sh
+++ b/ci-scripts/publish_release.sh
@@ -25,5 +25,8 @@ hash_upstream=$(git rev-parse $git_branch@{upstream})
 
 set -o errexit
 
+git config --global user.email "fundamental@sap.com"
+git config --global user.name "fundamental-bot"
+
 npm run std-version:release
 git push --follow-tags origin


### PR DESCRIPTION
Adds fundamental-bot to release script as it has admin rights to push to master.

Fixes regex where there was possible failures due to use of `/s` for whitespace.