### PR TITLE
chore: H1 margin; normalize content padding

### DIFF
--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -75,8 +75,7 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
             padding: 2rem;
 
             .frDocs-Content__header, .frDocs-markdown > h1 {
-                margin: 12px 0;
-                margin-top: 0;
+                margin: 0 0 12px;
                 font-size: 2.2rem;
             }
 

--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -71,16 +71,12 @@ $fd-fonts-path: '../../node_modules/fiori-fundamentals/dist/fonts/';
         .frDocs-Content {
             flex-grow: 1;
             overflow-y: scroll;
-            padding-bottom: 2rem;
             background-color: white;
-            margin-right: auto;
-            margin-left: 12px;
-            padding-left: 1rem;
-            padding-right: 1rem;
+            padding: 2rem;
 
             .frDocs-Content__header, .frDocs-markdown > h1 {
                 margin: 12px 0;
-                margin-top: 2rem;
+                margin-top: 0;
                 font-size: 2.2rem;
             }
 


### PR DESCRIPTION
### Description
margin for block-level elements should always be applied to the bottom. cleaning up H1 here.

![image](https://user-images.githubusercontent.com/5056972/52317506-1878e780-2975-11e9-843e-eef0017e6f29.png)

also cleaning up margin/padding for content area. gave no space on the right side

![image](https://user-images.githubusercontent.com/5056972/52317555-5544de80-2975-11e9-939f-c2dc190e2351.png)