### PR TITLE
chore: add background toggle for examples

### DIFF
--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -96,6 +96,12 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
                     justify-content: flex-end;
                     margin: 15px;
                 }
+
+                .frDocs-tile__centered {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                }
             }
             .frDocs-Content__tile-background {
                 background: #edeef0;
@@ -110,10 +116,6 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
 }
 
 .fd-tile__content {
-
-    .centered {
-        text-align: center;
-    }
 
     .fd-button--grouped {
         margin-right: 0;

--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -90,7 +90,15 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
                 border: 1px solid #ccc;
                 border-bottom: none;
                 padding: 10px 0;
-                background-color: '#f3f4f5'
+                
+                .frDocs-tile__background-toggle {
+                    display: flex;
+                    justify-content: flex-end;
+                    margin: 15px;
+                }
+            }
+            .frDocs-Content__tile-background {
+                background: #edeef0!important;
             }
         }
     }

--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -110,6 +110,11 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
 }
 
 .fd-tile__content {
+
+    .centered {
+        text-align: center;
+    }
+
     .fd-button--grouped {
         margin-right: 0;
     }

--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -98,7 +98,7 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
                 }
             }
             .frDocs-Content__tile-background {
-                background: #edeef0!important;
+                background: #edeef0;
             }
         }
     }

--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -105,6 +105,7 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
             }
             .frDocs-Content__tile-background {
                 background: #edeef0;
+                transition: background-color .25s;
             }
         }
     }

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -21,10 +21,6 @@ export class DocsTile extends Component {
     };
 
     render() {
-        const centerStyle = {
-            textAlign: 'center'
-        };
-
         const {centered, children} = this.props;
 
         const outerDivClasses = classnames(
@@ -41,15 +37,9 @@ export class DocsTile extends Component {
                     inputProps={{'aria-label': 'Toggle background color'}}
                     onChange={this.handleToggle}
                     size='xs' />
-                {centered
-                    ? (
-                        <div className='fd-tile__content'>
-                            <div style={centerStyle}>{children}</div>
-                        </div>
-                    )
-                    : (
-                        <div className='fd-tile__content'>{children}</div>
-                    )}
+                <div className='fd-tile__content'>
+                    {centered ? (<div className='centered'>{children}</div>) : children}
+                </div>
             </div>
         );
     }

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -43,7 +43,7 @@ export class DocsTile extends Component {
                     className='frDocs-tile__background-toggle'
                     inputProps={{'aria-label': 'Toggle background color'}}
                     onChange={this.handleToggle}
-                    size='xs' />
+                    size='xs'>Toggle background</Toggle>
                 <div className={innerDivClasses}>
                     {children}
                 </div>

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -1,30 +1,59 @@
 import { Button } from '../../../Button/Button';
+import classnames from 'classnames';
 import { googlecode } from 'react-syntax-highlighter/styles/hljs';
 import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
+import { Toggle } from '../../../Toggle/Toggle';
 import React, { Component } from 'react';
 
-export const DocsTile = props => {
-    const centerStyle = {
-        textAlign: 'center'
+export class DocsTile extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            backgroundToggle: false
+        };
+    }
+
+    handleToggle = () => {
+        this.setState({
+            backgroundToggle: !this.state.backgroundToggle
+        });
     };
 
-    const {centered, children} = props;
+    render() {
+        const centerStyle = {
+            textAlign: 'center'
+        };
 
-    return (
-        <div className='frDocs-Content__tile'>
-            {centered
-                ? (
-                    <div className='fd-tile__content'>
-                        <div style={centerStyle}>{children}</div>
-                    </div>
-                )
-                : (
-                    <div className='fd-tile__content'>{children}</div>
-                )}
-        </div>
-    );
-};
+        const {centered, children} = this.props;
+
+        const outerDivClasses = classnames(
+            'frDocs-Content__tile',
+            {
+                'frDocs-Content__tile-background': this.state.backgroundToggle
+            }
+        );
+
+        return (
+            <div className={outerDivClasses}>
+                <Toggle
+                    className='frDocs-tile__background-toggle'
+                    inputProps={{'aria-label': 'Toggle background color'}}
+                    onChange={this.handleToggle}
+                    size='xs' />
+                {centered
+                    ? (
+                        <div className='fd-tile__content'>
+                            <div style={centerStyle}>{children}</div>
+                        </div>
+                    )
+                    : (
+                        <div className='fd-tile__content'>{children}</div>
+                    )}
+            </div>
+        );
+    }
+}
 
 DocsTile.propTypes = {
     centered: PropTypes.bool,

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -26,7 +26,14 @@ export class DocsTile extends Component {
         const outerDivClasses = classnames(
             'frDocs-Content__tile',
             {
-                'frDocs-Content__tile-background': this.state.backgroundToggle
+                'frDocs-Content__tile-background': !this.state.backgroundToggle
+            }
+        );
+
+        const innerDivClasses = classnames(
+            'fd-tile__content',
+            {
+                'frDocs-tile__centered': centered
             }
         );
 
@@ -37,8 +44,8 @@ export class DocsTile extends Component {
                     inputProps={{'aria-label': 'Toggle background color'}}
                     onChange={this.handleToggle}
                     size='xs' />
-                <div className='fd-tile__content'>
-                    {centered ? (<div className='centered'>{children}</div>) : children}
+                <div className={innerDivClasses}>
+                    {children}
                 </div>
             </div>
         );


### PR DESCRIPTION
### Description
Adds light and dark mode for examples as seen in Fundamental NGX and Fiori Fundamentals.

![2019-01-30 13 59 27](https://user-images.githubusercontent.com/29607818/52015722-7a2de300-2497-11e9-928c-dd149da38622.gif)

fixes #300 