### PR TITLE
chore: add gh deploy script to publish

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -19,6 +19,8 @@ if [[ "$TRAVIS_BRANCH" = "tmp_branch_for_automated_release_do_not_use" ]]; then
   
     npm publish
 
+    npm run deploy
+
 # bump and publish rc
 else
     # update the package rc version and commit to the git repository


### PR DESCRIPTION
Adds gh-pages release to publish script. Tested that this does run predeploy and deploy at the same time.