### PR TITLE
fix: update publishing script for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   - stage: "Fundamental-react: Test & Lint"
     script: npm run lint && npm run test:coveralls && npm run size
   - stage: Deploy
-    if: (branch = master OR branch = automated_travis_release_do_not_use) AND type = push
+    if: (branch = master OR branch = tmp_branch_for_automated_release_do_not_use) AND type = push
     before_deploy:
     - bash ./ci-scripts/setup_npm.sh
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,15 @@ jobs:
   - stage: "Fundamental-react: Test & Lint"
     script: npm run lint && npm run test:coveralls && npm run size
   - stage: Deploy
-    if: branch = master AND type != pull_request
+    if: (branch = master OR branch = automated_travis_release_do_not_use) AND type = push
     before_deploy:
     - bash ./ci-scripts/setup_npm.sh
     deploy:
       - provider: script
         script: bash ./ci-scripts/publish.sh $TRAVIS_BRANCH $TRAVIS_BUILD_NUMBER
         skip_cleanup: true
+        on:
+          all_branches: true
 notifications:
   email:
     on_failure: always

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 
-
 git config --global user.email "fundamental@sap.com"
 git config --global user.name "fundamental-bot"
 
@@ -9,6 +8,8 @@ npm install
 
 # publish releases
 if [[ "$TRAVIS_BRANCH" = "tmp_branch_for_automated_release_do_not_use" ]]; then
+    # delete tmp_branch_for_automated_release_do_not_use branch from remote
+    git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" :tmp_branch_for_automated_release_do_not_use > /dev/null 2>&1;
 
    # update the package version and commit to the git repository
     npm run std-version
@@ -18,12 +19,8 @@ if [[ "$TRAVIS_BRANCH" = "tmp_branch_for_automated_release_do_not_use" ]]; then
   
     npm publish
 
-    # delete tmp_branch_for_automated_release_do_not_use branch from remote
-    git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" :tmp_branch_for_automated_release_do_not_use > /dev/null 2>&1;
-
 # bump and publish rc
 else
-
     # update the package rc version and commit to the git repository
     npm run std-version -- --prerelease rc --no-verify
 

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -1,15 +1,30 @@
 #! /bin/bash
 
-# publish releases (already tagged by publish_release.sh)
-if [[ "$TRAVIS_COMMIT_MESSAGE" =~ chore\(release\):[[:space:]]version[[:space:]][0-9]+\.[0-9]+\.[0-9]+$.* ]]; then
+
+git config --global user.email "fundamental@sap.com"
+git config --global user.name "fundamental-bot"
+
+git checkout master
+npm install
+
+# publish releases
+if [[ "$TRAVIS_BRANCH" = "automated_travis_release_do_not_use" ]]; then
+
+   # update the package version and commit to the git repository
+    npm run std-version
+    
+    # pushes changes to master
+    git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
+  
     npm publish
+
+    # delete automated_travis_release_do_not_use branch from remote
+    git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" :automated_travis_release_do_not_use > /dev/null 2>&1;
+
 # bump and publish rc
 else
-    git config --global user.email "fundamental@sap.com"
-    git config --global user.name "fundamental-bot"
 
-    git checkout master
-    # update the package verion and commit to the git repository
+    # update the package rc version and commit to the git repository
     npm run std-version -- --prerelease rc --no-verify
 
     # pushes changes to master

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -8,7 +8,7 @@ git checkout master
 npm install
 
 # publish releases
-if [[ "$TRAVIS_BRANCH" = "automated_travis_release_do_not_use" ]]; then
+if [[ "$TRAVIS_BRANCH" = "tmp_branch_for_automated_release_do_not_use" ]]; then
 
    # update the package version and commit to the git repository
     npm run std-version
@@ -18,8 +18,8 @@ if [[ "$TRAVIS_BRANCH" = "automated_travis_release_do_not_use" ]]; then
   
     npm publish
 
-    # delete automated_travis_release_do_not_use branch from remote
-    git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" :automated_travis_release_do_not_use > /dev/null 2>&1;
+    # delete tmp_branch_for_automated_release_do_not_use branch from remote
+    git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" :tmp_branch_for_automated_release_do_not_use > /dev/null 2>&1;
 
 # bump and publish rc
 else

--- a/ci-scripts/publish_release.sh
+++ b/ci-scripts/publish_release.sh
@@ -1,4 +1,3 @@
-
 #! /bin/bash
 NOCOLOR='\033[0m'
 ERROR='\033[31m'
@@ -26,12 +25,12 @@ hash_upstream=$(git rev-parse $git_branch@{upstream})
 
 set -o errexit
 
-git checkout -b automated_travis_release_do_not_use
+git checkout -b tmp_branch_for_automated_release_do_not_use
 git commit --allow-empty -m "chore(release): create new release via script"
 
 # push new branch to trigger travis build
-git push --set-upstream origin automated_travis_release_do_not_use
+git push --set-upstream origin tmp_branch_for_automated_release_do_not_use
 
 # delete branch on local machine
 git checkout master
-git branch -D automated_travis_release_do_not_use
+git branch -D tmp_branch_for_automated_release_do_not_use

--- a/ci-scripts/publish_release.sh
+++ b/ci-scripts/publish_release.sh
@@ -1,3 +1,4 @@
+
 #! /bin/bash
 NOCOLOR='\033[0m'
 ERROR='\033[31m'
@@ -25,14 +26,12 @@ hash_upstream=$(git rev-parse $git_branch@{upstream})
 
 set -o errexit
 
-githubEmail=`git config --get user.email`
-githubName=`git config --get user.name`
+git checkout -b automated_travis_release_do_not_use
+git commit --allow-empty -m "chore(release): create new release via script"
 
-git config --global user.email "fundamental@sap.com"
-git config --global user.name "fundamental-bot"
+# push new branch to trigger travis build
+git push --set-upstream origin automated_travis_release_do_not_use
 
-npm run std-version:release
-git push --follow-tags origin
-
-git config --global user.email "$githubEmail"
-git config --global user.name "$githubName"
+# delete branch on local machine
+git checkout master
+git branch -D automated_travis_release_do_not_use

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "size:debug": "npm run build && size-limit --why",
     "start-js": "node scripts/start.js",
     "start": "node scripts/start.js",
-    "std-version:release": "standard-version -m \"chore(release): version %s\"",
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test:coverage": "jest --coverage",
     "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
Change logic for publishing releases.

`npm run release` will checkout a new branch on your local machine called `automated_travis_release_do_not_use` and use `git push` to trigger a travis build. Travis will then run a deployment based off branch names. Merges to master will still result in a rc release, while builds from `automated_travis_release_do_not_use` will result in a release.
`automated_travis_release_do_not_use` will then be deleted both locally and remotely to ensure this works for multiple releases. 