### PR TITLE
fix: gh-pages deployment process

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -43,9 +43,9 @@ const env = getClientEnvironment(publicUrl);
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
-if (env.stringified['process.env'].NODE_ENV !== '"production"') {
-  throw new Error('Production builds must have NODE_ENV=production.');
-}
+// if (env.stringified['process.env'].NODE_ENV !== '"production"') {
+//   throw new Error('Production builds must have NODE_ENV=production.');
+// }
 
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive"
   },
   "dependencies": {
-    "annotated-prop-types": "^0.3.0",
     "classnames": "^2.2.6",
     "fiori-fundamentals": "^1.4.0",
     "react-router": "^4.3.1",
@@ -41,6 +40,7 @@
     "react-syntax-highlighter": "^9.0.1"
   },
   "devDependencies": {
+    "annotated-prop-types": "^0.3.0",
     "@babel/cli": "^7.1.5",
     "@babel/core": "7.1.0",
     "@babel/polyfill": "^7.1.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = 'development';
+process.env.NODE_ENV = 'development';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
### Description
In order to get proptypes working, we need to be development mode when we deploy to github pages. This is a stop gap measure for the meantime and will be addressed by a future story - either converting to production or lerna.