### PR TITLE
fix: forminput state proptype is now oneOf, not string

### DIFF
--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { INPUT_TYPES } from '../utils/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -22,7 +23,7 @@ FormInput.displayName = 'FormInput';
 
 FormInput.propTypes = {
     className: PropTypes.string,
-    state: PropTypes.string
+    state: PropTypes.oneOf(INPUT_TYPES)
 };
 
 FormInput.propDescriptions = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,8 +23,7 @@ export const INPUT_TYPES = [
     'warning',
     'help',
     'disabled',
-    'readonly',
-    '' //empty for 'normal'
+    'readonly'
 ];
 
 export const LABEL_TYPES = [

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -16,6 +16,17 @@ export const BADGE_MODIFIERS = [
     'filled'
 ];
 
+export const INPUT_TYPES = [
+    'normal',
+    'valid',
+    'invalid',
+    'warning',
+    'help',
+    'disabled',
+    'readonly',
+    '' //empty for 'normal'
+];
+
 export const LABEL_TYPES = [
     'success',
     'warning',


### PR DESCRIPTION
### Description

The state prop for FormInput has a list of valid values, but the prop now uses PropTypes.oneOf validator rather than .string

fixes #428