### PR TITLE
chore: Added repo arg to the gh-pages call

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -19,4 +19,5 @@ npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch m
 
 npm publish
 
-npm run deploy
+npm run build-doc
+npm run deploy -- --repo "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:index": "babel-node devtools/buildIndexFiles.js",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "eslint --fix 'config/**' --ext .js,.jsx --env browser,node",
-    "deploy": "npm run build-doc && gh-pages -d build -r \"https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}\"",
+    "deploy": "gh-pages -d build",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",
     "lint:fix": "npm run build:lint:fix  && npm run scripts:lint:fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:index": "babel-node devtools/buildIndexFiles.js",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "eslint --fix 'config/**' --ext .js,.jsx --env browser,node",
-    "deploy": "npm run build-doc && gh-pages -d build",
+    "deploy": "npm run build-doc && gh-pages -d build -r \"https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}\"",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",
     "lint:fix": "npm run build:lint:fix  && npm run scripts:lint:fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",


### PR DESCRIPTION
### Description
The `gh-pages` package uses simple authentication by default which was causing the `fundamental-bot` user to fail authentication when attempting to publish the docs.  I added a `repo` argument that embeds the GitHub token so we can push to the `gh-pages` branch.

fixes #352 