### PR TITLE
docs: Updated display names for sub components

### DIFF
--- a/src/ActionBar/_ActionBarActions.js
+++ b/src/ActionBar/_ActionBarActions.js
@@ -11,7 +11,7 @@ const ActionBarActions = ({ children, className, ...props }) => {
     return <div {...props} className={actionBarActionsClasses}>{children}</div>;
 };
 
-ActionBarActions.displayName = 'ActionBarActions';
+ActionBarActions.displayName = 'ActionBar.Actions';
 
 ActionBarActions.propTypes = {
     children: PropTypes.node,

--- a/src/ActionBar/_ActionBarBack.js
+++ b/src/ActionBar/_ActionBarBack.js
@@ -18,7 +18,7 @@ const ActionBarBack = ({ onClick, className, buttonProps, ...props }) => {
     );
 };
 
-ActionBarBack.displayName = 'ActionBarBack';
+ActionBarBack.displayName = 'ActionBar.Back';
 
 ActionBarBack.propTypes = {
     buttonProps: PropTypes.object,

--- a/src/ActionBar/_ActionBarHeader.js
+++ b/src/ActionBar/_ActionBarHeader.js
@@ -22,7 +22,7 @@ const ActionBarHeader = ({ className, description, descriptionProps, title, titl
     );
 };
 
-ActionBarHeader.displayName = 'ActionBarHeader';
+ActionBarHeader.displayName = 'ActionBar.Header';
 
 ActionBarHeader.propTypes = {
     title: PropTypes.string.isRequired,

--- a/src/Breadcrumb/_BreadcrumbItem.js
+++ b/src/Breadcrumb/_BreadcrumbItem.js
@@ -27,7 +27,7 @@ const BreadcrumbItem = ({ url, name, className, children, ...props }) => {
     );
 };
 
-BreadcrumbItem.displayName = 'BreadcrumbItem';
+BreadcrumbItem.displayName = 'Breadcrumb.Item';
 
 BreadcrumbItem.propTypes = {
     name: PropTypes.string,

--- a/src/ListGroup/_ListGroupItem.js
+++ b/src/ListGroup/_ListGroupItem.js
@@ -16,7 +16,7 @@ const ListGroupItem = ({ children, className, ...props }) => {
     );
 };
 
-ListGroupItem.displayName = 'ListGroupItem';
+ListGroupItem.displayName = 'ListGroup.Item';
 
 ListGroupItem.propTypes = {
     children: PropTypes.node,

--- a/src/ListGroup/_ListGroupItemActions.js
+++ b/src/ListGroup/_ListGroupItemActions.js
@@ -15,7 +15,7 @@ const ListGroupItemActions = ({ children, className, ...props }) => {
     );
 };
 
-ListGroupItemActions.displayName = 'ListGroupItemActions';
+ListGroupItemActions.displayName = 'ListGroup.ItemActions';
 
 ListGroupItemActions.propTypes = {
     children: PropTypes.node,

--- a/src/ListGroup/_ListGroupItemCheckbox.js
+++ b/src/ListGroup/_ListGroupItemCheckbox.js
@@ -19,7 +19,7 @@ const ListGroupItemCheckbox = ({ children, labelProps, inputProps, ...props }) =
     );
 };
 
-ListGroupItemCheckbox.displayName = 'ListGroupItemCheckbox';
+ListGroupItemCheckbox.displayName = 'ListGroup.ItemCheckbox';
 
 ListGroupItemCheckbox.propTypes = {
     children: PropTypes.node,

--- a/src/Menu/_MenuGroup.js
+++ b/src/Menu/_MenuGroup.js
@@ -16,7 +16,7 @@ const MenuGroup = ({ title, children, className, titleProps, ...props }) => {
     );
 };
 
