### PR TITLE
chore: update readme for consuming library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ https://www.npmjs.com/get-npm).
     npm install fundamental-react
     ```
 
-1. Include the Fiori Fundamentals CSS in your React application. In your App.scss file include the following lines:
+1. Load the fiori-fundamentals styles in App.css
     ```
-    $fd-icons-path: "~fiori-fundamentals/scss/icons/";
-    $fd-fonts-path: "~fiori-fundamentals/scss/fonts/";
-    @import '../node_modules/fiori-fundamentals/scss/all.scss';
+    @import '~fiori-fundamentals/dist/fiori-fundamentals.min.css';
     ```
 
 1. Import components as needed. See [Component Documentation](https://sap.github.io/fundamental-react/) for examples and API details.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ See [Component Documentation](https://sap.github.io/fundamental-react/) for exam
 You will need to install [Node and Node Package Manager](
 https://www.npmjs.com/get-npm).
 
+## Consuming the Library
+
+1. Fundamental-react does not include the SAP Fiori Fundamentals library which is required for styling. Install Fiori Fundamentals:
+    ```
+    npm install fiori-fundamentals
+    ```
+
+1. Install fundamental-react
+    ```
+    npm install fundamental-react
+    ```
+
+1. Include the Fiori Fundamentals CSS in your React application. In your App.scss file include the following lines:
+    ```
+    $fd-icons-path: "~fiori-fundamentals/scss/icons/";
+    $fd-fonts-path: "~fiori-fundamentals/scss/fonts/";
+    @import '../node_modules/fiori-fundamentals/scss/all.scss';
+    ```
+
+1. Import components as needed. See [Component Documentation](https://sap.github.io/fundamental-react/) for examples and API details.
+    ```
+    import { Alert } from 'fundamental-react/dist';
+    ```
+
+
 ## Getting Started
 
 1. Clone this repository to your local machine


### PR DESCRIPTION
This section for consuming the library was accidentally removed in a previous pr. Updates include reference only to App.scss as mentioned in https://github.com/SAP/fundamental-react/issues/267 and included import sample.