### PR TITLE
fix: Calendar component tests failing in Travis

### DIFF
--- a/src/Calendar/Calendar.test.js
+++ b/src/Calendar/Calendar.test.js
@@ -85,7 +85,6 @@ describe('<Calendar />', () => {
             .at(1)
             .simulate('click');
 
-
         expect(wrapper.state('showMonths')).toBeTruthy();
 
         wrapper


### PR DESCRIPTION
### Description

We need to force set an initial date that exists in every month to avoid tests failing on the 31st of every month. 

We should audit other tests and relook at how Calendar and DatePicker are working to make sure this won't happen for other tests.