### PR TITLE
fix: basic babel plugin to remove propDescriptions

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 
 const defaultPresets = [
     '@babel/preset-react',
@@ -24,7 +25,8 @@ const productionPlugins = [
     ],
     [
         '@babel/plugin-transform-react-inline-elements'
-    ]
+    ],
+    path.resolve(__dirname, './devtools/remove-prop-descriptions/index.js')
 ];
 
 module.exports = {

--- a/devtools/remove-prop-descriptions/index.js
+++ b/devtools/remove-prop-descriptions/index.js
@@ -1,0 +1,18 @@
+exports.default = function(babel) {
+    const { types: t } = babel;
+
+    return {
+        name: 'babel-transform-remove-prop-descriptions', // not required
+        visitor: {
+            AssignmentExpression(path) {
+                const { node } = path;
+
+                if (node.left.property && node.left.property.name && node.left.property.name === 'propDescriptions') {
+                    path.remove(node.left);
+                }
+            }
+        }
+    };
+};
+
+module.exports = exports.default;

--- a/devtools/remove-prop-descriptions/index.js
+++ b/devtools/remove-prop-descriptions/index.js
@@ -2,7 +2,7 @@ exports.default = function(babel) {
     const { types: t } = babel;
 
     return {
-        name: 'babel-transform-remove-prop-descriptions', // not required
+        name: 'babel-transform-remove-prop-descriptions',
         visitor: {
             AssignmentExpression(path) {
                 const { node } = path;


### PR DESCRIPTION
### Description
This is a very basic babel plugin to remove propDescriptions from the prod build. Babel uses AST Traversal, much like codemods. This _seems_ to do what we want it to do but I'd like to get @jbadan's eyes on this. 


fixes https://github.com/SAP/fundamental-react/issues/376
