### PR TITLE
fix: Renamed popper CSS classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17827,9 +17827,9 @@
       "dev": true
     },
     "react-foco": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-foco/-/react-foco-1.2.0.tgz",
-      "integrity": "sha512-Gw+JHFxdqn+tIcqxaxxmkpX+unR8Nbu7MFGfn8d8gmntgtfel7PXOxfVBMM7QD3nv/zpUd9WnzygHAoBqQ9REw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-foco/-/react-foco-1.3.0.tgz",
+      "integrity": "sha512-qD1FZLcIm031UOKJcHdsBQLi91VA2/HOMWyKED1jsc15vkLSH8DGWqxntY9ezIJ+ihjaWK0fWcoIfsprfptBbg=="
     },
     "react-helmet-async": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "focus-trap-react": "^6.0.0",
     "keycode": "^2.2.0",
     "prop-types": "^15.7.1",
-    "react-foco": "^1.2.0",
+    "react-foco": "^1.3.0",
     "react-overlays": "^1.1.2",
     "react-popper": "^1.3.3",
     "shortid": "^2.2.14"

--- a/src/ComboboxInput/ComboboxInput.test.js
+++ b/src/ComboboxInput/ComboboxInput.test.js
@@ -56,10 +56,8 @@ describe('<ComboboxInput />', () => {
         test('should allow props to be spread to the ComboboxInput component\'s Popover component', () => {
             const element = mount(<ComboboxInput menu={defaultMenu} popoverProps={{ 'data-sample': 'Sample' }} />);
 
-            element.find('.fd-combobox-control').simulate('click');
-
             expect(
-                element.find('div.fd-popper__body').getDOMNode().attributes['data-sample'].value
+                element.find('div.fd-popover').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
 

--- a/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
+++ b/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
@@ -7,7 +7,7 @@ exports[`<ComboboxInput /> create combobox input 1`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -37,7 +37,7 @@ exports[`<ComboboxInput /> create combobox input 1`] = `
           </div>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -49,7 +49,7 @@ exports[`<ComboboxInput /> create combobox input 2`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -79,7 +79,7 @@ exports[`<ComboboxInput /> create combobox input 2`] = `
           </div>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
+++ b/src/ComboboxInput/__snapshots__/ComboboxInput.test.js.snap
@@ -4,37 +4,41 @@ exports[`<ComboboxInput /> create combobox input 1`] = `
 <div
   className="fd-combobox-input"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
-        className="fd-combobox-control"
-        onClick={[Function]}
+        className="fd-popover__control"
       >
         <div
-          className="fd-input-group fd-input-group--after"
+          className="fd-combobox-control"
+          onClick={[Function]}
         >
-          <input
-            className="fd-input"
-            placeholder="Select Fruit"
-            type="text"
-          />
-          <span
-            className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+          <div
+            className="fd-input-group fd-input-group--after"
           >
-            <button
-              className=" fd-button--light sap-icon--navigation-down-arrow"
+            <input
+              className="fd-input"
+              placeholder="Select Fruit"
+              type="text"
             />
-          </span>
+            <span
+              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+            >
+              <button
+                className=" fd-button--light sap-icon--navigation-down-arrow"
+              />
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -42,36 +46,40 @@ exports[`<ComboboxInput /> create combobox input 2`] = `
 <div
   className="fd-combobox-input blue"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
-        className="fd-combobox-control"
-        onClick={[Function]}
+        className="fd-popover__control"
       >
         <div
-          className="fd-input-group fd-input-group--after fd-input-group--compact"
+          className="fd-combobox-control"
+          onClick={[Function]}
         >
-          <input
-            className="fd-input fd-input--compact"
-            placeholder="Select Fruit"
-            type="text"
-          />
-          <span
-            className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+          <div
+            className="fd-input-group fd-input-group--after fd-input-group--compact"
           >
-            <button
-              className=" fd-button--light sap-icon--navigation-down-arrow"
+            <input
+              className="fd-input fd-input--compact"
+              placeholder="Select Fruit"
+              type="text"
             />
-          </span>
+            <span
+              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+            >
+              <button
+                className=" fd-button--light sap-icon--navigation-down-arrow"
+              />
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;

--- a/src/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -7,7 +7,7 @@ exports[`<Dropdown /> create dropdown component 1`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -22,7 +22,7 @@ exports[`<Dropdown /> create dropdown component 1`] = `
           Select
         </button>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -34,7 +34,7 @@ exports[`<Dropdown /> create dropdown component 2`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -49,7 +49,7 @@ exports[`<Dropdown /> create dropdown component 2`] = `
           Select
         </button>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -61,7 +61,7 @@ exports[`<Dropdown /> create dropdown component 3`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -76,7 +76,7 @@ exports[`<Dropdown /> create dropdown component 3`] = `
           Select
         </button>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -89,7 +89,7 @@ exports[`<Dropdown /> create dropdown component 4`] = `
     className="fd-popover"
     id="jhqD0557"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -104,7 +104,7 @@ exports[`<Dropdown /> create dropdown component 4`] = `
           Select
         </button>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -117,7 +117,7 @@ exports[`<Dropdown /> create dropdown component 5`] = `
     className="fd-popover"
     id="jhqD0561"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -133,7 +133,7 @@ exports[`<Dropdown /> create dropdown component 5`] = `
           Select
         </button>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -4,22 +4,26 @@ exports[`<Dropdown /> create dropdown component 1`] = `
 <div
   className="fd-dropdown"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <button
-        className="fd-button fd-dropdown__control"
-        onClick={[Function]}
+      <div
+        className="fd-popover__control"
       >
-        Select
-      </button>
-    </div>
-  </span>
+        <button
+          className="fd-button fd-dropdown__control"
+          onClick={[Function]}
+        >
+          Select
+        </button>
+      </div>
+    </span>
+  </div>
 </div>
 `;
 
@@ -27,22 +31,26 @@ exports[`<Dropdown /> create dropdown component 2`] = `
 <div
   className="fd-dropdown blue"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <button
-        className="fd-button fd-dropdown__control fd-button--compact"
-        onClick={[Function]}
+      <div
+        className="fd-popover__control"
       >
-        Select
-      </button>
-    </div>
-  </span>
+        <button
+          className="fd-button fd-dropdown__control fd-button--compact"
+          onClick={[Function]}
+        >
+          Select
+        </button>
+      </div>
+    </span>
+  </div>
 </div>
 `;
 
@@ -50,22 +58,26 @@ exports[`<Dropdown /> create dropdown component 3`] = `
 <div
   className="fd-dropdown fd-dropdown--standard"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <button
-        className="fd-button fd-button--standard fd-dropdown__control"
-        onClick={[Function]}
+      <div
+        className="fd-popover__control"
       >
-        Select
-      </button>
-    </div>
-  </span>
+        <button
+          className="fd-button fd-button--standard fd-dropdown__control"
+          onClick={[Function]}
+        >
+          Select
+        </button>
+      </div>
+    </span>
+  </div>
 </div>
 `;
 
@@ -73,22 +85,27 @@ exports[`<Dropdown /> create dropdown component 4`] = `
 <div
   className="fd-dropdown"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
+    id="jhqD0557"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <button
-        className="fd-button fd-dropdown__control sap-icon--filter"
-        onClick={[Function]}
+      <div
+        className="fd-popover__control"
       >
-        Select
-      </button>
-    </div>
-  </span>
+        <button
+          className="fd-button fd-dropdown__control sap-icon--filter"
+          onClick={[Function]}
+        >
+          Select
+        </button>
+      </div>
+    </span>
+  </div>
 </div>
 `;
 
@@ -96,22 +113,27 @@ exports[`<Dropdown /> create dropdown component 5`] = `
 <div
   className="fd-dropdown"
 >
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
+    id="jhqD0561"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <button
-        className="fd-button fd-dropdown__control sap-icon--filter is-disabled"
-        disabled={true}
-        onClick={[Function]}
+      <div
+        className="fd-popover__control"
       >
-        Select
-      </button>
-    </div>
-  </span>
+        <button
+          className="fd-button fd-dropdown__control sap-icon--filter is-disabled"
+          disabled={true}
+          onClick={[Function]}
+        >
+          Select
+        </button>
+      </div>
+    </span>
+  </div>
 </div>
 `;

--- a/src/LocalizationEditor/LocalizationEditor.test.js
+++ b/src/LocalizationEditor/LocalizationEditor.test.js
@@ -90,10 +90,8 @@ describe('<LocalizationEditor />', () => {
                     }} />
             );
 
-            element.find('.fd-popper__control > div').simulate('click');
-
             expect(
-                element.find('.fd-popper__body').getDOMNode().attributes['data-sample'].value
+                element.find('.fd-popover').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
 
@@ -183,7 +181,7 @@ describe('<LocalizationEditor />', () => {
                     menu={defaultMenuArray} />
             );
 
-            element.find('.fd-popper__control > div').simulate('click');
+            element.find('.fd-popover__control > div').simulate('click');
 
             expect(
                 element.find('nav > ul').getDOMNode().attributes['data-sample'].value
@@ -202,7 +200,7 @@ describe('<LocalizationEditor />', () => {
                     menu={menu} />
             );
 
-            element.find('.fd-popper__control > div').simulate('click');
+            element.find('.fd-popover__control > div').simulate('click');
 
             const listItems = element.find('nav > ul > li');
 
@@ -231,7 +229,7 @@ describe('<LocalizationEditor />', () => {
                     textarea />
             );
 
-            element.find('.fd-popper__control > div').simulate('click');
+            element.find('.fd-popover__control > div').simulate('click');
 
             const listItems = element.find('nav ul li textarea');
 
@@ -259,7 +257,7 @@ describe('<LocalizationEditor />', () => {
                     menu={menu} />
             );
 
-            element.find('.fd-popper__control > div').simulate('click');
+            element.find('.fd-popover__control > div').simulate('click');
 
             const listItems = element.find('nav ul li input');
 

--- a/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
+++ b/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
@@ -12,7 +12,7 @@ exports[`<LocalizationEditor /> create localization editor 1`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -40,7 +40,7 @@ exports[`<LocalizationEditor /> create localization editor 1`] = `
           </span>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -57,7 +57,7 @@ exports[`<LocalizationEditor /> create localization editor 2`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -85,7 +85,7 @@ exports[`<LocalizationEditor /> create localization editor 2`] = `
           </span>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;
@@ -102,7 +102,7 @@ exports[`<LocalizationEditor /> create localization editor 3`] = `
   <div
     className="fd-popover"
   >
-    <span
+    <div
       onFocus={[Function]}
       onMouseDown={[Function]}
       onTouchStart={[Function]}
@@ -126,7 +126,7 @@ exports[`<LocalizationEditor /> create localization editor 3`] = `
           </span>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
+++ b/src/LocalizationEditor/__snapshots__/LocalizationEditor.test.js.snap
@@ -9,35 +9,39 @@ exports[`<LocalizationEditor /> create localization editor 1`] = `
   >
     Localization Editor Label
   </label>
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
-        className="fd-input-group fd-input-group--after"
-        onClick={[Function]}
+        className="fd-popover__control"
       >
-        <input
-          className=""
-          placeholder="Enter Label"
-          type="text"
-        />
-        <span
-          className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+        <div
+          className="fd-input-group fd-input-group--after"
+          onClick={[Function]}
         >
-          <button
-            className="fd-button--light fd-localization-editor__button"
+          <input
+            className=""
+            placeholder="Enter Label"
+            type="text"
+          />
+          <span
+            className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
           >
-            EN*
-          </button>
-        </span>
+            <button
+              className="fd-button--light fd-localization-editor__button"
+            >
+              EN*
+            </button>
+          </span>
+        </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -50,35 +54,39 @@ exports[`<LocalizationEditor /> create localization editor 2`] = `
   >
     Localization Editor Compact Mode
   </label>
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
-        className="fd-input-group fd-input-group--compact fd-input-group--after"
-        onClick={[Function]}
+        className="fd-popover__control"
       >
-        <input
-          className="fd-input fd-input--compact"
-          placeholder="Enter Label"
-          type="text"
-        />
-        <span
-          className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
+        <div
+          className="fd-input-group fd-input-group--compact fd-input-group--after"
+          onClick={[Function]}
         >
-          <button
-            className="fd-button--light fd-localization-editor__button"
+          <input
+            className="fd-input fd-input--compact"
+            placeholder="Enter Label"
+            type="text"
+          />
+          <span
+            className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button"
           >
-            EN*
-          </button>
-        </span>
+            <button
+              className="fd-button--light fd-localization-editor__button"
+            >
+              EN*
+            </button>
+          </span>
+        </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -91,30 +99,34 @@ exports[`<LocalizationEditor /> create localization editor 3`] = `
   >
     Localization Editor Label
   </label>
-  <span
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <div
+    className="fd-popover"
   >
-    <div
-      className="fd-popper__control fd-popover"
+    <span
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
       <div
-        className="fd-input-group fd-input-group--after"
-        onClick={[Function]}
+        className="fd-popover__control"
       >
-        <textarea />
-        <span
-          className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button fd-input-group__addon--textarea"
+        <div
+          className="fd-input-group fd-input-group--after"
+          onClick={[Function]}
         >
-          <button
-            className="fd-button--light fd-localization-editor__button"
+          <textarea />
+          <span
+            className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button fd-input-group__addon--textarea"
           >
-            EN*
-          </button>
-        </span>
+            <button
+              className="fd-button--light fd-localization-editor__button"
+            >
+              EN*
+            </button>
+          </span>
+        </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,4 +1,5 @@
 import { chain } from 'chain-function';
+import classnames from 'classnames';
 import Popper from '../utils/_Popper';
 import { POPPER_PLACEMENTS } from '../utils/constants';
 import PropTypes from 'prop-types';
@@ -37,6 +38,7 @@ class Popover extends Component {
             body,
             className,
             placement,
+            popperProps,
             ...rest
         } = this.props;
 
@@ -49,19 +51,24 @@ class Popover extends Component {
             onClick: onClickFunctions
         });
 
+        const popoverClasses = classnames('fd-popover', className);
+
         return (
-            <Popper
-                noArrow={noArrow}
-                onClickOutside={this.handleOutsideClick}
-                onEscapeKey={this.handleOutsideClick}
-                popperClassName={className}
-                popperPlacement={placement}
-                popperProps={rest}
-                referenceClassName='fd-popover'
-                referenceComponent={referenceComponent}
-                show={this.state.isExpanded && !disabled}>
-                {body}
-            </Popper>
+            <div {...rest} className={popoverClasses}>
+                <Popper
+                    cssBlock='fd-popover'
+                    noArrow={noArrow}
+                    onClickOutside={this.handleOutsideClick}
+                    onEscapeKey={this.handleOutsideClick}
+                    popperPlacement={placement}
+                    popperProps={popperProps}
+                    referenceClassName='fd-popover__control'
+                    referenceComponent={referenceComponent}
+                    show={this.state.isExpanded && !disabled}
+                    usePortal>
+                    {body}
+                </Popper>
+            </div>
         );
     }
 }
@@ -74,14 +81,16 @@ Popover.propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     noArrow: PropTypes.bool,
-    placement: PropTypes.oneOf(POPPER_PLACEMENTS)
+    placement: PropTypes.oneOf(POPPER_PLACEMENTS),
+    popperProps: PropTypes.object
 };
 
 Popover.propDescriptions = {
     body: 'Node(s) to render in the overlay.',
     control: 'Node to render as the reference element (that the `body` will be placed in relation to).',
     noArrow: 'Set to **true** to render a popover without an arrow.',
-    placement: 'Initial position of the `body` (overlay) related to the `control`.'
+    placement: 'Initial position of the `body` (overlay) related to the `control`.',
+    popperProps: 'Additional props to be spread to the overlay element.'
 };
 
 export default Popover;

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -96,11 +96,11 @@ describe('<Popover />', () => {
         const wrapper = mount(popOver);
 
         // click on popover to show
-        wrapper.find('div.fd-popper__control .sap-icon--cart').simulate('click');
+        wrapper.find('div.fd-popover__control .sap-icon--cart').simulate('click');
         expect(wrapper.state('isExpanded')).toBeTruthy();
 
         // click on popover to hide
-        wrapper.find('div.fd-popper__control .sap-icon--cart').simulate('click');
+        wrapper.find('div.fd-popover__control .sap-icon--cart').simulate('click');
         expect(wrapper.state('isExpanded')).toBeFalsy();
 
         // wrapper.instance().componentWillUnmount();
@@ -110,7 +110,7 @@ describe('<Popover />', () => {
         const wrapper = mount(popOver);
 
         // click on popover to show
-        wrapper.find('div.fd-popper__control .sap-icon--cart').simulate('click');
+        wrapper.find('div.fd-popover__control .sap-icon--cart').simulate('click');
         expect(wrapper.state('isExpanded')).toBeTruthy();
 
         // handle esc key
@@ -123,7 +123,7 @@ describe('<Popover />', () => {
         const wrapper = mount(popOver);
 
         // click on popover to show
-        wrapper.find('div.fd-popper__control .sap-icon--cart').simulate('click');
+        wrapper.find('div.fd-popover__control .sap-icon--cart').simulate('click');
         expect(wrapper.state('isExpanded')).toBeTruthy();
 
         // handle click on document
@@ -136,7 +136,7 @@ describe('<Popover />', () => {
         const wrapper = mount(popOverDisabled);
 
         // click on popover to show
-        wrapper.find('div.fd-popper__control .sap-icon--cart').simulate('click');
+        wrapper.find('div.fd-popover__control .sap-icon--cart').simulate('click');
         expect(wrapper.state('isExpanded')).toBeFalsy();
     });
 
@@ -149,10 +149,8 @@ describe('<Popover />', () => {
                     data-sample='Sample' />
             );
 
-            element.find('div.fd-popper__control .sap-icon--cart').simulate('click');
-
             expect(
-                element.find('.fd-popper__body').getDOMNode().attributes['data-sample'].value
+                element.find('.fd-popover').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
     });

--- a/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__snapshots__/Popover.test.js.snap
@@ -1,69 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Popover /> create Popover 1`] = `
-<span
-  onFocus={[Function]}
-  onMouseDown={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="fd-popover"
 >
-  <div
-    className="fd-popper__control fd-popover"
+  <span
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
   >
-    <span
-      className="sap-icon--cart sap-icon--xl"
-      onClick={[Function]}
-    />
-  </div>
-</span>
+    <div
+      className="fd-popover__control"
+    >
+      <span
+        className="sap-icon--cart sap-icon--xl"
+        onClick={[Function]}
+      />
+    </div>
+  </span>
+</div>
 `;
 
 exports[`<Popover /> create Popover 2`] = `
-<span
-  onFocus={[Function]}
-  onMouseDown={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="fd-popover blue"
 >
-  <div
-    className="fd-popper__control fd-popover"
+  <span
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
   >
-    <span
-      className="sap-icon--cart sap-icon--xl"
-      onClick={[Function]}
-    />
-  </div>
-</span>
+    <div
+      className="fd-popover__control"
+    >
+      <span
+        className="sap-icon--cart sap-icon--xl"
+        onClick={[Function]}
+      />
+    </div>
+  </span>
+</div>
 `;
 
 exports[`<Popover /> create Popover 3`] = `
-<span
-  onFocus={[Function]}
-  onMouseDown={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="fd-popover"
 >
-  <div
-    className="fd-popper__control fd-popover"
+  <span
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
   >
-    <span
-      className="sap-icon--cart sap-icon--xl"
-      onClick={[Function]}
-    />
-  </div>
-</span>
+    <div
+      className="fd-popover__control"
+    >
+      <span
+        className="sap-icon--cart sap-icon--xl"
+        onClick={[Function]}
+      />
+    </div>
+  </span>
+</div>
 `;
 
 exports[`<Popover /> create Popover 4`] = `
-<span
-  onFocus={[Function]}
-  onMouseDown={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="fd-popover"
 >
-  <div
-    className="fd-popper__control fd-popover"
+  <span
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
   >
-    <span
-      className="sap-icon--cart sap-icon--xl"
-      onClick={[Function]}
-    />
-  </div>
-</span>
+    <div
+      className="fd-popover__control"
+    >
+      <span
+        className="sap-icon--cart sap-icon--xl"
+        onClick={[Function]}
+      />
+    </div>
+  </span>
+</div>
 `;

--- a/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__snapshots__/Popover.test.js.snap
@@ -4,7 +4,7 @@ exports[`<Popover /> create Popover 1`] = `
 <div
   className="fd-popover"
 >
-  <span
+  <div
     onFocus={[Function]}
     onMouseDown={[Function]}
     onTouchStart={[Function]}
@@ -17,7 +17,7 @@ exports[`<Popover /> create Popover 1`] = `
         onClick={[Function]}
       />
     </div>
-  </span>
+  </div>
 </div>
 `;
 
@@ -25,7 +25,7 @@ exports[`<Popover /> create Popover 2`] = `
 <div
   className="fd-popover blue"
 >
-  <span
+  <div
     onFocus={[Function]}
     onMouseDown={[Function]}
     onTouchStart={[Function]}
@@ -38,7 +38,7 @@ exports[`<Popover /> create Popover 2`] = `
         onClick={[Function]}
       />
     </div>
-  </span>
+  </div>
 </div>
 `;
 
@@ -46,7 +46,7 @@ exports[`<Popover /> create Popover 3`] = `
 <div
   className="fd-popover"
 >
-  <span
+  <div
     onFocus={[Function]}
     onMouseDown={[Function]}
     onTouchStart={[Function]}
@@ -59,7 +59,7 @@ exports[`<Popover /> create Popover 3`] = `
         onClick={[Function]}
       />
     </div>
-  </span>
+  </div>
 </div>
 `;
 
@@ -67,7 +67,7 @@ exports[`<Popover /> create Popover 4`] = `
 <div
   className="fd-popover"
 >
-  <span
+  <div
     onFocus={[Function]}
     onMouseDown={[Function]}
     onTouchStart={[Function]}
@@ -80,6 +80,6 @@ exports[`<Popover /> create Popover 4`] = `
         onClick={[Function]}
       />
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/src/Shellbar/Shellbar.test.js
+++ b/src/Shellbar/Shellbar.test.js
@@ -275,7 +275,7 @@ describe('<Shellbar />', () => {
     test('click back button from collapsed product switcher', () => {
         const wrapper = mount(coPilotShell);
 
-        wrapper.find('.fd-popper__control .fd-shellbar-collapse--control').simulate('click');
+        wrapper.find('.fd-popover__control .fd-shellbar-collapse--control').simulate('click');
 
         wrapper.find('a.fd-menu__item span.sap-icon--grid').simulate('click');
         wrapper.find('span.fd-menu.sap-icon--nav-back').simulate('click');

--- a/src/Shellbar/__snapshots__/Shellbar.test.js.snap
+++ b/src/Shellbar/__snapshots__/Shellbar.test.js.snap
@@ -40,7 +40,7 @@ exports[`<Shellbar /> create shellbar 1`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -56,7 +56,7 @@ exports[`<Shellbar /> create shellbar 1`] = `
                   JS
                 </span>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -105,7 +105,7 @@ exports[`<Shellbar /> create shellbar 2`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -121,7 +121,7 @@ exports[`<Shellbar /> create shellbar 2`] = `
                   JS
                 </span>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -154,7 +154,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -173,7 +173,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -247,7 +247,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -268,13 +268,13 @@ exports[`<Shellbar /> create shellbar 3`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
       <div
         className="fd-popover"
       >
-        <span
+        <div
           onFocus={[Function]}
           onMouseDown={[Function]}
           onTouchStart={[Function]}
@@ -299,7 +299,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
               </button>
             </div>
           </div>
-        </span>
+        </div>
       </div>
       <div
         className="fd-shellbar__action fd-shellbar__action--collapse"
@@ -310,7 +310,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -337,7 +337,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   </button>
                 </div>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -350,7 +350,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -366,7 +366,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   JS
                 </span>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -379,7 +379,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -392,7 +392,7 @@ exports[`<Shellbar /> create shellbar 3`] = `
                   onClick={[Function]}
                 />
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -425,7 +425,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -444,7 +444,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -518,7 +518,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -539,13 +539,13 @@ exports[`<Shellbar /> create shellbar 4`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
       <div
         className="fd-popover"
       >
-        <span
+        <div
           onFocus={[Function]}
           onMouseDown={[Function]}
           onTouchStart={[Function]}
@@ -563,7 +563,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
               />
             </div>
           </div>
-        </span>
+        </div>
       </div>
       <div
         className="fd-shellbar__action fd-shellbar__action--collapse"
@@ -574,7 +574,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -601,7 +601,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
                   </button>
                 </div>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -614,7 +614,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -630,7 +630,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
                   JS
                 </span>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -643,7 +643,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -656,7 +656,7 @@ exports[`<Shellbar /> create shellbar 4`] = `
                   onClick={[Function]}
                 />
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -689,7 +689,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -708,7 +708,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -795,7 +795,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
       <div
         className="fd-popover"
       >
-        <span
+        <div
           onFocus={[Function]}
           onMouseDown={[Function]}
           onTouchStart={[Function]}
@@ -813,7 +813,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
               />
             </div>
           </div>
-        </span>
+        </div>
       </div>
       <div
         className="fd-shellbar__action fd-shellbar__action--collapse"
@@ -824,7 +824,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -851,7 +851,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
                   </button>
                 </div>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -864,7 +864,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -880,7 +880,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
                   JS
                 </span>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -893,7 +893,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -906,7 +906,7 @@ exports[`<Shellbar /> create shellbar 5`] = `
                   onClick={[Function]}
                 />
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -939,7 +939,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -958,7 +958,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>
@@ -1032,7 +1032,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
         <div
           className="fd-popover"
         >
-          <span
+          <div
             onFocus={[Function]}
             onMouseDown={[Function]}
             onTouchStart={[Function]}
@@ -1053,7 +1053,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
                 </span>
               </button>
             </div>
-          </span>
+          </div>
         </div>
       </div>
       <div
@@ -1081,7 +1081,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -1108,7 +1108,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
                   </button>
                 </div>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -1121,7 +1121,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -1140,7 +1140,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
                   }
                 />
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -1153,7 +1153,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
           <div
             className="fd-popover"
           >
-            <span
+            <div
               onFocus={[Function]}
               onMouseDown={[Function]}
               onTouchStart={[Function]}
@@ -1166,7 +1166,7 @@ exports[`<Shellbar /> create shellbar 6`] = `
                   onClick={[Function]}
                 />
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Shellbar/__snapshots__/Shellbar.test.js.snap
+++ b/src/Shellbar/__snapshots__/Shellbar.test.js.snap
@@ -37,23 +37,27 @@ exports[`<Shellbar /> create shellbar 1`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
-                onClick={[Function]}
-                role=""
+              <div
+                className="fd-popover__control"
               >
-                JS
-              </span>
-            </div>
-          </span>
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
+                  onClick={[Function]}
+                  role=""
+                >
+                  JS
+                </span>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -98,23 +102,27 @@ exports[`<Shellbar /> create shellbar 2`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
-                onClick={[Function]}
-                role=""
+              <div
+                className="fd-popover__control"
               >
-                JS
-              </span>
-            </div>
-          </span>
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
+                  onClick={[Function]}
+                  role=""
+                >
+                  JS
+                </span>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -143,26 +151,30 @@ exports[`<Shellbar /> create shellbar 3`] = `
       <div
         className="fd-product-menu"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <div
+          className="fd-popover"
         >
-          <div
-            className="fd-popper__control fd-popover"
+          <span
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <button
-              className="fd-product-menu__control"
-              onClick={[Function]}
+            <div
+              className="fd-popover__control"
             >
-              <span
-                className="fd-shellbar__title fd-product-menu__title"
+              <button
+                className="fd-product-menu__control"
+                onClick={[Function]}
               >
-                Corporate Portal
-              </span>
-            </button>
-          </div>
-        </span>
+                <span
+                  className="fd-shellbar__title fd-product-menu__title"
+                >
+                  Corporate Portal
+                </span>
+              </button>
+            </div>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -232,60 +244,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
       <div
         className="fd-shellbar__action fd-shellbar__action--collapsible"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
-        >
-          <div
-            className="fd-popper__control fd-popover"
-          >
-            <button
-              aria-label="Settings"
-              className=" fd-button--shell sap-icon--settings"
-              onClick={[Function]}
-            >
-              <span
-                aria-label="Unread count"
-                className="fd-counter fd-counter--notification"
-              >
-                5
-              </span>
-            </button>
-          </div>
-        </span>
-      </div>
-      <span
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
         <div
-          className="fd-popper__control fd-popover"
-        >
-          <div
-            className="fd-shellbar__action fd-shellbar__action--collapsible"
-            onClick={[Function]}
-          >
-            <button
-              aria-label="Notifications"
-              className=" fd-button--shell sap-icon--bell"
-            >
-              <span
-                aria-label="Unread count"
-                className="fd-counter fd-counter--notification"
-              >
-                2
-              </span>
-            </button>
-          </div>
-        </div>
-      </span>
-      <div
-        className="fd-shellbar__action fd-shellbar__action--collapse"
-      >
-        <div
-          className="fd-shellbar-collapse"
+          className="fd-popover"
         >
           <span
             onFocus={[Function]}
@@ -293,28 +253,92 @@ exports[`<Shellbar /> create shellbar 3`] = `
             onTouchStart={[Function]}
           >
             <div
-              className="fd-popper__control fd-popover"
+              className="fd-popover__control"
             >
-              <div
-                className="fd-shellbar-collapse--control"
+              <button
+                aria-label="Settings"
+                className=" fd-button--shell sap-icon--settings"
                 onClick={[Function]}
-                role="button"
               >
-                <button
-                  className=" fd-button--shell sap-icon--overflow"
+                <span
+                  aria-label="Unread count"
+                  className="fd-counter fd-counter--notification"
                 >
-                  <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
-                  >
-                     
-                    7
-                     
-                  </span>
-                </button>
-              </div>
+                  5
+                </span>
+              </button>
             </div>
           </span>
+        </div>
+      </div>
+      <div
+        className="fd-popover"
+      >
+        <span
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="fd-popover__control"
+          >
+            <div
+              className="fd-shellbar__action fd-shellbar__action--collapsible"
+              onClick={[Function]}
+            >
+              <button
+                aria-label="Notifications"
+                className=" fd-button--shell sap-icon--bell"
+              >
+                <span
+                  aria-label="Unread count"
+                  className="fd-counter fd-counter--notification"
+                >
+                  2
+                </span>
+              </button>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="fd-shellbar__action fd-shellbar__action--collapse"
+      >
+        <div
+          className="fd-shellbar-collapse"
+        >
+          <div
+            className="fd-popover"
+          >
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="fd-popover__control"
+              >
+                <div
+                  className="fd-shellbar-collapse--control"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  <button
+                    className=" fd-button--shell sap-icon--overflow"
+                  >
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      7
+                       
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -323,23 +347,27 @@ exports[`<Shellbar /> create shellbar 3`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
-                onClick={[Function]}
-                role=""
+              <div
+                className="fd-popover__control"
               >
-                JS
-              </span>
-            </div>
-          </span>
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
+                  onClick={[Function]}
+                  role=""
+                >
+                  JS
+                </span>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -348,20 +376,24 @@ exports[`<Shellbar /> create shellbar 3`] = `
         <div
           className="fd-product-switcher"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <button
-                className=" fd-button--shell sap-icon--grid"
-                onClick={[Function]}
-              />
-            </div>
-          </span>
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  className=" fd-button--shell sap-icon--grid"
+                  onClick={[Function]}
+                />
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -390,26 +422,30 @@ exports[`<Shellbar /> create shellbar 4`] = `
       <div
         className="fd-product-menu"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <div
+          className="fd-popover"
         >
-          <div
-            className="fd-popper__control fd-popover"
+          <span
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <button
-              className="fd-product-menu__control"
-              onClick={[Function]}
+            <div
+              className="fd-popover__control"
             >
-              <span
-                className="fd-shellbar__title fd-product-menu__title"
+              <button
+                className="fd-product-menu__control"
+                onClick={[Function]}
               >
-                Corporate Portal
-              </span>
-            </button>
-          </div>
-        </span>
+                <span
+                  className="fd-shellbar__title fd-product-menu__title"
+                >
+                  Corporate Portal
+                </span>
+              </button>
+            </div>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -479,53 +515,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
       <div
         className="fd-shellbar__action fd-shellbar__action--collapsible"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
-        >
-          <div
-            className="fd-popper__control fd-popover"
-          >
-            <button
-              aria-label="Settings"
-              className=" fd-button--shell sap-icon--settings"
-              onClick={[Function]}
-            >
-              <span
-                aria-label="Unread count"
-                className="fd-counter fd-counter--notification"
-              >
-                5
-              </span>
-            </button>
-          </div>
-        </span>
-      </div>
-      <span
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
         <div
-          className="fd-popper__control fd-popover"
-        >
-          <div
-            className="fd-shellbar__action fd-shellbar__action--collapsible"
-            onClick={[Function]}
-          >
-            <button
-              aria-label="Notifications"
-              className=" fd-button--shell sap-icon--bell"
-            />
-          </div>
-        </div>
-      </span>
-      <div
-        className="fd-shellbar__action fd-shellbar__action--collapse"
-      >
-        <div
-          className="fd-shellbar-collapse"
+          className="fd-popover"
         >
           <span
             onFocus={[Function]}
@@ -533,28 +524,85 @@ exports[`<Shellbar /> create shellbar 4`] = `
             onTouchStart={[Function]}
           >
             <div
-              className="fd-popper__control fd-popover"
+              className="fd-popover__control"
             >
-              <div
-                className="fd-shellbar-collapse--control"
+              <button
+                aria-label="Settings"
+                className=" fd-button--shell sap-icon--settings"
                 onClick={[Function]}
-                role="button"
               >
-                <button
-                  className=" fd-button--shell sap-icon--overflow"
+                <span
+                  aria-label="Unread count"
+                  className="fd-counter fd-counter--notification"
                 >
-                  <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
-                  >
-                     
-                    5
-                     
-                  </span>
-                </button>
-              </div>
+                  5
+                </span>
+              </button>
             </div>
           </span>
+        </div>
+      </div>
+      <div
+        className="fd-popover"
+      >
+        <span
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="fd-popover__control"
+          >
+            <div
+              className="fd-shellbar__action fd-shellbar__action--collapsible"
+              onClick={[Function]}
+            >
+              <button
+                aria-label="Notifications"
+                className=" fd-button--shell sap-icon--bell"
+              />
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="fd-shellbar__action fd-shellbar__action--collapse"
+      >
+        <div
+          className="fd-shellbar-collapse"
+        >
+          <div
+            className="fd-popover"
+          >
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="fd-popover__control"
+              >
+                <div
+                  className="fd-shellbar-collapse--control"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  <button
+                    className=" fd-button--shell sap-icon--overflow"
+                  >
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      5
+                       
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -563,23 +611,27 @@ exports[`<Shellbar /> create shellbar 4`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
-                onClick={[Function]}
-                role=""
+              <div
+                className="fd-popover__control"
               >
-                JS
-              </span>
-            </div>
-          </span>
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
+                  onClick={[Function]}
+                  role=""
+                >
+                  JS
+                </span>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -588,20 +640,24 @@ exports[`<Shellbar /> create shellbar 4`] = `
         <div
           className="fd-product-switcher"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <button
-                className=" fd-button--shell sap-icon--grid"
-                onClick={[Function]}
-              />
-            </div>
-          </span>
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  className=" fd-button--shell sap-icon--grid"
+                  onClick={[Function]}
+                />
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -630,26 +686,30 @@ exports[`<Shellbar /> create shellbar 5`] = `
       <div
         className="fd-product-menu"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <div
+          className="fd-popover"
         >
-          <div
-            className="fd-popper__control fd-popover"
+          <span
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <button
-              className="fd-product-menu__control"
-              onClick={[Function]}
+            <div
+              className="fd-popover__control"
             >
-              <span
-                className="fd-shellbar__title fd-product-menu__title"
+              <button
+                className="fd-product-menu__control"
+                onClick={[Function]}
               >
-                Corporate Portal
-              </span>
-            </button>
-          </div>
-        </span>
+                <span
+                  className="fd-shellbar__title fd-product-menu__title"
+                >
+                  Corporate Portal
+                </span>
+              </button>
+            </div>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -732,59 +792,67 @@ exports[`<Shellbar /> create shellbar 5`] = `
           </span>
         </button>
       </div>
-      <span
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
+      <div
+        className="fd-popover"
       >
-        <div
-          className="fd-popper__control fd-popover"
+        <span
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
         >
           <div
-            className="fd-shellbar__action fd-shellbar__action--collapsible"
-            onClick={[Function]}
+            className="fd-popover__control"
           >
-            <button
-              aria-label="Notifications"
-              className=" fd-button--shell sap-icon--bell"
-            />
+            <div
+              className="fd-shellbar__action fd-shellbar__action--collapsible"
+              onClick={[Function]}
+            >
+              <button
+                aria-label="Notifications"
+                className=" fd-button--shell sap-icon--bell"
+              />
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
       <div
         className="fd-shellbar__action fd-shellbar__action--collapse"
       >
         <div
           className="fd-shellbar-collapse"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
               <div
-                className="fd-shellbar-collapse--control"
-                onClick={[Function]}
-                role="button"
+                className="fd-popover__control"
               >
-                <button
-                  className=" fd-button--shell sap-icon--overflow"
+                <div
+                  className="fd-shellbar-collapse--control"
+                  onClick={[Function]}
+                  role="button"
                 >
-                  <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
+                  <button
+                    className=" fd-button--shell sap-icon--overflow"
                   >
-                     
-                    5
-                     
-                  </span>
-                </button>
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      5
+                       
+                    </span>
+                  </button>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -793,23 +861,27 @@ exports[`<Shellbar /> create shellbar 5`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
-                onClick={[Function]}
-                role=""
+              <div
+                className="fd-popover__control"
               >
-                JS
-              </span>
-            </div>
-          </span>
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
+                  onClick={[Function]}
+                  role=""
+                >
+                  JS
+                </span>
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -818,20 +890,24 @@ exports[`<Shellbar /> create shellbar 5`] = `
         <div
           className="fd-product-switcher"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <button
-                className=" fd-button--shell sap-icon--grid"
-                onClick={[Function]}
-              />
-            </div>
-          </span>
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  className=" fd-button--shell sap-icon--grid"
+                  onClick={[Function]}
+                />
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -860,26 +936,30 @@ exports[`<Shellbar /> create shellbar 6`] = `
       <div
         className="fd-product-menu"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <div
+          className="fd-popover"
         >
-          <div
-            className="fd-popper__control fd-popover"
+          <span
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <button
-              className="fd-product-menu__control"
-              onClick={[Function]}
+            <div
+              className="fd-popover__control"
             >
-              <span
-                className="fd-shellbar__title fd-product-menu__title"
+              <button
+                className="fd-product-menu__control"
+                onClick={[Function]}
               >
-                Corporate Portal
-              </span>
-            </button>
-          </div>
-        </span>
+                <span
+                  className="fd-shellbar__title fd-product-menu__title"
+                >
+                  Corporate Portal
+                </span>
+              </button>
+            </div>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -949,28 +1029,32 @@ exports[`<Shellbar /> create shellbar 6`] = `
       <div
         className="fd-shellbar__action fd-shellbar__action--collapsible"
       >
-        <span
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <div
+          className="fd-popover"
         >
-          <div
-            className="fd-popper__control fd-popover"
+          <span
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <button
-              aria-label="Settings"
-              className=" fd-button--shell sap-icon--settings"
-              onClick={[Function]}
+            <div
+              className="fd-popover__control"
             >
-              <span
-                aria-label="Unread count"
-                className="fd-counter fd-counter--notification"
+              <button
+                aria-label="Settings"
+                className=" fd-button--shell sap-icon--settings"
+                onClick={[Function]}
               >
-                5
-              </span>
-            </button>
-          </div>
-        </span>
+                <span
+                  aria-label="Unread count"
+                  className="fd-counter fd-counter--notification"
+                >
+                  5
+                </span>
+              </button>
+            </div>
+          </span>
+        </div>
       </div>
       <div
         className="fd-shellbar__action fd-shellbar__action--collapsible"
@@ -994,34 +1078,38 @@ exports[`<Shellbar /> create shellbar 6`] = `
         <div
           className="fd-shellbar-collapse"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
               <div
-                className="fd-shellbar-collapse--control"
-                onClick={[Function]}
-                role="button"
+                className="fd-popover__control"
               >
-                <button
-                  className=" fd-button--shell sap-icon--overflow"
+                <div
+                  className="fd-shellbar-collapse--control"
+                  onClick={[Function]}
+                  role="button"
                 >
-                  <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
+                  <button
+                    className=" fd-button--shell sap-icon--overflow"
                   >
-                     
-                    7
-                     
-                  </span>
-                </button>
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      7
+                       
+                    </span>
+                  </button>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1030,26 +1118,30 @@ exports[`<Shellbar /> create shellbar 6`] = `
         <div
           className="fd-user-menu"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <span
-                className="fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail"
-                onClick={[Function]}
-                role="presentation"
-                style={
-                  Object {
-                    "backgroundImage": "url(//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png)",
+              <div
+                className="fd-popover__control"
+              >
+                <span
+                  className="fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail"
+                  onClick={[Function]}
+                  role="presentation"
+                  style={
+                    Object {
+                      "backgroundImage": "url(//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png)",
+                    }
                   }
-                }
-              />
-            </div>
-          </span>
+                />
+              </div>
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1058,20 +1150,24 @@ exports[`<Shellbar /> create shellbar 6`] = `
         <div
           className="fd-product-switcher"
         >
-          <span
-            onFocus={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <div
+            className="fd-popover"
           >
-            <div
-              className="fd-popper__control fd-popover"
+            <span
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              <button
-                className=" fd-button--shell sap-icon--grid"
-                onClick={[Function]}
-              />
-            </div>
-          </span>
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  className=" fd-button--shell sap-icon--grid"
+                  onClick={[Function]}
+                />
+              </div>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/Tile/__snapshots__/Tile.test.js.snap
+++ b/src/Tile/__snapshots__/Tile.test.js.snap
@@ -82,20 +82,24 @@ exports[`<Tile /> create tile component 4`] = `
   <div
     className="fd-tile__actions yellow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
-        <button
-          className="fd-button fd-button--standard sap-icon--vertical-grip"
-          onClick={[Function]}
-        />
-      </div>
-    </span>
+        <div
+          className="fd-popover__control"
+        >
+          <button
+            className="fd-button fd-button--standard sap-icon--vertical-grip"
+            onClick={[Function]}
+          />
+        </div>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -144,20 +148,24 @@ exports[`<Tile /> create tile component 6`] = `
   <div
     className="fd-tile__actions"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
-        <button
-          className="fd-button fd-button--standard sap-icon--vertical-grip"
-          onClick={[Function]}
-        />
-      </div>
-    </span>
+        <div
+          className="fd-popover__control"
+        >
+          <button
+            className="fd-button fd-button--standard sap-icon--vertical-grip"
+            onClick={[Function]}
+          />
+        </div>
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/Tile/__snapshots__/Tile.test.js.snap
+++ b/src/Tile/__snapshots__/Tile.test.js.snap
@@ -85,7 +85,7 @@ exports[`<Tile /> create tile component 4`] = `
     <div
       className="fd-popover"
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -98,7 +98,7 @@ exports[`<Tile /> create tile component 4`] = `
             onClick={[Function]}
           />
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -151,7 +151,7 @@ exports[`<Tile /> create tile component 6`] = `
     <div
       className="fd-popover"
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -164,7 +164,7 @@ exports[`<Tile /> create tile component 6`] = `
             onClick={[Function]}
           />
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/TimePicker/TimePicker.test.js
+++ b/src/TimePicker/TimePicker.test.js
@@ -296,7 +296,7 @@ describe('<TimePicker />', () => {
             element.find('.fd-popover__control').at(1).simulate('click');
 
             expect(
-                element.find('div.fd-popper__body div.fd-time').getDOMNode().attributes['data-sample'].value
+                element.find('div.fd-popover__popper div.fd-time').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
     });

--- a/src/TimePicker/__snapshots__/TimePicker.test.js.snap
+++ b/src/TimePicker/__snapshots__/TimePicker.test.js.snap
@@ -12,7 +12,7 @@ exports[`<TimePicker /> create time picker 1`] = `
       className="fd-popover"
       id="myTime-popover"
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -50,7 +50,7 @@ exports[`<TimePicker /> create time picker 1`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -67,7 +67,7 @@ exports[`<TimePicker /> create time picker 2`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -103,7 +103,7 @@ exports[`<TimePicker /> create time picker 2`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -120,7 +120,7 @@ exports[`<TimePicker /> create time picker 3`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -156,7 +156,7 @@ exports[`<TimePicker /> create time picker 3`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -173,7 +173,7 @@ exports[`<TimePicker /> create time picker 4`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -211,7 +211,7 @@ exports[`<TimePicker /> create time picker 4`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -228,7 +228,7 @@ exports[`<TimePicker /> create time picker 5`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -264,7 +264,7 @@ exports[`<TimePicker /> create time picker 5`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -281,7 +281,7 @@ exports[`<TimePicker /> create time picker 6`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -317,7 +317,7 @@ exports[`<TimePicker /> create time picker 6`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -334,7 +334,7 @@ exports[`<TimePicker /> create time picker 7`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -370,7 +370,7 @@ exports[`<TimePicker /> create time picker 7`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -387,7 +387,7 @@ exports[`<TimePicker /> create time picker 8`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -423,7 +423,7 @@ exports[`<TimePicker /> create time picker 8`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -440,7 +440,7 @@ exports[`<TimePicker /> create time picker 9`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -476,7 +476,7 @@ exports[`<TimePicker /> create time picker 9`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>
@@ -493,7 +493,7 @@ exports[`<TimePicker /> create time picker 10`] = `
       className="fd-popover"
       id=""
     >
-      <span
+      <div
         onFocus={[Function]}
         onMouseDown={[Function]}
         onTouchStart={[Function]}
@@ -529,7 +529,7 @@ exports[`<TimePicker /> create time picker 10`] = `
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/TimePicker/__snapshots__/TimePicker.test.js.snap
+++ b/src/TimePicker/__snapshots__/TimePicker.test.js.snap
@@ -8,45 +8,50 @@ exports[`<TimePicker /> create time picker 1`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id="myTime-popover"
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              id="myTime-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
-                id="myTime-button"
+              <input
+                className="fd-input"
+                id="myTime-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                  id="myTime-button"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -58,43 +63,48 @@ exports[`<TimePicker /> create time picker 2`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -106,43 +116,48 @@ exports[`<TimePicker /> create time picker 3`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -154,45 +169,50 @@ exports[`<TimePicker /> create time picker 4`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss"
-              readOnly={true}
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
-                disabled={true}
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss"
+                readOnly={true}
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                  disabled={true}
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -204,43 +224,48 @@ exports[`<TimePicker /> create time picker 5`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -252,43 +277,48 @@ exports[`<TimePicker /> create time picker 6`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -300,43 +330,48 @@ exports[`<TimePicker /> create time picker 7`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:mm:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:mm:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -348,43 +383,48 @@ exports[`<TimePicker /> create time picker 8`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="mm:ss"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="mm:ss"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -396,43 +436,48 @@ exports[`<TimePicker /> create time picker 9`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="mm:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="mm:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -444,43 +489,48 @@ exports[`<TimePicker /> create time picker 10`] = `
   <div
     className="fd-popover fd-popover--no-arrow"
   >
-    <span
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
+    <div
+      className="fd-popover"
+      id=""
     >
-      <div
-        className="fd-popper__control fd-popover"
+      <span
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className="fd-popover__control"
-          onClick={[Function]}
         >
           <div
-            className="fd-input-group fd-input-group--after"
+            className="fd-popover__control"
+            onClick={[Function]}
           >
-            <input
-              className="fd-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              placeholder="hh:ss am/pm"
-              type="text"
-              value=""
-            />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+            <div
+              className="fd-input-group fd-input-group--after"
             >
-              <button
-                aria-controls="rthHR811"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+              <input
+                className="fd-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                placeholder="hh:ss am/pm"
+                type="text"
+                value=""
               />
-            </span>
+              <span
+                className="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button "
+              >
+                <button
+                  aria-controls="rthHR811"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control"
+                />
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </span>
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/_playground/_popper.scss
+++ b/src/_playground/_popper.scss
@@ -2,7 +2,7 @@ $arrow-height: 8px;
 $arrow-width: 13px;
 $arrow-width-half: $arrow-width/2;
 
-.fd-popper__body {
+.fd-popover__popper {
     border: solid 1px #89919a;
     position: absolute;
     white-space: nowrap;
@@ -16,12 +16,12 @@ $arrow-width-half: $arrow-width/2;
     &--no-arrow {
         margin: 0 !important;
 
-        .fd-popper__arrow {
+        .fd-popover__arrow {
             display: none;
         }
     }
 
-    .fd-popper__arrow {
+    .fd-popover__arrow {
         position: absolute;
         width: 0;
         height: 0;
@@ -43,7 +43,7 @@ $arrow-width-half: $arrow-width/2;
     &[data-placement^="top"] {
         margin-bottom: $arrow-height;
 
-        .fd-popper__arrow {
+        .fd-popover__arrow {
             bottom: -$arrow-height;
             margin: 0 $arrow-width-half;
             border-width: $arrow-height $arrow-width-half 0 $arrow-width-half;
@@ -63,7 +63,7 @@ $arrow-width-half: $arrow-width/2;
     &[data-placement^="bottom"] {
         margin-top: $arrow-height;
 
-        .fd-popper__arrow {
+        .fd-popover__arrow {
             top: -$arrow-height;
             margin: 0 $arrow-width-half;
             border-width: 0 $arrow-width-half $arrow-height $arrow-width-half;
@@ -83,7 +83,7 @@ $arrow-width-half: $arrow-width/2;
     &[data-placement^="left"] {
         margin-right: $arrow-height;
 
-        .fd-popper__arrow {
+        .fd-popover__arrow {
             right: -$arrow-height;
             margin: $arrow-width-half 0;
             border-width: $arrow-width-half 0 $arrow-width-half $arrow-height;
@@ -103,7 +103,7 @@ $arrow-width-half: $arrow-width/2;
     &[data-placement^="right"] {
         margin-left: $arrow-height;
 
-        .fd-popper__arrow {
+        .fd-popover__arrow {
             left: -$arrow-height;
             margin: $arrow-width-half 0;
             border-width: $arrow-width-half $arrow-height $arrow-width-half 0;
@@ -122,7 +122,7 @@ $arrow-width-half: $arrow-width/2;
 }
 
 .fd-time-picker {
-    .fd-popper__body {
+    .fd-popover__popper {
         padding: 16px;
     }
 }

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -120,7 +120,10 @@ class Popper extends React.Component {
 
         return (
             <Manager>
-                <Foco onClickOutside={onClickOutside}>
+                <Foco
+                    component='div'
+                    onClickOutside={onClickOutside}
+                    onFocusOutside={onClickOutside}>
                     <Reference>
                         {({ ref }) => (
                             <div

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -61,6 +61,7 @@ class Popper extends React.Component {
     render() {
         const {
             children,
+            cssBlock,
             disableEdgeDetection,
             noArrow,
             onClickOutside,
@@ -81,8 +82,8 @@ class Popper extends React.Component {
             ...flipModifier
         };
 
-        const popperClasses = classnames('fd-popper__body', popperClassName, {
-            'fd-popper__body--no-arrow': !!noArrow
+        const popperClasses = classnames(`${cssBlock}__popper`, popperClassName, {
+            [`${cssBlock}__popper--no-arrow`]: !!noArrow
         });
 
         let popper = (
@@ -104,7 +105,7 @@ class Popper extends React.Component {
                             style={style}>
                             {children}
                             <span
-                                className='fd-popper__arrow'
+                                className={`${cssBlock}__arrow`}
                                 ref={arrowProps.ref}
                                 style={arrowProps.style} />
                         </div>
@@ -117,8 +118,6 @@ class Popper extends React.Component {
             popper = ReactDOM.createPortal(popper, document.querySelector('body'));
         }
 
-        const referenceClasses = classnames('fd-popper__control', referenceClassName);
-
         return (
             <Manager>
                 <Foco onClickOutside={onClickOutside}>
@@ -126,7 +125,7 @@ class Popper extends React.Component {
                         {({ ref }) => (
                             <div
                                 {...referenceProps}
-                                className={referenceClasses}
+                                className={referenceClassName}
                                 ref={ref}>
                                 {referenceComponent}
                             </div>
@@ -143,6 +142,7 @@ Popper.displayName = 'Popper';
 
 Popper.propTypes = {
     children: PropTypes.node.isRequired,
+    cssBlock: PropTypes.string.isRequired,
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
     noArrow: PropTypes.bool,


### PR DESCRIPTION
### Description
In preparation for the move of the popper.js CSS to the Fiori Fundamentals library, renamed the classes to retain "popover" as the block-level name and made "popper" an element.

_**NOTE:** A number of snapshot files changes because of the classname changes._