### PR TITLE
chore: move syntax highlighter to dev Dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "classnames": "^2.2.6",
     "fiori-fundamentals": "^1.4.0",
     "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
-    "react-syntax-highlighter": "^9.0.1"
+    "react-router-dom": "^4.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
@@ -106,6 +105,7 @@
     "react-dev-utils": "^6.1.1",
     "react-dom": "^16.6.3",
     "react-markdown": "^4.0.6",
+    "react-syntax-highlighter": "^9.0.1",
     "react-test-renderer": "^16.6.3",
     "resolve": "1.8.1",
     "sass-loader": "7.1.0",


### PR DESCRIPTION
### Description
react-syntax-highlighter should be a devDep