### PR TITLE
fix: Remove offset for start of week date in Calendar

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -290,7 +290,7 @@ export class Calendar extends Component {
 
     retrieveStartOfWeek = (date) => {
         let day = date.getDay();
-        let difference = date.getDate() - day + (day === 0 ? -6 : 0);
+        let difference = date.getDate() - day;
         return new Date(date.setDate(difference));
     }
 


### PR DESCRIPTION
### Description
The original issue (#358) describes the issue within `DatePicker` but it actually lies in the `Calendar` component calculation. The offset used for the calculation for the starting day of the month was causing issues with any month that started on Sunday. The offset could be increased to 7 (rather than 6) or removed completely (which is what I decided to do in this commit). The only difference would be that the previous week from previous month would be shown also.

For example, June 1st 2025 is a Sunday.

**Before fix** - June 1st 2025 is shown as a Saturday (incorrect) and Friday & Saturday are disabled rather than Saturday & Sunday.

<img width="396" alt="screenshot 2019-02-11 at 22 04 50" src="https://user-images.githubusercontent.com/6461288/52596893-59776d00-2e49-11e9-806d-c769e841e62a.png">

**After Fix** - the day is corrected (June 1st 2025 is a Sunday) and Saturday & Sunday are disabled as expected.

<img width="339" alt="screenshot 2019-02-11 at 22 05 05" src="https://user-images.githubusercontent.com/6461288/52596993-8e83bf80-2e49-11e9-9582-f2bb368dc5de.png">



fixes #358 