### PR TITLE
feat(button;forms): Expose ref for focusable elements

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -3,21 +3,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { BUTTON_OPTIONS, BUTTON_TYPES } from '../utils/constants';
 
-const Button = ({
-    option,
-    type,
-    compact,
-    glyph,
-    dropdown,
-    navbar,
-    selected,
-    disabled,
-    typeAttr,
-    onClick,
+const Button = React.forwardRef(({
     children,
     className,
+    compact,
+    disabled,
+    dropdown,
+    glyph,
+    navbar,
+    onClick,
+    option,
+    selected,
+    type,
+    typeAttr,
     ...props
-}) => {
+}, ref) => {
     const buttonClasses = classnames(
         {
             'fd-button': !option,
@@ -33,12 +33,17 @@ const Button = ({
         className
     );
 
-    return (<button {...props} className={buttonClasses}
-        disabled={disabled} onClick={onClick}
-        selected={selected} type={typeAttr}>
+    return (<button
+        {...props}
+        className={buttonClasses}
+        disabled={disabled}
+        onClick={onClick}
+        ref={ref}
+        selected={selected}
+        type={typeAttr}>
         {children}
     </button>);
-};
+});
 
 Button.displayName = 'Button';
 

--- a/src/Button/Button.test.js
+++ b/src/Button/Button.test.js
@@ -79,4 +79,17 @@ describe('<Button />', () => {
             ).toBe('Sample');
         });
     });
+
+    test('forwards the ref', () => {
+        let ref;
+        class Test extends React.Component {
+            constructor(props) {
+                super(props);
+                ref = React.createRef();
+            }
+            render = () => <Button ref={ref}>Button</Button>;
+        }
+        mount(<Test />);
+        expect(ref.current.tagName).toEqual('BUTTON');
+    });
 });

--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -3,7 +3,18 @@ import { INPUT_TYPES } from '../utils/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FormInput = ({ state, className, disabled, id, name, placeholder, readOnly, type, value, ...props }) => {
+const FormInput = React.forwardRef(({
+    className,
+    disabled,
+    id,
+    name,
+    placeholder,
+    readOnly,
+    state,
+    type,
+    value,
+    ...props
+}, ref) => {
     const formInputClasses = classnames(
         'fd-form__control',
         {
@@ -21,10 +32,11 @@ const FormInput = ({ state, className, disabled, id, name, placeholder, readOnly
             name={name}
             placeholder={placeholder}
             readOnly={readOnly}
+            ref={ref}
             type={type}
             value={value} />
     );
-};
+});
 
 FormInput.displayName = 'FormInput';
 

--- a/src/Forms/FormInput.test.js
+++ b/src/Forms/FormInput.test.js
@@ -28,4 +28,17 @@ describe('<FormInput />', () => {
             ).toBe('Sample');
         });
     });
+
+    test('forwards the ref', () => {
+        let ref;
+        class Test extends React.Component {
+            constructor(props) {
+                super(props);
+                ref = React.createRef();
+            }
+            render = () => <FormInput ref={ref} />;
+        }
+        mount(<Test />);
+        expect(ref.current.tagName).toEqual('INPUT');
+    });
 });

--- a/src/Forms/FormRadioItem.js
+++ b/src/Forms/FormRadioItem.js
@@ -2,7 +2,17 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FormRadioItem = ({ checked, children, className, disabled, id, inline, name, value, ...props }) => {
+const FormRadioItem = React.forwardRef(({
+    checked,
+    children,
+    className,
+    disabled,
+    id,
+    inline,
+    name,
+    value,
+    ...props
+}, ref) => {
     const classes = classnames(
         className,
         'fd-form__item',
@@ -22,13 +32,14 @@ const FormRadioItem = ({ checked, children, className, disabled, id, inline, nam
                     disabled={disabled}
                     id={id}
                     name={name}
+                    ref={ref}
                     type='radio'
                     value={value} />
                 {children}
             </label>
         </div>
     );
-};
+});
 
 FormRadioItem.displayName = 'FormRadioItem';
 

--- a/src/Forms/FormRadioItem.test.js
+++ b/src/Forms/FormRadioItem.test.js
@@ -83,4 +83,17 @@ describe('<FormRadioItem />', () => {
             ).toBe('Sample');
         });
     });
+
+    test('forwards the ref', () => {
+        let ref;
+        class Test extends React.Component {
+            constructor(props) {
+                super(props);
+                ref = React.createRef();
+            }
+            render = () => <FormRadioItem ref={ref}>radio</FormRadioItem>;
+        }
+        mount(<Test />);
+        expect(ref.current.type).toEqual('radio');
+    });
 });

--- a/src/Forms/FormSelect.js
+++ b/src/Forms/FormSelect.js
@@ -2,7 +2,12 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FormSelect = ({ disabled, children, className, ...props }) => {
+const FormSelect = React.forwardRef(({
+    children,
+    className,
+    disabled,
+    ...props
+}, ref) => {
     const formSelectClasses = classnames(
         'fd-form__control',
         className
@@ -12,11 +17,12 @@ const FormSelect = ({ disabled, children, className, ...props }) => {
         <select
             {...props}
             className={formSelectClasses}
-            disabled={disabled}>
+            disabled={disabled}
+            ref={ref}>
             {children}
         </select>
     );
-};
+});
 
 FormSelect.displayName = 'FormSelect';
 

--- a/src/Forms/FormSelect.test.js
+++ b/src/Forms/FormSelect.test.js
@@ -27,4 +27,17 @@ describe('<FormSelect />', () => {
             ).toBe('Sample');
         });
     });
+
+    test('forwards the ref', () => {
+        let ref;
+        class Test extends React.Component {
+            constructor(props) {
+                super(props);
+                ref = React.createRef();
+            }
+            render = () => <FormSelect ref={ref} />;
+        }
+        mount(<Test />);
+        expect(ref.current.tagName).toEqual('SELECT');
+    });
 });

--- a/src/Forms/FormTextArea.test.js
+++ b/src/Forms/FormTextArea.test.js
@@ -25,4 +25,17 @@ describe('<FormTextArea />', () => {
             ).toBe('Sample');
         });
     });
+
+    test('forwards the ref', () => {
+        let ref;
+        class Test extends React.Component {
+            constructor(props) {
+                super(props);
+                ref = React.createRef();
+            }
+            render = () => <FormTextarea ref={ref} />;
+        }
+        mount(<Test />);
+        expect(ref.current.tagName).toEqual('TEXTAREA');
+    });
 });

--- a/src/Forms/FormTextarea.js
+++ b/src/Forms/FormTextarea.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FormTextarea = ({ children, className, ...props }) => {
+const FormTextarea = React.forwardRef(({ children, className, ...props }, ref) => {
     const formTextAreaClasses = classnames(
         'fd-form__control',
         className
@@ -11,11 +11,12 @@ const FormTextarea = ({ children, className, ...props }) => {
     return (
         <textarea
             {...props}
-            className={formTextAreaClasses}>
+            className={formTextAreaClasses}
+            ref={ref}>
             {children}
         </textarea>
     );
-};
+});
 
 FormTextarea.displayName = 'FormTextarea';
 


### PR DESCRIPTION
### Description

Forward refs to:
 - Button
 - FormInput
 - FormRadioItem
 - FormSelect
 - FormTextArea

Others components that this may be expected on:
 - Toggle (Breaking change if somebody is relying on ref.handleChange)
 - Tab (`<a>`)
 - SearchInput (`<input>`)
 - Combobox (`<input>`)


fixes #576