### PR TITLE
chore: change fiori fundamentals dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ You will need to install [Node and Node Package Manager](https://www.npmjs.com/g
 
 For an existing react application, follow the steps below:
 
-1. Install fundamental-react
+1. Install Fundamental-react and Fiori Fundamentals.
 
     ```
-    npm install fundamental-react
+    npm install fiori-fundamentals fundamental-react
     ```
 
 1. Load the fiori-fundamentals styles. If using create-react-app, this will be in `App.css`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6380,7 +6380,8 @@
     "fiori-fundamentals": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/fiori-fundamentals/-/fiori-fundamentals-1.4.1.tgz",
-      "integrity": "sha512-llWVhfp9Qowig8SHBHUntLXiRnthrNTs/rS4A74fYsE2VARWaSUp67ZH9D3gpci4UTfalF6MV2hAeqjKNGLaFg=="
+      "integrity": "sha512-llWVhfp9Qowig8SHBHUntLXiRnthrNTs/rS4A74fYsE2VARWaSUp67ZH9D3gpci4UTfalF6MV2hAeqjKNGLaFg==",
+      "dev": true
     },
     "flat-cache": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "fiori-fundamentals": "^1.4.0",
     "focus-trap-react": "^6.0.0",
     "prop-types": "^15.7.1"
   },
@@ -88,6 +87,7 @@
     "eslint-plugin-loosely-restrict-imports": "^0.1.15",
     "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",
+    "fiori-fundamentals": "^1.4.0",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-extra": "7.0.0",
     "gh-pages": "^2.0.1",
@@ -131,6 +131,7 @@
     "workbox-webpack-plugin": "3.6.3"
   },
   "peerDependencies": {
+    "fiori-fundamentals": "^1.4.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"
   },


### PR DESCRIPTION
### Description
`fiori-fundamentals` should be installed by the consumer, not us

leaving as a peer so we can at least require minimum versions of `fiori-fundamentals`