### PR TITLE
fix: update FormInput state prop description

### DIFF
--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -29,7 +29,7 @@ FormInput.propTypes = {
 };
 
 FormInput.propDescriptions = {
-    state: 'Sets the state of the input.'
+    state: 'Sets the state of the input. Can be left empty for default styles.'
 };
 
 export default FormInput;

--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -23,6 +23,8 @@ FormInput.displayName = 'FormInput';
 
 FormInput.propTypes = {
     className: PropTypes.string,
+    disabled: PropTypes.bool,
+    readOnly: PropTypes.bool,
     state: PropTypes.oneOf(INPUT_TYPES)
 };
 

--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -27,7 +27,7 @@ FormInput.propTypes = {
 };
 
 FormInput.propDescriptions = {
-    state: 'Sets the state of the input. Options include \'normal\', \'valid\', \'invalid\', \'warning\', \'help\', \'disabled\', and \'readonly\'. Leave empty for normal.'
+    state: 'Sets the state of the input.'
 };
 
 export default FormInput;

--- a/src/Forms/Forms.Component.js
+++ b/src/Forms/Forms.Component.js
@@ -92,7 +92,7 @@ export const FormsComponent = () => {
 
             <Example
                 description={`The state of the input field can reflect validity of the data entered, 
-                    whether the input data is editable or disabled.\n\n* **Default**: The field is 
+                    whether the input data is editable or disabled.\n\n* **Normal**: The field is 
                     editable but no validation has occurred. \n\n* **Valid**: The data format entered 
                     has been validated and it’s correct, such as an email address.\n\n* **Invalid**: The 
                     data entered is not valid and must be corrected.\n\n* **Warning**: The data entered 
@@ -103,7 +103,7 @@ export const FormsComponent = () => {
                 <div>
                     <FormSet>
                         <FormItem>
-                            <FormLabel htmlFor='OatmD552'>Default Input</FormLabel>
+                            <FormLabel htmlFor='OatmD552'>Normal Input</FormLabel>
                             <FormInput id='OatmD552' placeholder='Field placeholder text'
                                 type='text' />
                             <FormMessage>Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</FormMessage>

--- a/src/Forms/Forms.Component.js
+++ b/src/Forms/Forms.Component.js
@@ -97,10 +97,7 @@ export const FormsComponent = () => {
                     has been validated and it’s correct, such as an email address.\n\n* **Invalid**: The 
                     data entered is not valid and must be corrected.\n\n* **Warning**: The data entered 
                     is formatted correctly but there are other issues are problematic but will not stop 
-                    the user from moving forward.\n\n* **Disabled**: This indicates the field is not 
-                    editable. A common use case is that this field is dependent on a previous entry or 
-                    selection within the form.\n\n* **Read Only**: Used to display static information 
-                    in the context of a form.\n\nAlong with Invalid and Warning, error messages should 
+                    the user from moving forward.\n\nAlong with Invalid and Warning, error messages should 
                     be displayed below the field so the user can correct the error and move forward.`}
                 title='Input States'>
                 <div>
@@ -142,18 +139,16 @@ export const FormsComponent = () => {
                             </FormMessage>
                         </FormItem>
                     </FormSet>
+                </div>
+            </Example>
 
-                    <FormSet>
-                        <FormItem>
-                            <FormLabel htmlFor='OatmD556'>Field Label</FormLabel>
-                            <FormInput id='OatmD556' placeholder='Field placeholder text'
-                                state='help' type='text' />
-                            <FormMessage type='help'>
-                                Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
-                            </FormMessage>
-                        </FormItem>
-                    </FormSet>
-
+            <Example
+                description={`* **Disabled**: This indicates the field is not 
+                editable. A common use case is that this field is dependent on a previous entry or 
+                selection within the form.\n\n* **Read Only**: Used to display static information 
+                in the context of a form.`}
+                title='Disabled and Read Only'>
+                <React.Fragment>
                     <FormSet>
                         <FormItem>
                             <FormLabel htmlFor='OatmD557'>Disabled Input</FormLabel>
@@ -161,7 +156,6 @@ export const FormsComponent = () => {
                                 disabled
                                 id='OatmD557'
                                 placeholder='Field placeholder text'
-                                state='help'
                                 type='text' />
                         </FormItem>
                     </FormSet>
@@ -173,13 +167,11 @@ export const FormsComponent = () => {
                                 id='OatmD558'
                                 placeholder='Field placeholder text'
                                 readOnly
-                                state='help'
                                 type='text' />
                         </FormItem>
                     </FormSet>
-                </div>
+                </React.Fragment>
             </Example>
-
             <Example
                 description={`The **FormSelect** component is similar to a **Dropdown** but is more commonly used within a form. It can also be
                     set to a disabled state.`}

--- a/src/Forms/Forms.test.js
+++ b/src/Forms/Forms.test.js
@@ -30,7 +30,7 @@ describe('<Forms />', () => {
                 <FormInput
                     id='input-1'
                     placeholder='Field placeholder text'
-                    state='help'
+                    state='warning'
                     type='text' />
                 <FormTextarea className='blue' id='textarea-1'>
                     Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.

--- a/src/Forms/__snapshots__/Forms.test.js.snap
+++ b/src/Forms/__snapshots__/Forms.test.js.snap
@@ -33,7 +33,7 @@ exports[`<Forms /> create form item 1`] = `
       *
     </label>
     <input
-      className="fd-form__control is-help"
+      className="fd-form__control is-warning"
       id="input-1"
       placeholder="Field placeholder text"
       type="text"

--- a/src/_playground/documentation/Properties/defaults.js
+++ b/src/_playground/documentation/Properties/defaults.js
@@ -14,7 +14,7 @@ export const defaultPropDescriptions = {
     onClick: 'Callback function when user clicks on the component.',
     placeholder: 'Localized placeholder text of the input.',
     popoverProps: 'Additional props to be spread to the `Popover` component.',
-    readOnly: 'Adds the readonly attribute to the element.',
+    readOnly: 'Set to **true** to mark component as readonly.',
     size: 'Size of the component.',
     title: 'Localized text for the heading.',
     titleProps: 'Additional props to be spread to the title\'s heading element.',

--- a/src/_playground/documentation/Properties/defaults.js
+++ b/src/_playground/documentation/Properties/defaults.js
@@ -14,6 +14,7 @@ export const defaultPropDescriptions = {
     onClick: 'Callback function when user clicks on the component.',
     placeholder: 'Localized placeholder text of the input.',
     popoverProps: 'Additional props to be spread to the `Popover` component.',
+    readOnly: 'Adds the readonly attribute to the element.',
     size: 'Size of the component.',
     title: 'Localized text for the heading.',
     titleProps: 'Additional props to be spread to the title\'s heading element.',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -20,10 +20,7 @@ export const INPUT_TYPES = [
     'normal',
     'valid',
     'invalid',
-    'warning',
-    'help',
-    'disabled',
-    'readonly'
+    'warning'
 ];
 
 export const LABEL_TYPES = [


### PR DESCRIPTION
### Description

State prop description update was missed in https://github.com/SAP/fundamental-react/pull/453

These are now pulled from the Proptypes OneOf list.

Removed disabled, readOnly and help from state prop constant.

`readOnly` and `disabled` did not work as described (`state='disabled' or state='readonly'`) and instead are standalone attributes that work as expected when added like: `<FormInput disabled />` or `<FormInput readOnly />`. The examples have been updated as well as the prop list. 

`state='help'` also did not exist, although they have an example using a help input here: https://sap.github.io/fundamental/components/form.html#input-states, these are the same thing: https://sap.github.io/fundamental/components/form.html#input-help-elements, which we have also here: https://sap.github.io/fundamental-react/forms#input-help-elements

One snapshot had to be updated because it used the now defunct state of help.

<img width="1215" alt="screen shot 2019-03-06 at 6 57 46 pm" src="https://user-images.githubusercontent.com/29607818/53927211-5d12a400-4043-11e9-90c4-02a36abd820f.png">
<img width="1232" alt="screen shot 2019-03-06 at 6 58 08 pm" src="https://user-images.githubusercontent.com/29607818/53927216-613ec180-4043-11e9-90a8-957a19771674.png">
<img width="1247" alt="screen shot 2019-03-06 at 6 58 17 pm" src="https://user-images.githubusercontent.com/29607818/53927223-626fee80-4043-11e9-9ec7-7a6ee572865a.png">






fixes #428 