### PR TITLE
fix: temporarily disable coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 jobs:
   include:
   - stage: Lint and Test
-    script: npm run lint && npm run test && npm run size && npm run test:coveralls
+    script: npm run lint && npm run test:coverage && npm run size && npm run test:coveralls
   - stage: Pre-release
     if: branch = master
     before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ script:
 jobs:
   include:
   - stage: Lint and Test
-    script: npm run lint && npm run test && npm run size
-  - stage: Coveralls Report
-    script: npm run test:coveralls
+    script: npm run lint && npm run test && npm run size && npm run test:coveralls
   - stage: Pre-release
     if: branch = master
     before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ script:
 jobs:
   include:
   - stage: Lint and Test
-    script: npm run lint && npm run test:coveralls && npm run size
+    script: npm run lint && npm run test && npm run size
+  - stage: Coveralls Report
+    script: npm run test:coveralls
   - stage: Pre-release
     if: branch = master
     before_deploy:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test:coverage": "jest --coverage",
     "test:coverage:watch": "jest --coverage --watch",
-    "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\n\" )",
     "test:dev": "jest",
     "test:watch": "jest --watch",
     "test": "npm run test:watch",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test:coverage": "jest --coverage",
     "test:coverage:watch": "jest --coverage --watch",
-    "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\n\" )",
+    "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
     "test:dev": "jest",
     "test:watch": "jest --watch",
     "test": "npm run test:watch",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test:coverage": "jest --coverage",
     "test:coverage:watch": "jest --coverage --watch",
-    "test:coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
+    "test:coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
     "test:dev": "jest",
     "test:watch": "jest --watch",
     "test": "npm run test:watch",


### PR DESCRIPTION
### Description
Coveralls is currently causing all builds to fail in Travis. This is a known recurring issue on their end: 
https://github.com/lemurheavy/coveralls-public/issues/1264

This PR allows coveralls to fail without stopping the build.

related to #416 