### PR TITLE
fix: CORUI-6264: Support default exports for components

### DIFF
--- a/devtools/buildIndexFiles.js
+++ b/devtools/buildIndexFiles.js
@@ -28,8 +28,13 @@ componentDirs.map((directory) => {
     directory.fileNames.map((fileName) => {
         // Grab the file's exports.
         let components = require(path.join(directory.path, fileName));
+
         Object.keys(components).map((component) => {
-            fileContents += `export { ${component} } from './${fileName}';\n`;
+            if (component === 'default') {
+                fileContents += `export { default as ${components.default.name} } from './${fileName}';\n`;
+            } else {
+                fileContents += `export { ${component} } from './${fileName}';\n`;
+            }
         });
     });
     // write the index file into the directory.


### PR DESCRIPTION
### Description
The `buildIndexFiles.js` script only supported named exports in component files. This works fine when we have multiple components in one file as named exports. Since we want to implement the one component per file lint rule, we need to support default exports as well.
