### PR TITLE
fix: eslint no sparse arrays

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,7 +101,7 @@ rules:
     no-regex-spaces: 2
     #no-shadow: 2
     no-spaced-func: 2
-    #no-sparse-arrays: 2
+    no-sparse-arrays: 2
     no-trailing-spaces: 2
     no-undef: 2
     #no-undefined: 2

--- a/src/Tree/Tree.test.js
+++ b/src/Tree/Tree.test.js
@@ -89,7 +89,7 @@ describe('<Tree />', () => {
             {
               displayText: '',
               linkUrl: 'http://me.com'
-            },,
+            },
             'Data Col 2',
             'Data Col 3',
             'INACTIVE'


### PR DESCRIPTION
Enabled the `no-sparse-arrays` eslint rule and fixed lint errors.