### PR TITLE
fix: updated publish scripts to copy package.json after standard versioning is complete

### DIFF
--- a/ci-scripts/publish-rc.sh
+++ b/ci-scripts/publish-rc.sh
@@ -9,6 +9,8 @@ npm run std-version -- --prerelease rc --no-verify
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" "$TRAVIS_BRANCH" > /dev/null 2>&1;
 
+npm run build:copy-files
+
 cd lib
 
 npm publish --tag prerelease

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -15,6 +15,8 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
+npm run build:copy-files
+
 cd lib
 
 npm publish

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-js": "node scripts/build.js",
     "build:lint:fix": "npm run build:lint -- --fix",
     "build:lint": "eslint 'src/**' --ext .js,.jsx --env browser,node",
-    "build": "npm run build:index && rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\" && npm run build:copy-files",
+    "build": "npm run build:index && rm -rf lib && NODE_ENV=production babel src --out-dir lib --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\"",
     "build:index": "babel-node devtools/buildIndexFiles.js",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "config:lint:fix": "npm run config:lint -- --fix",


### PR DESCRIPTION
### Description
Standard versioning was off in the package-json file within lib because I copied it over before standard versioning was complete. It will now copy package-json file over once standard versioning is complete.


fixes #issueid