### PR TITLE
docs: Call out FormInput's props explicitly

### DIFF
--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -41,7 +41,10 @@ FormInput.propTypes = {
 };
 
 FormInput.propDescriptions = {
-    state: 'Sets the state of the input. Can be left empty for default styles.'
+    name: 'Value for the `name` attribute on the input.',
+    state: 'Sets the state of the input. Can be left empty for default styles.',
+    type: 'Value for the `type` attribute on the input.',
+    value: 'Value for the `value` attribute on the input.'
 };
 
 export default FormInput;

--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -3,7 +3,7 @@ import { INPUT_TYPES } from '../utils/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FormInput = ({ state, className, ...props }) => {
+const FormInput = ({ state, className, disabled, id, name, placeholder, readOnly, type, value, ...props }) => {
     const formInputClasses = classnames(
         'fd-form__control',
         {
@@ -15,7 +15,14 @@ const FormInput = ({ state, className, ...props }) => {
     return (
         <input
             {...props}
-            className={formInputClasses} />
+            className={formInputClasses}
+            disabled={disabled}
+            id={id}
+            name={name}
+            placeholder={placeholder}
+            readOnly={readOnly}
+            type={type}
+            value={value} />
     );
 };
 
@@ -24,8 +31,13 @@ FormInput.displayName = 'FormInput';
 FormInput.propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
+    id: PropTypes.string,
+    name: PropTypes.string,
+    placeholder: PropTypes.string,
     readOnly: PropTypes.bool,
-    state: PropTypes.oneOf(INPUT_TYPES)
+    state: PropTypes.oneOf(INPUT_TYPES),
+    type: PropTypes.string,
+    value: PropTypes.string
 };
 
 FormInput.propDescriptions = {


### PR DESCRIPTION
### Description

Call out more of FormInput's props explicitly for PropType validation using FormRadioItem as a model.

fixes #464 