### PR TITLE
fix: Removed bin config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "https://github.com/SAP/fundamental-react"
   },
-  "bin": {
-    "create-release": "ci-scripts/create-release.js"
-  },
   "scripts": {
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "build-doc": "node scripts/build.js",


### PR DESCRIPTION
### Description
I was making improper use of the `bin` config option in `package.json`.  Since the script in this block isn't exported as part of the distribution package, adding this to the path causes a failure.

fixes #347 