### PR TITLE
fix: Prop spreading for Table

### DIFF
--- a/src/Table/Table.Component.js
+++ b/src/Table/Table.Component.js
@@ -131,11 +131,29 @@ export const TableComponent = () => {
 
             <Properties
                 properties={[
-                    { name: 'headers', description: 'array of strings for the column headers of the table' },
+                    {
+                        name: 'headers',
+                        description: 'array of strings for the column headers of the table'
+                    },
                     {
                         name: 'tableData',
-                        description:
-                            'array of objects that contain two properties, rowData (an array of strings containing data for each column in the row), and children (an array of objects containing additional rows).'
+                        description: 'array of objects that contain two properties, rowData (an array of strings containing data for each column in the row), and children (an array of objects containing additional rows).'
+                    },
+                    {
+                        name: 'tableHeaderProps',
+                        description: 'object - additional props to be spread to the thead element.'
+                    },
+                    {
+                        name: 'tableHeaderRowProps',
+                        description: 'object - additional props to be spread to the tr element in the thead.'
+                    },
+                    {
+                        name: 'tableBodyProps',
+                        description: 'object - additional props to be spread to the tbody element.'
+                    },
+                    {
+                        name: 'tableBodyRowProps',
+                        description: 'object or function - additional props to be spread to the tr elements in the tbody. If using a function, the parameters passed will be an object representing the row (from tableData) and the row index.'
                     }
                 ]}
                 type='Inputs' />

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -2,20 +2,36 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 export const Table = props => {
-    const { headers, tableData, className, ...rest } = props;
+    const {
+        headers,
+        tableData,
+        className,
+        tableBodyProps,
+        tableBodyRowProps,
+        tableHeaderProps,
+        tableHeaderRowProps,
+        ...rest
+    } = props;
+
     return (
-        <table className={`fd-table${className ? ' ' + className : ''}`} {...rest}>
-            <thead>
-                <tr>
+        <table {...rest} className={`fd-table${className ? ' ' + className : ''}`}>
+            <thead {...tableHeaderProps}>
+                <tr {...tableHeaderRowProps}>
                     {headers.map((header, index) => {
                         return <th key={index}>{header}</th>;
                     })}
                 </tr>
             </thead>
-            <tbody>
+            <tbody {...tableBodyProps}>
                 {tableData.map((row, index) => {
+                    let rowProps;
+                    if (tableBodyRowProps) {
+                        rowProps = (typeof tableBodyRowProps === 'function'
+                            ? tableBodyRowProps(row, index)
+                            : tableBodyRowProps);
+                    }
                     return (
-                        <tr key={index}>
+                        <tr {...rowProps} key={index}>
                             {row.rowData.map((rowData, cellIndex) => {
                                 return <td key={cellIndex}>{rowData}</td>;
                             })}
@@ -33,5 +49,12 @@ Table.propTypes = {
         }).isRequired
     ).isRequired,
     className: PropTypes.string,
-    headers: PropTypes.array
+    headers: PropTypes.array,
+    tableBodyProps: PropTypes.object,
+    tableBodyRowProps: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.func
+    ]),
+    tableHeaderProps: PropTypes.object,
+    tableHeaderRowProps: PropTypes.object
 };

--- a/src/Table/Table.test.js
+++ b/src/Table/Table.test.js
@@ -56,20 +56,109 @@ describe('<Table />', () => {
             ).toBe('Sample');
         });
 
-        xtest('should allow props to be spread to the Table component\'s thead element', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the Table component\'s thead element', () => {
+            const element = mount(
+                <Table
+                    headers={defaultHeaders}
+                    tableData={defaultData}
+                    tableHeaderProps={{
+                        'data-sample': 'Sample'
+                    }} />
+            );
+
+            expect(
+                element.find('thead').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
         });
 
-        xtest('should allow props to be spread to the Table component\'s thead > tr elements', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the Table component\'s thead > tr element', () => {
+            const element = mount(
+                <Table
+                    headers={defaultHeaders}
+                    tableData={defaultData}
+                    tableHeaderRowProps={{
+                        'data-sample': 'Sample'
+                    }} />
+            );
+
+            expect(
+                element.find('thead > tr').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
         });
 
-        xtest('should allow props to be spread to the Table component\'s tbody element', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the Table component\'s tbody element', () => {
+            const element = mount(
+                <Table
+                    headers={defaultHeaders}
+                    tableBodyProps={{
+                        'data-sample': 'Sample'
+                    }}
+                    tableData={defaultData} />
+            );
+
+            expect(
+                element.find('tbody').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
         });
 
-        xtest('should allow props to be spread to the Table component\'s tbody > tr elements', () => {
-            // TODO: placeholder for this test description once that functionality is built
+        test('should allow props to be spread to the Table component\'s tbody > tr elements via object', () => {
+            const data = [
+                {
+                    rowData: ['Data 1', 'Data 2', 'Data 3', 'Data 4']
+                },
+                {
+                    rowData: ['Data 5', 'Data 6', 'Data 7', 'Data 8']
+                }
+            ];
+            const element = mount(
+                <Table
+                    headers={defaultHeaders}
+                    tableBodyRowProps={{
+                        'data-sample': 'Sample'
+                    }}
+                    tableData={data} />
+            );
+
+            const rows = element.find('tbody > tr');
+
+            expect(rows).toHaveLength(2);
+            expect(
+                rows.at(0).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+            expect(
+                rows.at(1).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
+
+        test('should allow props to be spread to the Table component\'s tbody > tr elements via function', () => {
+            const data = [
+                {
+                    rowData: ['Data 1', 'Data 2', 'Data 3', 'Data 4']
+                },
+                {
+                    rowData: ['Data 5', 'Data 6', 'Data 7', 'Data 8']
+                }
+            ];
+            const element = mount(
+                <Table
+                    headers={defaultHeaders}
+                    tableBodyRowProps={(row, index) => {
+                        return {
+                            'data-sample': `Sample ${index}`
+                        };
+                    }}
+                    tableData={data} />
+            );
+
+            const rows = element.find('tbody > tr');
+
+            expect(rows).toHaveLength(2);
+            expect(
+                rows.at(0).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample 0');
+            expect(
+                rows.at(1).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample 1');
         });
     });
 });


### PR DESCRIPTION
**NOTE:** This supports prop spreading to the table, table header, table header row, table body and table body rows.  The API currently prevents easily prop spreading to table cells so I created a follow-up issue (#259) for that work.