### PR TITLE
fix: update index files generation to handle multiple component files in single directory

### DIFF
--- a/devtools/buildIndexFiles.js
+++ b/devtools/buildIndexFiles.js
@@ -17,16 +17,22 @@ const isComponentFile = (source) => {
 const componentDirs = readdirSync(srcPath).map(name => path.join(srcPath, name)).filter(isComponentDirectory).map(directory => {
     return {
         path: directory,
-        fileName: readdirSync(directory).filter(isComponentFile)
+        fileNames: readdirSync(directory).filter(isComponentFile)
     };
 });
 
+// For every component directory.
 componentDirs.map((directory) => {
-    let component = require(`${directory.path}/${directory.fileName}`);
     let fileContents = '';
-    Object.keys(component).map((single) => {
-        fileContents += `export { ${single} } from './${directory.fileName}';\n`;
-        let indexPath = `${directory.path}/index.js`;
-        writeFileSync(indexPath, fileContents);
+    // Loop through it's files.
+    directory.fileNames.map((name) => {
+        // Grab the file's exports.
+        let component = require(`${directory.path}/${name}`);
+        Object.keys(component).map((single) => {
+            fileContents += `export { ${single} } from './${name}';\n`;
+        });
     });
+    // write the index file into the directory.
+    let indexPath = `${directory.path}/index.js`;
+    writeFileSync(indexPath, fileContents);
 });

--- a/devtools/buildIndexFiles.js
+++ b/devtools/buildIndexFiles.js
@@ -24,15 +24,15 @@ const componentDirs = readdirSync(srcPath).map(name => path.join(srcPath, name))
 // For every component directory.
 componentDirs.map((directory) => {
     let fileContents = '';
-    // Loop through it's files.
-    directory.fileNames.map((name) => {
+    // Loop through its files.
+    directory.fileNames.map((fileName) => {
         // Grab the file's exports.
-        let component = require(`${directory.path}/${name}`);
-        Object.keys(component).map((single) => {
-            fileContents += `export { ${single} } from './${name}';\n`;
+        let components = require(path.join(directory.path, fileName));
+        Object.keys(components).map((component) => {
+            fileContents += `export { ${component} } from './${fileName}';\n`;
         });
     });
     // write the index file into the directory.
-    let indexPath = `${directory.path}/index.js`;
+    let indexPath = path.join(directory.path, 'index.js');
     writeFileSync(indexPath, fileContents);
 });


### PR DESCRIPTION
### Description
@chrismanciero found a bug that index file generation was failing on Travis when more than one component file existed in a directory. This fixes it.