### PR TITLE
chore: Release notes

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -15,9 +15,10 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
-npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
-
 npm publish
+
+# run this after publish to make sure GitHub finishes updating from the push
+npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
 
 npm run build-doc
 npm run deploy -- --repo "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8013,9 +8013,9 @@
       }
     },
     "github-assistant": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/github-assistant/-/github-assistant-0.2.0.tgz",
-      "integrity": "sha512-h33eREnaFNxdeLwQQA9zQH82UaPzPQqJsrGhGdMH4Z5FeSWpqXhp7o74saf6flt69ScFWcXAqzPuoQmbG0Jq3A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/github-assistant/-/github-assistant-0.3.0.tgz",
+      "integrity": "sha512-xvt3aRVBYIsu37cUA/xNBHZJWka84e74jG601M3b5Ws2lvj3ddtoep73QqLafMNHElmY6MyxnEOj8WAKJcASTg==",
       "dev": true,
       "requires": {
         "github-api": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-extra": "7.0.0",
     "gh-pages": "^2.0.1",
-    "github-assistant": "^0.2.0",
+    "github-assistant": "^0.3.0",
     "group-array": "^0.3.3",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "identity-obj-proxy": "3.0.0",


### PR DESCRIPTION
### Description
It was found in the `fundamental` repo that the calls to GitHub API to build the release notes _could_ happen prior to the commits being pushed (or updated within GitHub).  To help ensure this works, I have moved the create release call below publish.

Also, updated to a new version of `github-assistant` that will include a "Documentation" section in the release notes.

#### Example
![Screen Shot 2019-04-05 at 2 08 57 PM](https://user-images.githubusercontent.com/11407353/55651124-40d26600-57ad-11e9-99ea-b691e74b244f.png)
