### PR TITLE
fix: update failing calendar tests to work on all dates

### DIFF
--- a/src/Calendar/Calendar.test.js
+++ b/src/Calendar/Calendar.test.js
@@ -226,7 +226,9 @@ describe('<Calendar />', () => {
 
     test('click previous button', () => {
         let wrapper = mount(defaultCalendar);
-        const currentDateDisplayed = Object.assign(new Date(), wrapper.state('currentDateDisplayed'));
+
+        let initialDate = new Date('3/28/2019');
+        wrapper.setState({ currentDateDisplayed: initialDate });
 
         wrapper
             .find(
@@ -236,9 +238,7 @@ describe('<Calendar />', () => {
             .simulate('click');
         const newDateDisplayed = wrapper.state('currentDateDisplayed');
 
-        expect(newDateDisplayed.getMonth()).toEqual(
-            currentDateDisplayed.getMonth() - 1
-        );
+        expect(newDateDisplayed.getMonth()).toEqual(1);
 
         // previous button when year shown
         wrapper
@@ -256,11 +256,9 @@ describe('<Calendar />', () => {
             )
             .at(0)
             .simulate('click');
-
+        //should show 2007-2018 (12 years)
         const newYearDisplayed = wrapper.state('currentDateDisplayed');
-        expect(newYearDisplayed.getFullYear()).toEqual(
-            currentDateDisplayed.getFullYear() - 12
-        );
+        expect(newYearDisplayed.getFullYear()).toEqual(2007);
     });
 
     test('click next button', () => {


### PR DESCRIPTION
### Description
Like #329, and #342 ,  Travis builds are failing due to our unit tests for dates not being hardcoded.
It will fail throughout tonight (Travis is on German time and therefore already it is already 3/29) and tomorrow because 2/29 does not exist.


fixes #issueid