### PR TITLE
docs: Add toggle right to left control to playground

### DIFF
--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -140,9 +140,13 @@ $library-color: #61dafb;
                 border-bottom: none;
                 padding: 10px 0;
 
-                .frDocs-tile__background-toggle {
+                .frDocs-tile__features {
                     display: flex;
                     justify-content: flex-end;
+                }
+
+                .frDocs-tile__feature {
+                    display: flex;
                     margin: 15px;
                 }
 

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -44,10 +44,10 @@ export class DocsTile extends React.Component {
                 <div className='frDocs-tile__features'>
                     <Toggle
                         className='frDocs-tile__feature'
-                        inputProps={{ 'aria-label': 'Show right to Left' }}
+                        inputProps={{ 'aria-label': 'Show right to left' }}
                         onChange={this.toggleRTL}
                         size='xs'>
-                        Show right to Left
+                        Show right to left
                     </Toggle>
                     <Toggle
                         className='frDocs-tile__feature'

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -2,51 +2,62 @@ import { Button } from '../../../';
 import classnames from 'classnames';
 import { googlecode } from 'react-syntax-highlighter/styles/hljs';
 import PropTypes from 'prop-types';
+import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { Toggle } from '../../../Toggle/Toggle';
-import React, { Component } from 'react';
 
-export class DocsTile extends Component {
+export class DocsTile extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            backgroundToggle: false
+            backgroundToggle: false,
+            rightToLeft: false
         };
     }
 
     handleToggle = () => {
-        this.setState({
-            backgroundToggle: !this.state.backgroundToggle
-        });
+        this.setState(prevState => ({
+            backgroundToggle: !prevState.backgroundToggle
+        }));
+    };
+
+    handleToggleRightToLeft = () => {
+        this.setState(prevState => ({
+            rightToLeft: !prevState.rightToLeft
+        }));
     };
 
     render() {
         const { centered, children } = this.props;
+        const { backgroundToggle, rightToLeft } = this.state;
 
-        const outerDivClasses = classnames(
-            'frDocs-Content__tile',
-            {
-                'frDocs-Content__tile-background': !this.state.backgroundToggle
-            }
-        );
+        const outerDivClasses = classnames('frDocs-Content__tile', {
+            'frDocs-Content__tile-background': !backgroundToggle
+        });
 
-        const innerDivClasses = classnames(
-            'fd-tile__content',
-            {
-                'frDocs-tile__centered': centered
-            }
-        );
+        const innerDivClasses = classnames('fd-tile__content', {
+            'frDocs-tile__centered': centered
+        });
 
         return (
             <div className={outerDivClasses}>
-                <Toggle
-                    className='frDocs-tile__background-toggle'
-                    inputProps={{ 'aria-label': 'Toggle background color' }}
-                    onChange={this.handleToggle}
-                    size='xs'>Toggle background</Toggle>
-                <div className={innerDivClasses}>
-                    {children}
+                <div className='frDocs-tile__features'>
+                    <Toggle
+                        className='frDocs-tile__feature'
+                        inputProps={{ 'aria-label': 'Toggle right to left' }}
+                        onChange={this.handleToggleRightToLeft}
+                        size='xs'>
+                        Toggle right to left
+                    </Toggle>
+                    <Toggle
+                        className='frDocs-tile__feature'
+                        inputProps={{ 'aria-label': 'Toggle background color' }}
+                        onChange={this.handleToggle}
+                        size='xs'>
+                        Toggle background
+                    </Toggle>
                 </div>
+                <div className={innerDivClasses} dir={rightToLeft ? 'rtl' : ''}>{children}</div>
             </div>
         );
     }
@@ -57,7 +68,7 @@ DocsTile.propTypes = {
     children: PropTypes.node
 };
 
-export class DocsText extends Component {
+export class DocsText extends React.Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -10,29 +10,29 @@ export class DocsTile extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            backgroundOn: true,
-            rightToLeft: false
+            hideBackground: false,
+            showRTL: false
         };
     }
 
