### PR TITLE
fix: eslint no shadow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,7 @@ rules:
     #no-nested-ternary: 2
     no-obj-calls: 2
     no-regex-spaces: 2
-    #no-shadow: 2
+    no-shadow: 2
     no-spaced-func: 2
     #no-sparse-arrays: 2
     no-trailing-spaces: 2

--- a/src/MultiInput/MultiInput.test.js
+++ b/src/MultiInput/MultiInput.test.js
@@ -41,7 +41,7 @@ describe('<MultiInput />', () => {
 
   let wrapper;
 
-  const getListStatus = (wrapper, bIsShown) => {
+  const getListStatus = (bIsShown) => {
     const combobox = wrapper.find(
       `div.fd-combobox-control[aria-expanded=${bIsShown}]`
     );
@@ -83,7 +83,7 @@ describe('<MultiInput />', () => {
     expect(wrapper.state(['bShowList'])).toBe(false);
 
     // check to see if list is not shown
-    let results = getListStatus(wrapper, false);
+    let results = getListStatus(false);
     expect(results.combobox).toHaveLength(1);
     expect(results.popover).toHaveLength(1);
   });
@@ -94,7 +94,7 @@ describe('<MultiInput />', () => {
     expect(wrapper.state(['bShowList'])).toBe(false);
 
     // check to see if list is not shown
-    let results = getListStatus(wrapper, false);
+    let results = getListStatus(false);
     expect(results.combobox).toHaveLength(1);
     expect(results.popover).toHaveLength(1);
 
@@ -105,7 +105,7 @@ describe('<MultiInput />', () => {
     expect(wrapper.state(['bShowList'])).toBe(true);
 
     // check to see if list is shown
-    results = getListStatus(wrapper, true);
+    results = getListStatus(true);
     expect(results.combobox).toHaveLength(1);
     expect(results.popover).toHaveLength(1);
   });
@@ -116,7 +116,7 @@ describe('<MultiInput />', () => {
     expect(wrapper.state(['bShowList'])).toBe(false);
 
     // check to see if list is not shown
-    let results = getListStatus(wrapper, false);
+    let results = getListStatus(false);
     expect(results.combobox).toHaveLength(1);
     expect(results.popover).toHaveLength(1);
 
@@ -129,7 +129,7 @@ describe('<MultiInput />', () => {
     expect(wrapper.state(['bShowList'])).toBe(true);
 
     // check to see if list is shown
-    results = getListStatus(wrapper, true);
+    results = getListStatus(true);
     expect(results.combobox).toHaveLength(1);
     expect(results.popover).toHaveLength(1);
   });

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -16,8 +16,8 @@ export const Table = props => {
                 {tableData.map((row, index) => {
                     return (
                         <tr key={index}>
-                            {row.rowData.map((rowData, index) => {
-                                return <td key={index}>{rowData}</td>;
+                            {row.rowData.map((rowData, cellIndex) => {
+                                return <td key={cellIndex}>{rowData}</td>;
                             })}
                         </tr>
                     );


### PR DESCRIPTION
Enabled the `no-shadow` eslint rule and fixed lint errors.