### PR TITLE
fix: hide Month/Year selector after selection

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -121,6 +121,7 @@ export class Calendar extends Component {
             this.setState({
                 currentDateDisplayed: date,
                 selectedDate: date,
+                showMonths: false,
                 dateClick: true
             }, function() {
                 this.returnDateSelected(date);
@@ -128,6 +129,7 @@ export class Calendar extends Component {
         } else {
             this.setState({
                 currentDateDisplayed: date,
+                showMonths: false,
                 dateClick: true
             });
         }
@@ -139,6 +141,7 @@ export class Calendar extends Component {
         if (!this.props.enableRangeSelection) {
             this.setState({
                 currentDateDisplayed: date,
+                showYears: false,
                 selectedDate: date,
                 dateClick: true
             }, function() {
@@ -147,6 +150,7 @@ export class Calendar extends Component {
         } else {
             this.setState({
                 currentDateDisplayed: date,
+                showYears: false,
                 dateClick: true
             });
         }


### PR DESCRIPTION
### Description
Currently in the Calendar component when selecting a Month or Year the user has to click on the Month or Year to close the selector (see below)
![current-calendar](https://user-images.githubusercontent.com/38330612/52346396-819c4180-29ed-11e9-8fc2-08181d86ac87.gif)

This change will hide the Month/Year selector after making a selection
![new-calendar](https://user-images.githubusercontent.com/38330612/52346419-8fea5d80-29ed-11e9-9abe-75b1cea66292.gif)

