### PR TITLE
docs: Fix form modal breaking docs site

### DIFF
--- a/src/_playground/documentation/Example/Example.js
+++ b/src/_playground/documentation/Example/Example.js
@@ -27,6 +27,7 @@ class Example extends React.Component {
                     <React.Fragment>
                         <DocsText>
                             {reactElementToJSXString(element, {
+                                filterProps: ['ref'],
                                 showDefaultProps: false
                             })}
                         </DocsText>


### PR DESCRIPTION
### Description
Opening the form modal in the docs would create a ref on the input.

Trying to turn the example code to a JSXString using react-element-to-jsx-string would cause an infinite loop trying to parse the ref.  This happens after the ref is created and has a current value because it is a circular thing to parse: ref -> current -> element -> ref -> current .....

This PR just ignores the ref prop when creating the JSX string.


fixes #462
