### PR TITLE
fix: update css specificity for markdown

### DIFF
--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -78,13 +78,13 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
             padding-left: 1rem;
             padding-right: 1rem;
 
-            .frDocs-Content__header, h1 {
+            .frDocs-Content__header, .frDocs-markdown > h1 {
                 margin: 12px 0;
                 margin-top: 2rem;
                 font-size: 2.2rem;
             }
 
-            .frDocs-Content__description, p {
+            .frDocs-Content__description, .frDocs-markdown > p {
                 margin-bottom: 1.5rem;
                 font-size: 1rem;
                 font-weight: 300;


### PR DESCRIPTION
### Description

When adding styles for pages imported from markdown, I inadvertently overrode styles for the Side Navigation component. 

![screen shot 2019-02-05 at 7 33 19 am](https://user-images.githubusercontent.com/29607818/52284063-8d6a0400-2918-11e9-80ca-e5ac6b8983f6.png)
![screen shot 2019-02-05 at 7 33 09 am](https://user-images.githubusercontent.com/29607818/52284068-9064f480-2918-11e9-965a-4aa95f1c18d8.png)
 

fixes #354 