### PR TITLE
chore: bump fundamentals version and reference ie 11 compat css

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For an existing react application, follow the steps below:
 1. Load the fiori-fundamentals styles. If using create-react-app, this will be in `App.css`.
 
     ```scss
-    @import '~fiori-fundamentals/dist/fiori-fundamentals-ie11.min.css';
+    @import '~node_modules/fiori-fundamentals/dist/fiori-fundamentals-ie11.min.css';
     ```
 
 1. Import components as needed. See [Component Documentation](https://sap.github.io/fundamental-react/) for examples and API details.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For an existing react application, follow the steps below:
 1. Load the fiori-fundamentals styles. If using create-react-app, this will be in `App.css`.
 
     ```scss
-    @import '~node_modules/fiori-fundamentals/dist/fiori-fundamentals-ie11.min.css';
+    @import '~fiori-fundamentals/dist/fiori-fundamentals-ie11.min.css';
     ```
 
 1. Import components as needed. See [Component Documentation](https://sap.github.io/fundamental-react/) for examples and API details.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For an existing react application, follow the steps below:
 1. Load the fiori-fundamentals styles. If using create-react-app, this will be in `App.css`.
 
     ```scss
-    @import '~fiori-fundamentals/dist/fiori-fundamentals.min.css';
+    @import '~fiori-fundamentals/dist/fiori-fundamentals-ie11.min.css';
     ```
 
 1. Import components as needed. See [Component Documentation](https://sap.github.io/fundamental-react/) for examples and API details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,7 +1907,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2948,7 +2948,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -3088,7 +3088,7 @@
       "dependencies": {
         "css-select": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "dev": true,
           "requires": {
@@ -4453,7 +4453,7 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
           "dev": true
         },
@@ -6501,9 +6501,9 @@
       }
     },
     "fiori-fundamentals": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/fiori-fundamentals/-/fiori-fundamentals-1.4.1.tgz",
-      "integrity": "sha512-llWVhfp9Qowig8SHBHUntLXiRnthrNTs/rS4A74fYsE2VARWaSUp67ZH9D3gpci4UTfalF6MV2hAeqjKNGLaFg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/fiori-fundamentals/-/fiori-fundamentals-1.4.3.tgz",
+      "integrity": "sha512-tjLMVkeyPiLizmwakP67vgIquEf5nGiPyG4ZVQ3SoTuDeXAz5+vcAxG+mLZfkaEy6XyOjbOJg4tipHlLaqZy4Q==",
       "dev": true
     },
     "flat-cache": {
@@ -8526,7 +8526,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -9967,7 +9967,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -11413,7 +11413,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -11566,7 +11566,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -11924,7 +11924,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17541,7 +17541,7 @@
         },
         "css-select": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "dev": true,
           "requires": {
@@ -17754,7 +17754,7 @@
         },
         "callsites": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
           "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
           "dev": true
         },
@@ -17954,7 +17954,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -18434,7 +18434,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
@@ -19493,7 +19493,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
@@ -21068,7 +21068,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-loosely-restrict-imports": "^0.1.15",
     "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",
-    "fiori-fundamentals": "^1.4.0",
+    "fiori-fundamentals": "^1.4.3",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-extra": "7.0.0",
     "gh-pages": "^2.0.1",
@@ -134,7 +134,7 @@
     "workbox-webpack-plugin": "3.6.3"
   },
   "peerDependencies": {
-    "fiori-fundamentals": "^1.4.0",
+    "fiori-fundamentals": "^1.4.3",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"
   },


### PR DESCRIPTION
### Description
Bump fundamentals dependency to version with IE 11 css and reference IE 11 css distribution.



fixes https://github.com/SAP/fundamental-react/issues/436