-    handleBackgroundToggle = () => {
+    toggleBackground = () => {
         this.setState(prevState => ({
-            backgroundOn: !prevState.backgroundOn
+            hideBackground: !prevState.hideBackground
         }));
     };
 
-    handleRightToLeftToggle = () => {
+    toggleRTL = () => {
         this.setState(prevState => ({
-            rightToLeft: !prevState.rightToLeft
+            showRTL: !prevState.showRTL
         }));
     };
 
     render() {
         const { centered, children } = this.props;
-        const { backgroundOn, rightToLeft } = this.state;
+        const { hideBackground, showRTL } = this.state;
 
         const outerDivClasses = classnames('frDocs-Content__tile', {
-            'frDocs-Content__tile-background': backgroundOn
+            'frDocs-Content__tile-background': !hideBackground
         });
 
         const innerDivClasses = classnames('fd-tile__content', {
@@ -44,20 +44,20 @@ export class DocsTile extends React.Component {
                 <div className='frDocs-tile__features'>
                     <Toggle
                         className='frDocs-tile__feature'
-                        inputProps={{ 'aria-label': 'Toggle right to left' }}
-                        onChange={this.handleRightToLeftToggle}
+                        inputProps={{ 'aria-label': 'Show right to Left' }}
+                        onChange={this.toggleRTL}
                         size='xs'>
-                        Toggle right to left
+                        Show right to Left
                     </Toggle>
                     <Toggle
                         className='frDocs-tile__feature'
-                        inputProps={{ 'aria-label': 'Toggle background color' }}
-                        onChange={this.handleBackgroundToggle}
+                        inputProps={{ 'aria-label': 'Hide background' }}
+                        onChange={this.toggleBackground}
                         size='xs'>
-                        Toggle background
+                        Hide background
                     </Toggle>
                 </div>
-                <div className={innerDivClasses} dir={rightToLeft ? 'rtl' : ''}>{children}</div>
+                <div className={innerDivClasses} dir={showRTL ? 'rtl' : ''}>{children}</div>
             </div>
         );
     }

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -10,14 +10,14 @@ export class DocsTile extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            backgroundToggle: false,
+            backgroundOn: true,
             rightToLeft: false
         };
     }
 
     handleBackgroundToggle = () => {
         this.setState(prevState => ({
-            backgroundToggle: !prevState.backgroundToggle
+            backgroundOn: !prevState.backgroundOn
         }));
     };
 
@@ -29,10 +29,10 @@ export class DocsTile extends React.Component {
 
     render() {
         const { centered, children } = this.props;
-        const { backgroundToggle, rightToLeft } = this.state;
+        const { backgroundOn, rightToLeft } = this.state;
 
         const outerDivClasses = classnames('frDocs-Content__tile', {
-            'frDocs-Content__tile-background': !backgroundToggle
+            'frDocs-Content__tile-background': backgroundOn
         });
 
         const innerDivClasses = classnames('fd-tile__content', {

--- a/src/_playground/documentation/DocsTile/DocsTile.js
+++ b/src/_playground/documentation/DocsTile/DocsTile.js
@@ -15,13 +15,13 @@ export class DocsTile extends React.Component {
         };
     }
 
-    handleToggle = () => {
+    handleBackgroundToggle = () => {
         this.setState(prevState => ({
             backgroundToggle: !prevState.backgroundToggle
         }));
     };
 
-    handleToggleRightToLeft = () => {
+    handleRightToLeftToggle = () => {
         this.setState(prevState => ({
             rightToLeft: !prevState.rightToLeft
         }));
@@ -45,14 +45,14 @@ export class DocsTile extends React.Component {
                     <Toggle
                         className='frDocs-tile__feature'
                         inputProps={{ 'aria-label': 'Toggle right to left' }}
-                        onChange={this.handleToggleRightToLeft}
+                        onChange={this.handleRightToLeftToggle}
                         size='xs'>
                         Toggle right to left
                     </Toggle>
                     <Toggle
                         className='frDocs-tile__feature'
                         inputProps={{ 'aria-label': 'Toggle background color' }}
-                        onChange={this.handleToggle}
+                        onChange={this.handleBackgroundToggle}
                         size='xs'>
                         Toggle background
                     </Toggle>


### PR DESCRIPTION
### Description
<img width="1378" alt="screen shot 2019-02-27 at 5 28 01 am" src="https://user-images.githubusercontent.com/5314713/53493620-9bf79700-3a50-11e9-88a9-8d8c9f968fc5.png">

<img width="1378" alt="screen shot 2019-02-27 at 5 28 07 am" src="https://user-images.githubusercontent.com/5314713/53493607-9437f280-3a50-11e9-9e69-df6afc6497bb.png">

fixes #444