### PR TITLE
fix: Playground: Add a 404.html identical to index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
-    "build-doc": "node scripts/build.js",
+    "build-doc": "node scripts/build.js && cp build/index.html build/404.html",
     "build-js": "node scripts/build.js",
     "build:lint:fix": "eslint --fix 'src/**' --ext .js,.jsx --env browser,node",
     "build:lint": "eslint 'src/**' --ext .js,.jsx --env browser,node",
@@ -20,7 +20,7 @@
     "build:index": "babel-node devtools/buildIndexFiles.js",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "eslint --fix 'config/**' --ext .js,.jsx --env browser,node",
-    "deploy": "cp build/index.html build/404.html && gh-pages -d build",
+    "deploy": "gh-pages -d build",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",
     "lint:fix": "npm run build:lint:fix  && npm run scripts:lint:fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:index": "babel-node devtools/buildIndexFiles.js",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "eslint --fix 'config/**' --ext .js,.jsx --env browser,node",
-    "deploy": "gh-pages -d build",
+    "deploy": "cp build/index.html build/404.html && gh-pages -d build",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",
     "lint:fix": "npm run build:lint:fix  && npm run scripts:lint:fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",

--- a/src/_playground/Routes.js
+++ b/src/_playground/Routes.js
@@ -273,7 +273,7 @@ const routes = [
 
 const RouteNotFound = () => (
     <div>
-        <Header>404: Not found</Header>
+        <Header>Sorry, page not found.</Header>
         <Link to=''>Home</Link>
     </div>
 );

--- a/src/_playground/Routes.js
+++ b/src/_playground/Routes.js
@@ -10,6 +10,7 @@ import { DatePickerComponent } from '../DatePicker/DatePicker.Component';
 import { DropdownComponent } from '../Dropdown/Dropdown.Component';
 import { FormsComponent } from '../Forms/Forms.Component';
 import groupArray from 'group-array';
+import { Header } from './documentation/Header/Header';
 import { Home } from './documentation/Home/Home';
 import { IconComponent } from '../Icon/Icon.Component';
 import { IdentifierComponent } from '../Identifier/Identifier.Component';
@@ -37,7 +38,7 @@ import { TimePickerComponent } from '../TimePicker/TimePicker.Component';
 import { ToggleComponent } from '../Toggle/Toggle.Component';
 import { TokenComponent } from '../Token/Token.Component';
 import { TreeComponent } from '../Tree/Tree.Component';
-import { BrowserRouter, NavLink, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Link, NavLink, Redirect, Route, Switch } from 'react-router-dom';
 
 const sections = [
     {
@@ -270,6 +271,13 @@ const routes = [
     }
 ];
 
+const RouteNotFound = () => (
+    <div>
+        <Header>404: Not found</Header>
+        <Link to=''>Home</Link>
+    </div>
+);
+
 export const Routes = () => {
     let sectionRoutes;
     const groupedRoutes = groupArray(routes, 'section');
@@ -320,6 +328,7 @@ export const Routes = () => {
                         })}
                         <Redirect exact from=''
                             to='/home' />
+                        <Route component={RouteNotFound} />
                     </Switch>
                 </div>
             </div>


### PR DESCRIPTION
### Description
In the playground, hosting with Github pages doesn't support routing with SPAs very well because there is no server redirecting all requests to the index.html file.  

This is causing page refreshes or direct links to non-root routes (like https://sap.github.io/fundamental-react/datepicker) to return the Github 404 page.

This PR allows page refreshes and direct links by creating a 404.html file identical to the index.html file as part of the deploy script.  Github will direct 404s to this 404.html. 

It also provides a simple component for rendering a 404 within the docs

<img width="1667" alt="screen shot 2019-02-13 at 9 52 41 am" src="https://user-images.githubusercontent.com/5314713/52738693-cfd4b600-2f94-11e9-91a5-c105803d3502.png">
