### PR TITLE
fix: set currentDateDisplayed on date click

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -113,6 +113,8 @@ export class Calendar extends Component {
         let date = this.state.currentDateDisplayed;
         let months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
         date.setMonth(months.indexOf(month));
+        // reset date to first of month
+        date.setDate(1);
 
         //updates month state
         if (!this.props.enableRangeSelection) {
@@ -270,6 +272,7 @@ export class Calendar extends Component {
         }
 
         this.setState({
+            currentDateDisplayed: day,
             selectedDate: day,
             arrSelectedDates: selectedDates,
             dateClick: true
@@ -565,7 +568,7 @@ Calendar.propTypes = {
 };
 
 Calendar.defaultProps = {
-    onChange: () => {}
+    onChange: () => { }
 };
 
 Calendar.propDescriptions = {

--- a/src/Calendar/Calendar.test.js
+++ b/src/Calendar/Calendar.test.js
@@ -96,6 +96,9 @@ describe('<Calendar />', () => {
         const currentDateDisplayed = wrapper.state('currentDateDisplayed');
 
         expect(currentDateDisplayed.getMonth()).toEqual(3);
+
+        // check that first of month is selected
+        expect(currentDateDisplayed.getDate()).toEqual(1);
     });
 
     test('click month from list with date range', () => {
@@ -320,20 +323,10 @@ describe('<Calendar />', () => {
             .at(0)
             .simulate('click');
 
-        const currentDateDisplayed = new Date(wrapper.state('selectedDate'));
+        let selectedDate = new Date(wrapper.state('selectedDate'));
+        let currentDateDisplayed = new Date(wrapper.state('currentDateDisplayed'));
 
-        // select 2nd day of month
-        wrapper
-            .find(
-                'table.fd-calendar__table tbody.fd-calendar__group tr.fd-calendar__row td.fd-calendar__item:not(.fd-calendar__item--other-month)'
-            )
-            .at(1)
-            .simulate('click');
-
-        const newDateDisplayed = wrapper.state('selectedDate');
-        currentDateDisplayed.setDate(currentDateDisplayed.getDate() + 1);
-
-        expect(newDateDisplayed.getDate()).toEqual(currentDateDisplayed.getDate());
+        expect(selectedDate.getDate()).toEqual(currentDateDisplayed.getDate());
     });
 
     test('click on day with range enabled', () => {


### PR DESCRIPTION
### Description
Updated component to set **currentDateDisplayed** on date click. Also sets the value to the first of a month after selection from the Month picker.  If the **currentDateDisplayed** does not get updated to the first of the month on Month change. There would be an issue when switching from March 30th to Feb.


fixes #334 