### PR TITLE
docs: update example background color

### DIFF
--- a/src/_playground/App.scss
+++ b/src/_playground/App.scss
@@ -210,7 +210,7 @@ $menu-spacing: 20px;
     }
 
     &__tile-background {
-        background: #edeef0;
+        background: #F3F4F5;
         transition: background-color 0.25s;
     }
 


### PR DESCRIPTION
### Description

Background color with Toggle labels did not meet color contrast, this change bumps the contrast ratio to a passing 4.71:1. 

`#F3F4F5` was taken from the fundamental parent repo example containers.


fixes #461 