### PR TITLE
fix: eslint valid typeof

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,5 +143,5 @@ rules:
     strict: [2, 'global']
     use-isnan: 2
     #valid-jsdoc: [2, { prefer: { 'return': 'returns'}}]
-    #valid-typeof: 2
+    valid-typeof: 2
     wrap-iife: [2, 'any']

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -62,12 +62,7 @@ export class DatePicker extends Component {
         secondDateYear;
       } else {
       //Checks if the type of date doesn't match those types and that it doesn't contain any special character symbols
-          if (
-              (typeof date !== 'array' ||
-          typeof date !== 'date' ||
-          typeof date !== 'object') &&
-        date.toString().search(regex) !== 1
-          ) {
+          if (date.toString().search(regex) !== 1) {
               return '';
           } else {
               let month = date[0].getMonth();


### PR DESCRIPTION
Enabled the `valid-typeof` eslint rule and fixed lint errors.