### PR TITLE
docs: Property shapes

### DIFF
--- a/src/Badge/Badge.Component.js
+++ b/src/Badge/Badge.Component.js
@@ -60,7 +60,7 @@ export const BadgeComponent = () => {
 
             <Example
                 centered
-                title='Label'>
+                title='Default Label'>
                 <div className='fd-doc__margin--statusIndicator'>
                     <Label>Default</Label>
                     <Label type='success'>Default</Label>

--- a/src/Badge/Counter.js
+++ b/src/Badge/Counter.js
@@ -36,7 +36,7 @@ Counter.defaultProps = {
 };
 
 Counter.propDescriptions = {
-    localizedText: {
+    localizedTextShape: {
         counterLabel: 'The aria-label for the <span> element.'
     },
     notification: 'Set to **true** to enable counter with notification.'

--- a/src/LocalizationEditor/LocalizationEditor.js
+++ b/src/LocalizationEditor/LocalizationEditor.js
@@ -139,7 +139,11 @@ LocalizationEditor.propTypes = {
 };
 
 LocalizationEditor.propDescriptions = {
-    control: 'An object of shape `{ label: string, placeholder: string, language: string, labelProps: object, inputProps: object, buttonProps: object }` containing the values of the control localization editor.',
+    control: 'A collection of properties to apply to the `<label>`, `<input>`/`<textarea>` and `<button>` elements.',
+    controlShape: {
+        label: 'Localized text for the `<label>` element.',
+        language: 'Text to display on the `<button>` element. Meant to be the language of the text in the `<input>`/`<textarea>` element.'
+    },
     menu: 'An array of objects that represent the values of the elements in the dropdown menu. The shape of the objects in the array is `{ placeholder: string, language: string, inputProps: object }`.',
     textarea: 'Set to **true** to enable a Localization Editor with a textarea.'
 };

--- a/src/Menu/Menu.Component.js
+++ b/src/Menu/Menu.Component.js
@@ -15,7 +15,7 @@ export const MenuComponent = () => {
 
             <Example
                 description='The basic stucture of a menu.'
-                title='Menu'>
+                title='Basic Menu'>
                 <Menu>
                     <Menu.List>
                         <Menu.Item url='/'>Option 1</Menu.Item>

--- a/src/Panel/Panel.Component.js
+++ b/src/Panel/Panel.Component.js
@@ -10,7 +10,7 @@ export const PanelComponent = () => {
             title='Panel'>
 
             <Example
-                title='Panel'>
+                title='Single Panel'>
                 <div className='fd-doc__margin--panel'>
                     <Panel>
                         <Panel.Header>

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -69,7 +69,7 @@ Table.propTypes = {
 };
 
 Table.propDescriptions = {
-    tableData: 'Array of objects that contain two properties: `rowData` (an array of strings containing data for each column in the row), and `children` (an array of objects containing additional rows).',
+    tableData: 'Array of objects that contain one property: `rowData` (an array of strings containing data for each column in the row).',
     headers: 'Array of localized text strings for the column headers.',
     tableBodyProps: 'Additional props to be spread to the `<tbody>` element.',
     tableBodyRowProps: 'Additional props to be spread to the `<tr>` elements within `<tbody>`. If using a function, the parameters passed will be an object representing the row (from `tableData`) and the row index.',

--- a/src/_playground/documentation/Properties/_PropertyDescription.js
+++ b/src/_playground/documentation/Properties/_PropertyDescription.js
@@ -1,31 +1,19 @@
-import PropertyTable from './_PropertyTable';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
-const PropertyDescription = ({ defaultValue, description, prop }) => {
-    const typeChecker = prop.typeChecker;
-
-    return (
-        <React.Fragment>
-            <div>
-                <ReactMarkdown source={description} />
-            </div>
-            {prop.typeName === 'shape' &&
-                <PropertyTable
-                    defaultProps={defaultValue}
-                    propTypes={typeChecker} />
-            }
-        </React.Fragment>
-    );
-};
+const PropertyDescription = ({ description }) => (
+    <React.Fragment>
+        <div>
+            <ReactMarkdown source={description} />
+        </div>
+    </React.Fragment>
+);
 
 PropertyDescription.displayName = 'PropertyDescription';
 
 PropertyDescription.propTypes = {
-    defaultValue: PropTypes.any,
-    description: PropTypes.string,
-    prop: PropTypes.any
+    description: PropTypes.string
 };
 
 export default PropertyDescription;

--- a/src/_playground/documentation/Properties/_PropertyShape.js
+++ b/src/_playground/documentation/Properties/_PropertyShape.js
@@ -15,7 +15,7 @@ const PropertyShape = ({ title, propTypes, defaultProps, propDescriptions }) => 
     }
 
     let propInfo = Object.keys(propTypes).map((propName) => {
-        return { propName: propName, required: propTypes[propName].typeRequired };
+        return { propName: propName, required: !!propTypes[propName].typeRequired };
     });
     const sortedProps = propInfo.sort(sortBy('-required', 'propName'));
 

--- a/src/_playground/documentation/Properties/_PropertyShape.js
+++ b/src/_playground/documentation/Properties/_PropertyShape.js
@@ -1,3 +1,4 @@
+import { defaultPropDescriptions } from './defaults';
 import Heading from '../Heading/Heading';
 import PropertyDefault from './_PropertyDefault';
 import PropertyDescription from './_PropertyDescription';
@@ -7,7 +8,7 @@ import React from 'react';
 import sortBy from 'sort-by';
 import Table from '../../../Table/Table';
 
-const PropertyShape = ({ title, propTypes, defaultProps, propDescriptions }) => {
+const PropertyShape = ({ title, propTypes = {}, defaultProps = {}, propDescriptions = {} }) => {
     if (!propTypes) {
         return (
             <em>This shape has no defined properties.</em>
@@ -20,18 +21,23 @@ const PropertyShape = ({ title, propTypes, defaultProps, propDescriptions }) => 
     const sortedProps = propInfo.sort(sortBy('-required', 'propName'));
 
     let data = [];
+    const mergedPropDescriptions = {
+        ...defaultPropDescriptions,
+        ...propDescriptions
+    };
 
     sortedProps.forEach(({ propName }) => {
         data.push({
             rowData: [
                 propName,
-                <PropertyType prop={propTypes[propName]} />,
+                <PropertyType
+                    prop={propTypes[propName]}
+                    propName={propName} />,
                 <PropertyDefault
-                    defaultValue={defaultProps && defaultProps[propName]}
+                    defaultValue={defaultProps[propName]}
                     prop={propTypes[propName]} />,
                 <PropertyDescription
-                    description={propDescriptions[propName]}
-                    prop={propTypes[propName]} />
+                    description={mergedPropDescriptions[propName]} />
             ]
         });
     });

--- a/src/_playground/documentation/Properties/_PropertyTable.js
+++ b/src/_playground/documentation/Properties/_PropertyTable.js
@@ -17,7 +17,7 @@ const PropertyTable = ({ title, propTypes, defaultProps, propDescriptions }) => 
     }
 
     let propInfo = Object.keys(propTypes).map(propName => {
-        return { propName: propName, required: propTypes[propName].typeRequired };
+        return { propName: propName, required: !!propTypes[propName].typeRequired };
     });
     const sortedProps = propInfo.sort(sortBy('-required', 'propName'));
 

--- a/src/_playground/documentation/Properties/_PropertyTable.js
+++ b/src/_playground/documentation/Properties/_PropertyTable.js
@@ -1,4 +1,5 @@
 import { defaultPropDescriptions } from './defaults';
+import { getShapeTitle } from '../utils/getShapeTitle';
 import Heading from '../Heading/Heading';
 import PropertyDefault from './_PropertyDefault';
 import PropertyDescription from './_PropertyDescription';
@@ -9,7 +10,7 @@ import React from 'react';
 import sortBy from 'sort-by';
 import Table from '../../../Table/Table';
 
-const PropertyTable = ({ title, propTypes, defaultProps, propDescriptions }) => {
+const PropertyTable = ({ title, propTypes = {}, defaultProps = {}, propDescriptions = {} }) => {
     if (!propTypes) {
         return (
             <em>This component has no defined properties.</em>
@@ -32,17 +33,20 @@ const PropertyTable = ({ title, propTypes, defaultProps, propDescriptions }) => 
         data.push({
             rowData: [
                 propName,
-                <PropertyType componentName={title} prop={propTypes[propName]} />,
+                <PropertyType
+                    componentName={title}
+                    prop={propTypes[propName]}
+                    propName={propName}
+                    topLevel />,
                 <PropertyDefault
-                    defaultValue={defaultProps && defaultProps[propName]}
+                    defaultValue={defaultProps[propName]}
                     prop={propTypes[propName]} />,
                 <PropertyDescription
-                    defaultValue={defaultProps && defaultProps[propName]}
-                    description={mergedPropDescriptions[propName]}
-                    prop={propTypes[propName]} />
+                    description={mergedPropDescriptions[propName]} />
             ]
         });
-        if (propTypes[propName].typeName === 'i18n') {
+
+        if (propTypes[propName].typeName === 'shape' || propTypes[propName].typeName === 'i18n') {
             shapes.push(propName);
         }
     });
@@ -60,14 +64,15 @@ const PropertyTable = ({ title, propTypes, defaultProps, propDescriptions }) => 
                         'Description'
                     ]}
                 tableData={data} />
-            {shapes.map((shape, i) => {
-                const shapeName = `${title} - Localized Text`;
-                return (<PropertyShape
-                    defaultProps={defaultProps[shape]}
-                    key={i}
-                    propDescriptions={mergedPropDescriptions[`${shape}Shape`]}
-                    propTypes={propTypes[shape].typeChecker}
-                    title={shapeName} />);
+            {shapes.map((shapeName, i) => {
+                return (
+                    <PropertyShape
+                        defaultProps={defaultProps[shapeName]}
+                        key={i}
+                        propDescriptions={mergedPropDescriptions[`${shapeName}Shape`]}
+                        propTypes={propTypes[shapeName].typeChecker}
+                        title={getShapeTitle(title, shapeName, propTypes[shapeName].typeName)} />
+                );
             })}
         </React.Fragment>
     );

--- a/src/_playground/documentation/Properties/_PropertyType.js
+++ b/src/_playground/documentation/Properties/_PropertyType.js
@@ -1,8 +1,9 @@
+import { getShapeTitle } from '../utils/getShapeTitle';
 import { makeSafeId } from '../utils/makeSafeId';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const PropertyType = ({ prop, componentName }) => {
+const PropertyType = ({ prop, propName, componentName, topLevel }) => {
     const typeChecker = prop.typeChecker;
 
     switch (prop.typeName) {
@@ -12,7 +13,7 @@ const PropertyType = ({ prop, componentName }) => {
                 <React.Fragment>
                     <div>{prop.typeName}</div>
                     {typeChecker.typeChecker ? (
-                        <PropertyType prop={typeChecker} />
+                        <PropertyType prop={typeChecker} propName={propName} />
                     ) : (
                         <div>{`(${typeChecker.typeName})`}</div>
                     )}
@@ -23,7 +24,7 @@ const PropertyType = ({ prop, componentName }) => {
                 <React.Fragment>
                     <div>{prop.typeName}</div>
                     {typeChecker.typeChecker ? (
-                        <PropertyType prop={typeChecker} />
+                        <PropertyType prop={typeChecker} propName={propName} />
                     ) : (
                         <div>{`(${typeChecker.name || typeChecker.displayName})`}</div>
                     )}
@@ -39,7 +40,8 @@ const PropertyType = ({ prop, componentName }) => {
         case 'oneOfType':
             const types = typeChecker
                 .map((t, i) =>
-                    t.typeChecker ? <PropertyType key={i} prop={t} /> : <span key={i}>{`(${t.typeName})`}</span>
+                    t.typeChecker ? <PropertyType key={i} prop={t}
+                        propName={propName} /> : <span key={i}>{`(${t.typeName})`}</span>
                 ).reduce((prev, curr) => [prev, ', ', curr]);
             return (
                 <React.Fragment>
@@ -47,8 +49,6 @@ const PropertyType = ({ prop, componentName }) => {
                     [{types}]
                 </React.Fragment>
             );
-        case 'shape':
-            return <div>{prop.typeName} ({`\{${Object.keys(prop.typeChecker).sort().join(', ')}\}`})</div>;
         case 'range':
             const values = Object.keys(typeChecker).map(key => `${key}: ${typeChecker[key]}`);
             return (
@@ -57,9 +57,14 @@ const PropertyType = ({ prop, componentName }) => {
                     <div>{`(${values.join('; ')})`}</div>
                 </React.Fragment>
             );
+        case 'shape':
         case 'i18n':
-            const shapeName = `${componentName} - Localized Text`;
-            return (<a href={`#${makeSafeId(shapeName)}`}>Localized Text</a>);
+            return (
+                <React.Fragment>
+                    <div>{prop.typeName}</div>
+                    {topLevel && <div>(<a href={`#${makeSafeId(getShapeTitle(componentName, propName, prop.typeName))}`}>details</a>)</div>}
+                </React.Fragment>
+            );
         default:
             return <div>{prop.typeName}</div>;
     }
@@ -69,7 +74,9 @@ PropertyType.displayName = 'PropertyType';
 
 PropertyType.propTypes = {
     componentName: PropTypes.string,
-    prop: PropTypes.any
+    prop: PropTypes.any,
+    propName: PropTypes.string,
+    topLevel: PropTypes.bool
 };
 
 export default PropertyType;

--- a/src/_playground/documentation/utils/getShapeTitle.js
+++ b/src/_playground/documentation/utils/getShapeTitle.js
@@ -1,0 +1,3 @@
+export const getShapeTitle = (componentName, propName, typeName) => {
+    return `${componentName} - ${propName} (${typeName})`;
+};


### PR DESCRIPTION
### Description
Did some refactoring to make the `PropertyShape` component more generic so it will work with both `i18n` custom prop types _AND_ `shape` prop types.  Below are screenshots of both prop types.

Did some other minor cleanup:
- Changed some example titles/headings to prevent id collisions with the property tables
- Fixed an issue with `localizedText` for the `Counter` component
- Updated some prop descriptions where appropriate


![Screen Shot 2019-04-03 at 11 57 43 PM](https://user-images.githubusercontent.com/11407353/55530726-db775b80-566c-11e9-9f72-f84c2bca16a0.png)

![Screen Shot 2019-04-03 at 11 58 00 PM](https://user-images.githubusercontent.com/11407353/55530729-df0ae280-566c-11e9-96c6-485e03c0f5ac.png)
