### PR TITLE
fix: icon-example-rendering

### DIFF
--- a/src/Icon/Icon.Component.js
+++ b/src/Icon/Icon.Component.js
@@ -633,14 +633,18 @@ export const IconComponent = () => {
         'zoom-out'
     ];
 
-    let icons = listOfIcons.map((icon, index) => {
-        return (
-            <div className='demo-icon-wrapper' key={index}>
-                <Icon glyph={icon} size='xl' />
-                <h5>sap-icon--{icon}</h5>
-            </div>
-        );
-    });
+    let icons = (
+        <div className='fd-doc__margin--icon'>
+            {listOfIcons.map((icon, index) => {
+                return (
+                    <div className='demo-icon-wrapper' key={index}>
+                        <Icon glyph={icon} size='xl' />
+                        <h5>sap-icon--{icon}</h5>
+                    </div>
+                );
+            })}
+        </div>
+    );
 
     return (
         <div>
@@ -674,7 +678,7 @@ export const IconComponent = () => {
 
             <h2>Available Icons</h2>
 
-            <DocsTile>{icons}</DocsTile>
+            <DocsTile centered>{icons}</DocsTile>
 
             <Separator />
 


### PR DESCRIPTION
Small fix that addresses how the icons were rendered in the example: https://sap.github.io/fundamental-react/icon

# Before
<img width="1420" alt="screen shot 2019-02-11 at 11 52 46 am" src="https://user-images.githubusercontent.com/5314713/52582881-de379c00-2df3-11e9-8766-a97d88038c37.png">

# After
<img width="1419" alt="screen shot 2019-02-11 at 11 52 57 am" src="https://user-images.githubusercontent.com/5314713/52582897-e5f74080-2df3-11e9-9f4b-b42579c91f67.png">

