### PR TITLE
fix: Use React.Children.toArray to prune null children in TabGroup 

### DIFF
--- a/src/Tabs/TabGroup.js
+++ b/src/Tabs/TabGroup.js
@@ -57,7 +57,7 @@ class TabGroup extends Component {
             return (
                 <TabContent
                     {...child.props.tabContentProps}
-                    key={child.props.id || index}
+                    key={index}
                     selected={this.state.selectedIndex === index}>
                     {child.props.children}
                 </TabContent>);

--- a/src/Tabs/TabGroup.js
+++ b/src/Tabs/TabGroup.js
@@ -46,17 +46,18 @@ class TabGroup extends Component {
 
     // create tab list
     renderTabs = () => {
-        return React.Children.map(this.props.children, (child, index) => {
+        return React.Children.toArray(this.props.children).map((child, index) => {
             return this.cloneElement(child, index);
         });
     };
 
     // create content to show below tab list
     renderContent = () => {
-        return React.Children.map(this.props.children, (child, index) => {
+        return React.Children.toArray(this.props.children).map((child, index) => {
             return (
                 <TabContent
                     {...child.props.tabContentProps}
+                    key={child.props.id || index}
                     selected={this.state.selectedIndex === index}>
                     {child.props.children}
                 </TabContent>);

--- a/src/Tabs/TabGroup.test.js
+++ b/src/Tabs/TabGroup.test.js
@@ -89,4 +89,27 @@ describe('<Tabs />', () => {
             ).toBe('Sample');
         });
     });
+
+    describe('null tab children', () => {
+        test('should render all tabs that are not null', () => {
+            const tabsWithNull = (
+                <TabGroup>
+                    <Tab
+                        id='1'
+                        title='Tab 1'>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore et ducimus veritatis officiis amet? Vitae officia optio dolor exercitationem incidunt magnam non, suscipit, illo quisquam numquam fugiat? Debitis, delectus sequi?
+                    </Tab>
+                    {null}
+                    <Tab
+                        id='3'
+                        title='Tab 3'>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                    </Tab>
+                </TabGroup>
+            );
+            const component = renderer.create(tabsWithNull);
+            const tree = component.toJSON();
+            expect(tree).toMatchSnapshot();
+        });
+    });
 });

--- a/src/Tabs/TabGroup.test.js
+++ b/src/Tabs/TabGroup.test.js
@@ -92,18 +92,22 @@ describe('<Tabs />', () => {
 
     describe('null tab children', () => {
         test('should render all tabs that are not null', () => {
+            const condition = false;
             const tabsWithNull = (
                 <TabGroup>
-                    <Tab
-                        id='1'
-                        title='Tab 1'>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore et ducimus veritatis officiis amet? Vitae officia optio dolor exercitationem incidunt magnam non, suscipit, illo quisquam numquam fugiat? Debitis, delectus sequi?
+                    <Tab id='1' title='Tab 1'>
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore et ducimus
+                        veritatis officiis amet? Vitae officia optio dolor exercitationem incidunt
+                        magnam non, suscipit, illo quisquam numquam fugiat? Debitis, delectus
+                        sequi?
                     </Tab>
-                    {null}
-                    <Tab
-                        id='3'
-                        title='Tab 3'>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                    {condition && (
+                        <Tab id='2' title='Tab 2'>
+                            Lorem ipsum
+                        </Tab>
+                    )}
+                    <Tab id='3' title='Tab 3'>
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit.
                     </Tab>
                 </TabGroup>
             );

--- a/src/Tabs/__snapshots__/TabGroup.test.js.snap
+++ b/src/Tabs/__snapshots__/TabGroup.test.js.snap
@@ -185,3 +185,55 @@ Array [
   </div>,
 ]
 `;
+
+exports[`<Tabs /> null tab children should render all tabs that are not null 1`] = `
+Array [
+  <ul
+    className="fd-tabs"
+    role="tablist"
+  >
+    <li
+      className="fd-tabs__item"
+    >
+      <a
+        aria-controls="1"
+        aria-selected={true}
+        className="fd-tabs__link"
+        href="#1"
+        onClick={[Function]}
+        role="tab"
+      >
+        Tab 1
+      </a>
+    </li>
+    <li
+      className="fd-tabs__item"
+    >
+      <a
+        aria-controls="3"
+        aria-selected={false}
+        className="fd-tabs__link"
+        href="#3"
+        onClick={[Function]}
+        role="tab"
+      >
+        Tab 3
+      </a>
+    </li>
+  </ul>,
+  <div
+    aria-expanded={true}
+    className="fd-tabs__panel"
+    role="tabpanel"
+  >
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore et ducimus veritatis officiis amet? Vitae officia optio dolor exercitationem incidunt magnam non, suscipit, illo quisquam numquam fugiat? Debitis, delectus sequi?
+  </div>,
+  <div
+    aria-expanded={false}
+    className="fd-tabs__panel"
+    role="tabpanel"
+  >
+    Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  </div>,
+]
+`;


### PR DESCRIPTION
### Description
```js
React.Children.map(this.props.children, (child, index)
```
maintains null children in the map function while
```js
React.Children.toArray(this.props.children).map((child, index) => {
```
removes null values

fixes #514