### PR TITLE
fix: SearchInput onChange handler

### DIFF
--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -30,26 +30,19 @@ class SearchInput extends Component {
     };
 
     onChangeHandler = event => {
-        this.setState({
-            value: event.target.value
-        });
-        if (this.props.onChange) {
-            this.props.onChange(event);
-        } else {
-            if (this.state.searchList) {
-                let filteredResult = this.state.searchList.filter(item =>
-                    item.text.toLowerCase().startsWith(event.target.value.toLowerCase())
-                );
-                this.setState({
-                    filteredResult: filteredResult
-                });
-            }
-            if (!this.state.isExpanded) {
-                this.setState({
-                    isExpanded: true
-                });
-            }
+        let filteredResult;
+        if (this.state.searchList) {
+            filteredResult = this.state.searchList.filter(item =>
+                item.text.toLowerCase().startsWith(event.target.value.toLowerCase())
+            );
         }
+        this.setState({
+            value: event.target.value,
+            isExpanded: true,
+            filteredResult: filteredResult
+        }, () => {
+            this.props.onChange(event);
+        });
     };
 
     onClickHandler = () => {
@@ -282,6 +275,7 @@ SearchInput.propTypes = {
 };
 
 SearchInput.defaultProps = {
+    onChange: () => { },
     onEnter: () => { }
 };
 

--- a/src/SearchInput/SearchInput.test.js
+++ b/src/SearchInput/SearchInput.test.js
@@ -87,15 +87,32 @@ describe('<SearchInput />', () => {
         expect(tree).toMatchSnapshot();
     });
 
-    test('calling parent onChange event', () => {
-        const wrapper = shallow(searchOnChange);
+    describe('onChange handler', () => {
+        test('calling parent onChange event', () => {
+            const wrapper = shallow(searchOnChange);
 
-        // enter text into search input
-        wrapper
-            .find(searchInput)
-            .simulate('change', { target: { value: searchData[0].text } });
+            // enter text into search input
+            wrapper
+                .find(searchInput)
+                .simulate('change', { target: { value: searchData[0].text } });
 
-        expect(wrapper.state(['value'])).toBe(searchData[0].text);
+            expect(wrapper.state(['value'])).toBe(searchData[0].text);
+            expect(wrapper.state(['isExpanded'])).toBe(true);
+            expect(wrapper.state(['filteredResult'])).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ text: searchData[0].text })
+                ])
+            );
+        });
+
+        test('should dispatch the onChange callback with the event', () => {
+            let f = jest.fn();
+            const element = mount(<SearchInput onChange={f} />);
+
+            element.find('input').simulate('change');
+
+            expect(f).toHaveBeenCalledTimes(1);
+        });
     });
 
     test('check for enter key press on search input', () => {


### PR DESCRIPTION
### Description

This pr simplifies the onChange handler so that the list is still filtered when consumers provide an onChange callback. 

As we plan to refactor the component, I only added `this.props.onChange(event)` and did not setup for a custom filtering function to be passed in. That will be addressed during refactor.

fixes #545 