### PR TITLE
docs: Add aria-label for Search input

### DIFF
--- a/src/_playground/Routes.js
+++ b/src/_playground/Routes.js
@@ -377,6 +377,7 @@ export class Routes extends Component {
                             <div className='frDocs-Search'>
                                 <InputGroup
                                     inputPlaceholder='Search'
+                                    inputProps={{ 'aria-label': 'Search' }}
                                     inputType='search'
                                     inputValue={this.state.query}
                                     onChange={this.onChangeHandler} />


### PR DESCRIPTION
### Description

Add aria-label for Search input. GitHub logo has been updated since the issue was opened and no longer needs a label.

fixes #457 