### PR TITLE
fix: add roles to static element interactions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,7 +62,7 @@ rules:
     jsx-a11y/no-noninteractive-tabindex: 2
     #jsx-a11y/no-onchange: 2
     jsx-a11y/no-redundant-roles: 2
-    #jsx-a11y/no-static-element-interactions: 2
+    jsx-a11y/no-static-element-interactions: 2
     jsx-a11y/role-has-required-aria-props: 2
     #jsx-a11y/role-supports-aria-props: 2
     jsx-a11y/scope: 2

--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -426,10 +426,8 @@ export class Calendar extends Component {
                         </button>
                     </div>
 
-                    <div className='fd-calendar__action'
-                        onClick={this.next}
-                        role='presentation'>
-                        <button className='fd-button--standard fd-button--light fd-button--compact sap-icon--slim-arrow-right' />
+                    <div className='fd-calendar__action'>
+                        <button className='fd-button--standard fd-button--light fd-button--compact sap-icon--slim-arrow-right' onClick={this.next} />
                     </div>
                 </div>
             </header>

--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -426,7 +426,9 @@ export class Calendar extends Component {
                         </button>
                     </div>
 
-                    <div className='fd-calendar__action' onClick={this.next}>
+                    <div className='fd-calendar__action'
+                        onClick={this.next}
+                        role='presentation'>
                         <button className='fd-button--standard fd-button--light fd-button--compact sap-icon--slim-arrow-right' />
                     </div>
                 </div>

--- a/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
+++ b/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
@@ -11,6 +11,7 @@ exports[`<ComboboxInput /> create combobox input 1`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <div
         className="fd-combobox-control"
@@ -93,6 +94,7 @@ exports[`<ComboboxInput /> create combobox input 2`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <div
         className="fd-combobox-control"

--- a/src/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -11,6 +11,7 @@ exports[`<Dropdown /> create dropdown component 1`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <button
         className="fd-button fd-dropdown__control"
@@ -80,6 +81,7 @@ exports[`<Dropdown /> create dropdown component 2`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <button
         className="fd-button fd-dropdown__control fd-button--compact"
@@ -149,6 +151,7 @@ exports[`<Dropdown /> create dropdown component 3`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <button
         className="fd-button fd-button--standard fd-dropdown__control"
@@ -219,6 +222,7 @@ exports[`<Dropdown /> create dropdown component 4`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <button
         className="fd-button fd-dropdown__control sap-icon--filter"
@@ -291,6 +295,7 @@ exports[`<Dropdown /> create dropdown component 5`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <button
         className="fd-button fd-dropdown__control sap-icon--filter is-disabled"

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -15,7 +15,9 @@ export const Icon = ({ glyph, size, clickHandler, className, ...props }) => {
         <span
             {...props}
             className={iconClasses}
-            onClick={clickHandler} />
+            onClick={clickHandler}
+            role='button'
+            tabIndex='0' />
     );
 };
 

--- a/src/Icon/Icon.test.js
+++ b/src/Icon/Icon.test.js
@@ -33,6 +33,16 @@ describe('<Icon />', () => {
         expect(wrapper.prop('clickHandler')).toBeUndefined;
     });
 
+    describe('rendering', () => {
+        test('should have role button', () => {
+            const element = mount(<Icon glyph='cart' />);
+
+            expect(
+                element.getDOMNode().attributes.role.value
+            ).toBe('button');
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Icon component', () => {
             const element = mount(<Icon data-sample='Sample' glyph='cart' />);

--- a/src/Icon/__snapshots__/Icon.test.js.snap
+++ b/src/Icon/__snapshots__/Icon.test.js.snap
@@ -4,6 +4,8 @@ exports[`<Icon /> create icon 1`] = `
 <span
   className="sap-icon--cart blue"
   onClick={[MockFunction]}
+  role="button"
+  tabIndex="0"
 />
 `;
 
@@ -11,5 +13,7 @@ exports[`<Icon /> create icon 2`] = `
 <span
   className="sap-icon--cart sap-icon--s"
   onClick={[Function]}
+  role="button"
+  tabIndex="0"
 />
 `;

--- a/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
+++ b/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
@@ -11,6 +11,7 @@ exports[`<LocalizationEditor /> create localization editor 1`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <div>
         <label
@@ -114,6 +115,7 @@ exports[`<LocalizationEditor /> create localization editor 2`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <div>
         <label
@@ -217,6 +219,7 @@ exports[`<LocalizationEditor /> create localization editor 3`] = `
       aria-expanded={false}
       className="fd-popover__control"
       onClick={[Function]}
+      role="button"
     >
       <div>
         <label

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -63,7 +63,8 @@ export const MenuItem = ({ url, link, isLink, separator, addon, children, onclic
                 }
                 {(!url && !link) && <a {...linkProps}
                     className='fd-menu__item'
-                    onClick={onclick}>{children}</a>}
+                    onClick={onclick}
+                    role='button'>{children}</a>}
             </li>
             {separator && <hr />}
         </React.Fragment>

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -106,6 +106,16 @@ describe('<Menu />', () => {
         expect(tree).toMatchSnapshot();
     });
 
+    describe('rendering', () => {
+        test('Menu item anchor tag should have role of button', () => {
+            const element = mount(<MenuItem />);
+
+            expect(
+                element.find('a').getDOMNode().attributes.role.value
+            ).toBe('button');
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Menu component', () => {
             const element = mount(<Menu data-sample='Sample' />);

--- a/src/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/Menu/__snapshots__/Menu.test.js.snap
@@ -42,6 +42,7 @@ exports[`<Menu /> create basic menu component 1`] = `
     <li>
       <a
         className="fd-menu__item"
+        role="button"
       >
         Option 5
       </a>

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -98,7 +98,8 @@ export class Popover extends Component {
                     aria-controls={id}
                     aria-expanded={this.state.isExpanded}
                     className='fd-popover__control'
-                    onClick={this.triggerBody}>
+                    onClick={this.triggerBody}
+                    role='button'>
                     {control}
                 </div>
                 <div

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -142,6 +142,16 @@ describe('<Popover />', () => {
         expect(wrapper.state('isExpanded')).toBeFalsy();
     });
 
+    describe('rendering', () => {
+        test('trigger should have a role of button', () => {
+            const element = mount(<Popover />);
+
+            expect(
+                element.find('div.fd-popover__control').getDOMNode().attributes.role.value
+            ).toBe('button');
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Popover component', () => {
             const element = mount(<Popover data-sample='Sample' />);

--- a/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__snapshots__/Popover.test.js.snap
@@ -8,10 +8,13 @@ exports[`<Popover /> create Popover 1`] = `
     aria-expanded={false}
     className="fd-popover__control"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="sap-icon--cart sap-icon--xl"
       onClick={[Function]}
+      role="button"
+      tabIndex="0"
     />
   </div>
   <div
@@ -71,10 +74,13 @@ exports[`<Popover /> create Popover 2`] = `
     aria-expanded={false}
     className="fd-popover__control"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="sap-icon--cart sap-icon--xl"
       onClick={[Function]}
+      role="button"
+      tabIndex="0"
     />
   </div>
   <div
@@ -133,10 +139,13 @@ exports[`<Popover /> create Popover 3`] = `
     aria-expanded={false}
     className="fd-popover__control"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="sap-icon--cart sap-icon--xl"
       onClick={[Function]}
+      role="button"
+      tabIndex="0"
     />
   </div>
   <div
@@ -195,10 +204,13 @@ exports[`<Popover /> create Popover 4`] = `
     aria-expanded={false}
     className="fd-popover__control"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="sap-icon--cart sap-icon--xl"
       onClick={[Function]}
+      role="button"
+      tabIndex="0"
     />
   </div>
   <div

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -274,7 +274,8 @@ export class Shellbar extends Component {
                                                         <MenuItem>
                                                             <span
                                                                 className='fd-menu sap-icon--nav-back'
-                                                                onClick={this.backBtnHandler} />
+                                                                onClick={this.backBtnHandler}
+                                                                role='button' />
                                                         </MenuItem>
                                                         {productSwitcherList.map((item, index) => {
                                                             return (

--- a/src/Shellbar/__snapshots__/Shellbar.test.js.snap
+++ b/src/Shellbar/__snapshots__/Shellbar.test.js.snap
@@ -44,6 +44,7 @@ exports[`<Shellbar /> create shellbar 1`] = `
               aria-expanded={false}
               className="fd-popover__control"
               onClick={[Function]}
+              role="button"
             >
               <span
                 className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
@@ -65,6 +66,7 @@ exports[`<Shellbar /> create shellbar 1`] = `
                   <li>
                     <a
                       className="fd-menu__item"
+                      role="button"
                     >
                       John Snow
                     </a>
@@ -73,10 +75,13 @@ exports[`<Shellbar /> create shellbar 1`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--action-settings sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Settings
@@ -86,10 +91,13 @@ exports[`<Shellbar /> create shellbar 1`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--log sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Sign Out
@@ -150,6 +158,7 @@ exports[`<Shellbar /> create shellbar 2`] = `
               aria-expanded={false}
               className="fd-popover__control"
               onClick={[Function]}
+              role="button"
             >
               <span
                 className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
@@ -171,6 +180,7 @@ exports[`<Shellbar /> create shellbar 2`] = `
                   <li>
                     <a
                       className="fd-menu__item"
+                      role="button"
                     >
                       John Snow
                     </a>
@@ -179,10 +189,13 @@ exports[`<Shellbar /> create shellbar 2`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--action-settings sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Settings
@@ -192,10 +205,13 @@ exports[`<Shellbar /> create shellbar 2`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--log sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Sign Out
@@ -240,6 +256,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
             aria-expanded={false}
             className="fd-popover__control"
             onClick={[Function]}
+            role="button"
           >
             <button
               className="fd-product-menu__control"
@@ -265,6 +282,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   <a
                     className="fd-menu__item"
                     onClick={[Function]}
+                    role="button"
                   >
                     Application A
                   </a>
@@ -273,6 +291,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   <a
                     className="fd-menu__item"
                     onClick={[Function]}
+                    role="button"
                   >
                     Application B
                   </a>
@@ -281,6 +300,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   <a
                     className="fd-menu__item"
                     onClick={[Function]}
+                    role="button"
                   >
                     Application C
                   </a>
@@ -289,6 +309,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   <a
                     className="fd-menu__item"
                     onClick={[Function]}
+                    role="button"
                   >
                     Application D
                   </a>
@@ -373,6 +394,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
             aria-expanded={false}
             className="fd-popover__control"
             onClick={[Function]}
+            role="button"
           >
             <button
               aria-label="Settings"
@@ -432,6 +454,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
           aria-expanded={false}
           className="fd-popover__control"
           onClick={[Function]}
+          role="button"
         >
           <div
             className="fd-shellbar__action fd-shellbar__action--collapsible"
@@ -500,6 +523,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
               aria-expanded={false}
               className="fd-popover__control"
               onClick={[Function]}
+              role="button"
             >
               <div
                 className="fd-shellbar-collapse--control"
@@ -533,10 +557,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--search"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                        
                       Search
@@ -546,10 +573,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--settings"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       >
                         <span
                           aria-label="Unread count"
@@ -566,10 +596,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--bell"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       >
                         <span
                           aria-label="Unread count"
@@ -586,10 +619,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--grid"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                        
                       Product Switcher
@@ -614,6 +650,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
               aria-expanded={false}
               className="fd-popover__control"
               onClick={[Function]}
+              role="button"
             >
               <span
                 className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
@@ -635,6 +672,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   <li>
                     <a
                       className="fd-menu__item"
+                      role="button"
                     >
                       John Snow
                     </a>
@@ -643,10 +681,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--action-settings sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Settings
@@ -656,10 +697,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                     <a
                       className="fd-menu__item"
                       onClick={[Function]}
+                      role="button"
                     >
                       <span
                         className="sap-icon--log sap-icon--s"
                         onClick={[Function]}
+                        role="button"
+                        tabIndex="0"
                       />
                          
                       Sign Out
@@ -684,6 +728,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
               aria-expanded={false}
               className="fd-popover__control"
               onClick={[Function]}
+              role="button"
             >
               <button
                 className=" fd-button--shell sap-icon--grid"

--- a/src/Tile/__snapshots__/Tile.test.js.snap
+++ b/src/Tile/__snapshots__/Tile.test.js.snap
@@ -89,6 +89,7 @@ exports[`<Tile /> create tile component 4`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <button
           className="fd-button fd-button--standard sap-icon--vertical-grip"
@@ -197,6 +198,7 @@ exports[`<Tile /> create tile component 6`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <button
           className="fd-button fd-button--standard sap-icon--vertical-grip"

--- a/src/TimePicker/__snapshots__/TimePicker.test.js.snap
+++ b/src/TimePicker/__snapshots__/TimePicker.test.js.snap
@@ -16,6 +16,7 @@ exports[`<TimePicker /> create time picker 1`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -198,6 +199,7 @@ exports[`<TimePicker /> create time picker 2`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -417,6 +419,7 @@ exports[`<TimePicker /> create time picker 3`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -561,6 +564,7 @@ exports[`<TimePicker /> create time picker 4`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -743,6 +747,7 @@ exports[`<TimePicker /> create time picker 5`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -962,6 +967,7 @@ exports[`<TimePicker /> create time picker 6`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -1181,6 +1187,7 @@ exports[`<TimePicker /> create time picker 7`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -1400,6 +1407,7 @@ exports[`<TimePicker /> create time picker 8`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -1544,6 +1552,7 @@ exports[`<TimePicker /> create time picker 9`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"
@@ -1725,6 +1734,7 @@ exports[`<TimePicker /> create time picker 10`] = `
         aria-expanded={false}
         className="fd-popover__control"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="fd-popover__control"


### PR DESCRIPTION
Adds role='button' to static element interactions.

Adds unit tests for Icon, Menu, Popover new roles. Skipped unit test on Shellbar per plan to refactor (https://github.com/SAP/fundamental-react/issues/266).

Updated snapshots.

#245 