### PR TITLE
fix: Prop spreading for SideNavigation

### DIFF
--- a/src/SideNavigation/SideNavigation.js
+++ b/src/SideNavigation/SideNavigation.js
@@ -159,12 +159,12 @@ SideNavList.propTypes = {
 };
 
 export const SideNavGroup = props => {
-    const { title, children, className, headerProps, ...rest } = props;
+    const { title, children, className, titleProps, ...rest } = props;
     return (
         <div
             className={`fd-side-nav__group${className ? ' ' + className : ''}`}
             {...rest}>
-            <h1 {...headerProps} className='fd-side-nav__title'>{title}</h1>
+            <h1 {...titleProps} className='fd-side-nav__title'>{title}</h1>
             {children}
         </div>
     );
@@ -172,5 +172,6 @@ export const SideNavGroup = props => {
 
 SideNavGroup.propTypes = {
     className: PropTypes.string,
-    title: PropTypes.string
+    title: PropTypes.string,
+    titleProps: PropTypes.object
 };

--- a/src/SideNavigation/SideNavigation.js
+++ b/src/SideNavigation/SideNavigation.js
@@ -3,9 +3,9 @@ import { BrowserRouter, Link } from 'react-router-dom';
 import React, { Component } from 'react';
 
 export const SideNav = props => {
-    const { icons, children } = props;
+    const { icons, children, ...rest } = props;
     return (
-        <nav className={`fd-side-nav${icons ? ' fd-side-nav--icons' : ''}`}>
+        <nav {...rest} className={`fd-side-nav${icons ? ' fd-side-nav--icons' : ''}`}>
             {children}
         </nav>
     );
@@ -159,12 +159,12 @@ SideNavList.propTypes = {
 };
 
 export const SideNavGroup = props => {
-    const { title, children, className, ...rest } = props;
+    const { title, children, className, headerProps, ...rest } = props;
     return (
         <div
             className={`fd-side-nav__group${className ? ' ' + className : ''}`}
             {...rest}>
-            <h1 className='fd-side-nav__title'>{title}</h1>
+            <h1 {...headerProps} className='fd-side-nav__title'>{title}</h1>
             {children}
         </div>
     );

--- a/src/SideNavigation/SideNavigation.test.js
+++ b/src/SideNavigation/SideNavigation.test.js
@@ -226,7 +226,7 @@ describe('<SideNavigation />', () => {
         });
 
         test('should allow props to be spread to the SideNavGroup component\'s h1 element', () => {
-            const element = mount(<SideNavGroup headerProps={{'data-sample': 'Sample'}} />);
+            const element = mount(<SideNavGroup titleProps={{'data-sample': 'Sample'}} />);
 
             expect(
                 element.find('h1').getDOMNode().attributes['data-sample'].value

--- a/src/SideNavigation/SideNavigation.test.js
+++ b/src/SideNavigation/SideNavigation.test.js
@@ -196,8 +196,7 @@ describe('<SideNavigation />', () => {
     });
 
     describe('Prop spreading', () => {
-        xtest('should allow props to be spread to the SideNav component', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the SideNav component', () => {
             const element = mount(<SideNav data-sample='Sample' />);
 
             expect(
@@ -226,8 +225,12 @@ describe('<SideNavigation />', () => {
             ).toBe('Sample');
         });
 
-        xtest('should allow props to be spread to the SideNavGroup component\'s h1 element', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the SideNavGroup component\'s h1 element', () => {
+            const element = mount(<SideNavGroup headerProps={{'data-sample': 'Sample'}} />);
+
+            expect(
+                element.find('h1').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
         });
     });
 });


### PR DESCRIPTION
- Spread props to SideNavigation's elements
- Update unit tests

The documentation for this component didn't include the props for the component that I added prop spreading to so I didn't update docs.