### PR TITLE
docs: ignoring snap files for ghpages build

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -329,7 +329,7 @@ module.exports = {
                         // its runtime that would otherwise be processed through "file" loader.
                         // Also exclude `html` and `json` extensions so they get processed
                         // by webpacks internal loaders.
-                        exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+                        exclude: [/\.(js|mjs|jsx|ts|tsx|snap)$/, /\.html$/, /\.json$/],
                         loader: require.resolve('file-loader'),
                         options: {
                             name: 'static/media/[name].[hash:8].[ext]'

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -415,7 +415,7 @@ module.exports = {
                         // it's runtime that would otherwise be processed through "file" loader.
                         // Also exclude `html` and `json` extensions so they get processed
                         // by webpacks internal loaders.
-                        exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/, /\.snap$/],
+                        exclude: [/\.(js|mjs|jsx|ts|tsx|snap)$/, /\.html$/, /\.json$/],
                         options: {
                             name: 'static/media/[name].[hash:8].[ext]'
                         }

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -415,7 +415,7 @@ module.exports = {
                         // it's runtime that would otherwise be processed through "file" loader.
                         // Also exclude `html` and `json` extensions so they get processed
                         // by webpacks internal loaders.
-                        exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+                        exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/, /\.snap$/],
                         options: {
                             name: 'static/media/[name].[hash:8].[ext]'
                         }


### PR DESCRIPTION
### Description

Add snap files to ignore glob in webpack prod config for github pages. This will prevent new files from being uploaded, but still need to be manually deleted from gh-pages branch.

New build folder output:
<img width="1438" alt="screen shot 2019-03-04 at 3 44 04 pm" src="https://user-images.githubusercontent.com/29607818/53767910-788b7c80-3e94-11e9-88db-6ff745a02d88.png">


fixes #issueid