### PR TITLE
chore: disable anchor a11y rule on documentation pages

### DIFF
--- a/src/Alert/Alert.Component.js
+++ b/src/Alert/Alert.Component.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import { Alert, Icon } from '../';
 import { Description, DocsText, DocsTile, Header, Import, Playground, Properties, Separator } from '../_playground';

--- a/src/ListGroup/ListGroup.Component.js
+++ b/src/ListGroup/ListGroup.Component.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import { Button, ListGroup, ListGroupItem, ListGroupItemActions, ListGroupItemCheckbox } from '../';
 import { Description, DocsText, DocsTile, Header, Import, Playground, Properties, Separator } from '../_playground';

--- a/src/ListGroup/ListGroup.test.js
+++ b/src/ListGroup/ListGroup.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button } from '../Button/Button';
 import { mount } from 'enzyme';
 import React from 'react';

--- a/src/Table/Table.Component.js
+++ b/src/Table/Table.Component.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import { Button, Image, Menu, MenuItem, MenuList, Popover, Table } from '../';
 import { Description, DocsText, DocsTile, Header, Import, Properties, Separator } from '../_playground';


### PR DESCRIPTION
### Description
Disabling lint rule on component documentation pages. This is prework for changes needed in ShellBar and Pagination before the lint rule can be fully enabled.

#245 