### PR TITLE
chore: update no-noninteractive-element-to-interactive-role rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,7 +59,7 @@ rules:
     jsx-a11y/no-distracting-elements: 2
     jsx-a11y/no-interactive-element-to-noninteractive-role: 2
     #jsx-a11y/no-noninteractive-element-interactions: 2
-    #jsx-a11y/no-noninteractive-element-to-interactive-role: [2, { ul: ['tablist', 'menu']}]
+    #jsx-a11y/no-noninteractive-element-to-interactive-role: [2, { ul: ['tablist', 'menu', 'tree'], li: ['treeitem']}]
     jsx-a11y/no-noninteractive-tabindex: 2
     jsx-a11y/no-onchange: 2
     jsx-a11y/no-redundant-roles: 2


### PR DESCRIPTION
### Description
@jeffredodd  and I came to the conclusion that this rule is too strict for Tree components.   

This disables the no-noninteractive-element-to-interactive-role lint rule for `<ul role='tree'>` and `<li role='treeitem'>`. The way these are currently used match the WAI spec: https://www.w3.org/TR/wai-aria-1.1/#tree

To enable this rule completely, subsequent work is needed on Calendar, SearchInput components.

#245 