### PR TITLE
chore: add github pages deploy to publish script

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -16,4 +16,8 @@ else
     git push --verbose --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" "$TRAVIS_BRANCH" > /dev/null 2>&1;
 
     npm publish --tag prerelease
+
+    # deploy github pages
+    npm run predeploy
+    npm run deploy
 fi


### PR DESCRIPTION
Currently, the publish script does not include publishing to github pages, this pr automates that process.