-MenuGroup.displayName = 'MenuGroup';
+MenuGroup.displayName = 'Menu.Group';
 
 MenuGroup.propTypes = {
     title: PropTypes.string.isRequired,

--- a/src/Menu/_MenuItem.js
+++ b/src/Menu/_MenuItem.js
@@ -50,7 +50,7 @@ const MenuItem = ({ url, isLink, separator, addon, children, onclick, className,
     );
 };
 
-MenuItem.displayName = 'MenuItem';
+MenuItem.displayName = 'Menu.Item';
 
 MenuItem.propTypes = {
     addon: PropTypes.string,

--- a/src/Menu/_MenuList.js
+++ b/src/Menu/_MenuList.js
@@ -11,7 +11,7 @@ const MenuList = ({ children, className, ...props }) => {
     return <ul {...props} className={menuListClasses}>{children}</ul>;
 };
 
-MenuList.displayName = 'MenuList';
+MenuList.displayName = 'Menu.List';
 
 MenuList.propTypes = {
     children: PropTypes.node,

--- a/src/Panel/_PanelActions.js
+++ b/src/Panel/_PanelActions.js
@@ -13,7 +13,7 @@ const PanelActions = props => {
     return <div {...rest} className={panelActionsClasses}>{children}</div>;
 };
 
-PanelActions.displayName = 'PanelActions';
+PanelActions.displayName = 'Panel.Actions';
 
 PanelActions.propTypes = {
     className: PropTypes.string

--- a/src/Panel/_PanelBody.js
+++ b/src/Panel/_PanelBody.js
@@ -13,7 +13,7 @@ const PanelBody = props => {
     return <div {...rest} className={panelBodyClasses}>{children}</div>;
 };
 
-PanelBody.displayName = 'PanelBody';
+PanelBody.displayName = 'Panel.Body';
 
 PanelBody.propTypes = {
     className: PropTypes.string

--- a/src/Panel/_PanelFilters.js
+++ b/src/Panel/_PanelFilters.js
@@ -17,7 +17,7 @@ const PanelFilters = props => {
     );
 };
 
-PanelFilters.displayName = 'PanelFilters';
+PanelFilters.displayName = 'Panel.Filters';
 
 PanelFilters.propTypes = {
     className: PropTypes.string

--- a/src/Panel/_PanelFooter.js
+++ b/src/Panel/_PanelFooter.js
@@ -13,7 +13,7 @@ const PanelFooter = props => {
     return <div {...rest} className={panelFooterClasses}>{children}</div>;
 };
 
-PanelFooter.displayName = 'PanelFooter';
+PanelFooter.displayName = 'Panel.Footer';
 
 PanelFooter.propTypes = {
     className: PropTypes.string

--- a/src/Panel/_PanelHead.js
+++ b/src/Panel/_PanelHead.js
@@ -18,7 +18,7 @@ const PanelHead = props => {
     );
 };
 
-PanelHead.displayName = 'PanelHead';
+PanelHead.displayName = 'Panel.Head';
 
 PanelHead.propTypes = {
     className: PropTypes.string,

--- a/src/Panel/_PanelHeader.js
+++ b/src/Panel/_PanelHeader.js
@@ -13,7 +13,7 @@ const PanelHeader = props => {
     return <div {...rest} className={panelHeaderClasses}>{children}</div>;
 };
 
-PanelHeader.displayName = 'PanelHeader';
+PanelHeader.displayName = 'Panel.Header';
 
 PanelHeader.propTypes = {
     className: PropTypes.string

--- a/src/SideNavigation/_SideNavList.js
+++ b/src/SideNavigation/_SideNavList.js
@@ -76,6 +76,6 @@ SideNavList.propDescriptions = {
     onItemSelect: '_INTERNAL USE ONLY._'
 };
 
-SideNavList.displayName = 'SideNavList';
+SideNavList.displayName = 'SideNav.List';
 
 export default SideNavList;

--- a/src/SideNavigation/_SideNavListItem.js
+++ b/src/SideNavigation/_SideNavListItem.js
@@ -136,6 +136,6 @@ SideNavListItem.defaultProps = {
     onClick: () => {}
 };
 
-SideNavListItem.displayName = 'SideNavListItem';
+SideNavListItem.displayName = 'SideNav.ListItem';
 
 export default SideNavListItem;

--- a/src/Tile/_ProductTileContent.js
+++ b/src/Tile/_ProductTileContent.js
@@ -18,7 +18,7 @@ const ProductTileContent = props => {
     );
 };
 
-ProductTileContent.displayName = 'ProductTileContent';
+ProductTileContent.displayName = 'ProductTile.Content';
 
 ProductTileContent.propTypes = {
     className: PropTypes.string,

--- a/src/Tile/_ProductTileMedia.js
+++ b/src/Tile/_ProductTileMedia.js
@@ -18,7 +18,7 @@ const ProductTileMedia = props => {
     );
 };
 
-ProductTileMedia.displayName = 'ProductTileMedia';
+ProductTileMedia.displayName = 'ProductTile.Media';
 
 ProductTileMedia.propTypes = {
     image: PropTypes.string.isRequired,

--- a/src/Tile/_TileActions.js
+++ b/src/Tile/_TileActions.js
@@ -13,7 +13,7 @@ const TileActions = props => {
     return <div {...rest} className={tileActionsClasses}>{children}</div>;
 };
 
-TileActions.displayName = 'TileActions';
+TileActions.displayName = 'Tile.Actions';
 
 TileActions.propTypes = {
     children: PropTypes.node,

--- a/src/Tile/_TileContent.js
+++ b/src/Tile/_TileContent.js
@@ -18,7 +18,7 @@ const TileContent = props => {
     );
 };
 
-TileContent.displayName = 'TileContent';
+TileContent.displayName = 'Tile.Content';
 
 TileContent.propTypes = {
     title: PropTypes.string.isRequired,

--- a/src/Tile/_TileMedia.js
+++ b/src/Tile/_TileMedia.js
@@ -13,7 +13,7 @@ const TileMedia = props => {
     return <div {...rest} className={tileMediaClasses}>{children}</div>;
 };
 
-TileMedia.displayName = 'TileMedia';
+TileMedia.displayName = 'Tile.Media';
 
 TileMedia.propTypes = {
     children: PropTypes.node,

--- a/src/TreeView/TreeView.js
+++ b/src/TreeView/TreeView.js
@@ -119,8 +119,8 @@ class TreeView extends Component {
             <div {...rest}>
                 {
                     React.Children.map(children, (child) => {
-                        const isTreeHead = child.type && child.type.displayName === 'TreeHead';
-                        const isTree = child.type && child.type.displayName === 'Tree';
+                        const isTreeHead = child.type && child.type.displayName === 'TreeView.Head';
+                        const isTree = child.type && child.type.displayName === 'TreeView.Tree';
 
                         if (isTreeHead) {
                             // Pass expand all callbacks to TreeHead

--- a/src/TreeView/_Tree.js
+++ b/src/TreeView/_Tree.js
@@ -8,7 +8,7 @@ class Tree extends Component {
     }
 }
 
-Tree.displayName = 'Tree';
+Tree.displayName = 'TreeView.Tree';
 
 Tree.propTypes = {
     children: PropTypes.node,

--- a/src/TreeView/_TreeBranch.js
+++ b/src/TreeView/_TreeBranch.js
@@ -8,7 +8,7 @@ class TreeBranch extends Component {
     }
 }
 
-TreeBranch.displayName = 'TreeBranch';
+TreeBranch.displayName = 'TreeView.Branch';
 
 TreeBranch.propTypes = {
     children: PropTypes.node,

--- a/src/TreeView/_TreeCol.js
+++ b/src/TreeView/_TreeCol.js
@@ -25,7 +25,7 @@ class TreeCol extends Component {
     }
 }
 
-TreeCol.displayName = 'TreeCol';
+TreeCol.displayName = 'TreeView.Col';
 
 TreeCol.propTypes = {
     children: PropTypes.node,

--- a/src/TreeView/_TreeHead.js
+++ b/src/TreeView/_TreeHead.js
@@ -24,7 +24,7 @@ class TreeHead extends Component {
                 <div className='fd-tree__row fd-tree__row--header'>
                     {
                         React.Children.map(children, (child, index) => {
-                            const isFirstTreeCol = index === 0 && child.type && child.type.displayName === 'TreeCol';
+                            const isFirstTreeCol = index === 0 && child.type && child.type.displayName === 'TreeView.Col';
 
                             // Add control class to first TreeCol element
                             const childClassName = classnames({
@@ -56,7 +56,7 @@ class TreeHead extends Component {
     }
 }
 
-TreeHead.displayName = 'TreeHead';
+TreeHead.displayName = 'TreeView.Head';
 
 TreeHead.propTypes = {
     buttonProps: PropTypes.object,

--- a/src/TreeView/_TreeItem.js
+++ b/src/TreeView/_TreeItem.js
@@ -32,7 +32,7 @@ class TreeItem extends Component {
 
         // Render child TreeBranch with correct props
         const childBranch = React.Children.map(children, (child) => {
-            const isTreeBranch = child.type && child.type.displayName === 'TreeBranch';
+            const isTreeBranch = child.type && child.type.displayName === 'TreeView.Branch';
 
             return isTreeBranch ?
                 React.cloneElement(child, {
@@ -47,7 +47,7 @@ class TreeItem extends Component {
 
         // Render child TreeRow with correct props
         const childRow = React.Children.map(children, (child) => {
-            const isTreeRow = child.type && child.type.displayName === 'TreeRow';
+            const isTreeRow = child.type && child.type.displayName === 'TreeView.Row';
 
             return isTreeRow ?
                 React.cloneElement(child, {
@@ -73,7 +73,7 @@ class TreeItem extends Component {
     }
 }
 
-TreeItem.displayName = 'TreeItem';
+TreeItem.displayName = 'TreeView.Item';
 
 TreeItem.propTypes = {
     children: PropTypes.node,

--- a/src/TreeView/_TreeRow.js
+++ b/src/TreeView/_TreeRow.js
@@ -15,7 +15,7 @@ class TreeRow extends Component {
 
         // Render child TreeCols
         const cells = React.Children.map(children, (child, index) => {
-            const isTreeCol = child.type && child.type.displayName === 'TreeCol';
+            const isTreeCol = child.type && child.type.displayName === 'TreeView.Col';
             const isFirstTreeCol = index === 0 && isTreeCol;
 
             // Add control class to first TreeCol element
@@ -49,7 +49,7 @@ class TreeRow extends Component {
     }
 }
 
-TreeRow.displayName = 'TreeRow';
+TreeRow.displayName = 'TreeView.Row';
 
 TreeRow.propTypes = {
     children: PropTypes.node,


### PR DESCRIPTION
### Description
As a follow-up to #452, I changed the display names of the sub components to be in the format that consumers will actually use these components (_e.g._ `ParentComponent.SubComponent`).  This will fix the issue with the code samples for each example.