### PR TITLE
chore: adding module to package.json

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,8 +21,8 @@ const esPresets = [
 
 const defaultPlugins = [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }]
-    // '@babel/plugin-transform-object-assign'
+    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
+    '@babel/plugin-transform-object-assign'
 ];
 
 const productionPlugins = [

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 
-const defaultPresets = [
+const cjsPresets = [
     '@babel/preset-react',
     [
         '@babel/preset-env',
@@ -9,10 +9,20 @@ const defaultPresets = [
     ]
 ];
 
+const esPresets = [
+    '@babel/preset-react',
+    [
+        '@babel/preset-env',
+        {
+            modules: false
+        }
+    ]
+];
+
 const defaultPlugins = [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-    '@babel/plugin-transform-object-assign'
+    ['@babel/plugin-proposal-object-rest-spread', { loose: true }]
+    // '@babel/plugin-transform-object-assign'
 ];
 
 const productionPlugins = [
@@ -28,7 +38,7 @@ const productionPlugins = [
 ];
 
 module.exports = {
-    presets: defaultPresets,
+    presets: process.env.BABEL_ENV === 'es' ? esPresets : cjsPresets,
     plugins: defaultPlugins,
     env: {
         production: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "module": "lib/es/index.js",
   "homepage": "https://sap.github.io/fundamental-react",
   "repository": {
     "type": "git",
@@ -15,7 +16,9 @@
     "build-js": "node scripts/build.js",
     "build:lint:fix": "eslint --fix 'src/**' --ext .js,.jsx --env browser,node",
     "build:lint": "eslint 'src/**' --ext .js,.jsx --env browser,node",
-    "build": "rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\"",
+    "build": "npm run build:lib && npm run build:es",
+    "build:lib": "rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\"",
+    "build:es": "BABEL_ENV=es babel src --out-dir lib/es --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\"",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "eslint --fix 'config/**' --ext .js,.jsx --env browser,node",
     "deploy": "npm run build-doc && gh-pages -d build",


### PR DESCRIPTION
### Description

Setting modules to false to ensure that import statements are left as is (opposed to transpiling them to require) to create new `lib/es` folder . This should give us a tree shakeable icon on bundlephobia.