### PR TITLE
fix: Playground component to use onBlur and onChange

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,7 @@ rules:
     #jsx-a11y/no-noninteractive-element-interactions: 2
     #jsx-a11y/no-noninteractive-element-to-interactive-role: [2, { ul: ['tablist', 'menu']}]
     jsx-a11y/no-noninteractive-tabindex: 2
-    #jsx-a11y/no-onchange: 2
+    jsx-a11y/no-onchange: 2
     jsx-a11y/no-redundant-roles: 2
     #jsx-a11y/no-static-element-interactions: 2
     jsx-a11y/role-has-required-aria-props: 2

--- a/src/_playground/documentation/Playground/Playground.js
+++ b/src/_playground/documentation/Playground/Playground.js
@@ -191,7 +191,7 @@ export class Playground extends Component {
                               <input
                                   className='form-control'
                                   name={item.attribute}
-                                  onBlur={this.updateComponent}
+                                  onChange={this.updateComponent}
                                   type='text'
                                   value={item.initialValue} />
                           )}

--- a/src/_playground/documentation/Playground/Playground.js
+++ b/src/_playground/documentation/Playground/Playground.js
@@ -179,6 +179,7 @@ export class Playground extends Component {
                               <select
                                   className='form-control'
                                   name={item.attribute}
+                                  onBlur={this.updateComponent}
                                   onChange={this.updateComponent}>
                                   {item.enum.map(enumItem => (
                                       <option key={enumItem} value={enumItem}>
@@ -190,7 +191,7 @@ export class Playground extends Component {
                               <input
                                   className='form-control'
                                   name={item.attribute}
-                                  onChange={this.updateComponent}
+                                  onBlur={this.updateComponent}
                                   type='text'
                                   value={item.initialValue} />
                           )}
@@ -205,6 +206,7 @@ export class Playground extends Component {
                               <select
                                   className='form-control'
                                   name={item.attribute}
+                                  onBlur={this.updateComponent}
                                   onChange={this.updateComponent}>
                                   {item.enum.map(enumItem => (
                                       <option key={enumItem}>{enumItem}</option>
@@ -279,6 +281,7 @@ export class Playground extends Component {
                               <select
                                   className='form-control'
                                   name={item.attribute}
+                                  onBlur={this.updateComponentType}
                                   onChange={this.updateComponentType}>
                                   {item.enum.map(enumItem => (
                                       <option key={enumItem} value={enumItem}>


### PR DESCRIPTION
Add onBlur to playground component's <select> elements. Another option is to remove the onChange events from these <select> elements entirely. 

#245 