### PR TITLE
fix: enable jsx-a11y/aria-role lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,7 @@ rules:
     jsx-a11y/aria-activedescendant-has-tabindex: 2
     jsx-a11y/aria-props: 2
     jsx-a11y/aria-proptypes: 2
-    #jsx-a11y/aria-role: 2
+    jsx-a11y/aria-role: 2
     jsx-a11y/aria-unsupported-elements: 2
     #jsx-a11y/click-events-have-key-events: 2
     jsx-a11y/heading-has-content: 2

--- a/src/Identifier/Identifier.js
+++ b/src/Identifier/Identifier.js
@@ -18,7 +18,7 @@ export const Identifier = ({ glyph, size, modifier, color, label, backgroundImag
         className
     );
 
-    const ariaRole = `${!children ? 'presentation' : ''}`;
+    const ariaRole = !children ? 'presentation' : '';
 
     return (
         <span

--- a/src/Identifier/Identifier.js
+++ b/src/Identifier/Identifier.js
@@ -18,12 +18,14 @@ export const Identifier = ({ glyph, size, modifier, color, label, backgroundImag
         className
     );
 
+    const ariaRole = `${!children ? 'presentation' : ''}`;
+
     return (
         <span
             {...props}
             aria-label={label}
             className={identifierClasses}
-            role={`${!children ? 'presentation' : ''}`}
+            role={ariaRole}
             style={backgroundImageUrl && styles}>
             {children}
         </span>

--- a/src/Identifier/Identifier.test.js
+++ b/src/Identifier/Identifier.test.js
@@ -71,4 +71,21 @@ describe('<Identifier />', () => {
             ).toBe('Sample');
         });
     });
+    describe('Roles', () => {
+        test('should have role of presentation by default', () => {
+            const element = mount(<Identifier />);
+
+            expect(
+                element.getDOMNode().attributes.role.value
+            ).toBe('presentation');
+        });
+
+        test('should have empty role if children prop is passed', () => {
+            const element = mount(<Identifier children='Test child' />);
+
+            expect(
+                element.getDOMNode().attributes.role.value
+            ).toBe('');
+        });
+    });
 });


### PR DESCRIPTION
Enables jsx-a11y/aria-role lint rule by moving logic out of role in Identifier and adds unit tests for role.