### PR TITLE
fix: CORUI-6949: add onBlur callback to DatePicker

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -367,7 +367,8 @@ DatePicker.defaultProps = {
 
 DatePicker.propDescriptions = {
     ...Calendar.propDescriptions,
-    enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).'
+    enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).',
+    onBlur: 'Callback function for onBlur events. In the object returned, date is the date object and formattedDate is the formatted date.'
 };
 
 export default DatePicker;

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -207,12 +207,17 @@ class DatePicker extends Component {
 
     clickOutside = () => {
         this.validateDates();
-        this.setState({ hidden: true });
+        this.setState({
+            hidden: true
+        }, () => {
+            this.props.onBlur({
+                date: this.state.selectedDate,
+                formattedDate: this.state.formattedDate
+            });
+        });
     };
 
     updateDate = (date) => {
-        // console.log('Inside updateDate function. The event is: ', date);
-
         if (this.props.enableRangeSelection) {
             if (date.length === 2) {
                 let firstDateMonth = date[0].getMonth() + 1;
@@ -269,7 +274,7 @@ class DatePicker extends Component {
     render() {
         const { enableRangeSelection, disableWeekends, disableBeforeDate, disableAfterDate,
             disableWeekday, disablePastDates, disableFutureDates, blockedDates, disabledDates,
-            compact, className, inputProps, buttonProps, ...props } = this.props;
+            compact, className, inputProps, buttonProps, onBlur, ...props } = this.props;
 
         const datePickerClasses = classnames(
             'fd-date-picker',
@@ -303,6 +308,8 @@ class DatePicker extends Component {
                             <input
                                 {...inputProps}
                                 className={datePickerInputClasses}
+                                onBlur={() => onBlur({ date: this.state.selectedDate,
+                                    formattedDate: this.state.formattedDate })}
                                 onChange={this.modifyDate}
                                 onClick={() => this.openCalendar('input')}
                                 onKeyPress={this.sendUpdate}
@@ -350,7 +357,12 @@ DatePicker.propTypes = {
     buttonProps: PropTypes.object,
     compact: PropTypes.bool,
     enableRangeSelection: PropTypes.bool,
-    inputProps: PropTypes.object
+    inputProps: PropTypes.object,
+    onBlur: PropTypes.func
+};
+
+DatePicker.defaultProps = {
+    onBlur: () => {}
 };
 
 DatePicker.propDescriptions = {

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -271,6 +271,13 @@ class DatePicker extends Component {
         }
     }
 
+    _handleBlur = () => {
+        this.props.onBlur({
+            date: this.state.selectedDate,
+            formattedDate: this.state.formattedDate
+        });
+    };
+
     render() {
         const { enableRangeSelection, disableWeekends, disableBeforeDate, disableAfterDate,
             disableWeekday, disablePastDates, disableFutureDates, blockedDates, disabledDates,
@@ -308,8 +315,7 @@ class DatePicker extends Component {
                             <input
                                 {...inputProps}
                                 className={datePickerInputClasses}
-                                onBlur={() => onBlur({ date: this.state.selectedDate,
-                                    formattedDate: this.state.formattedDate })}
+                                onBlur={this._handleBlur}
                                 onChange={this.modifyDate}
                                 onClick={() => this.openCalendar('input')}
                                 onKeyPress={this.sendUpdate}
@@ -368,7 +374,7 @@ DatePicker.defaultProps = {
 DatePicker.propDescriptions = {
     ...Calendar.propDescriptions,
     enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).',
-    onBlur: 'Callback function for onBlur events. In the object returned, date is the date object and formattedDate is the formatted date.'
+    onBlur: 'Callback function for onBlur events. In the object returned, `date` is the date object and `formattedDate` is the formatted date.'
 };
 
 export default DatePicker;

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -367,6 +367,37 @@ describe('<DatePicker />', () => {
         expect(wrapper.state('formattedDate')).toEqual('05/04/2018');
     });
 
+    describe('onBlur callback', () => {
+        test('should call onBlur after clicking outside calendar overlay', () => {
+            const blur = jest.fn();
+            const element = mount(<DatePicker onBlur={blur} />);
+
+            element.find('button.fd-popover__control.fd-button--light.sap-icon--calendar').simulate('click', { type: 'input' });
+
+            element.find('table.fd-calendar__table tbody.fd-calendar__group tr.fd-calendar__row td.fd-calendar__item:not(.fd-calendar__item--other-month)')
+                .at(0)
+                .simulate('click');
+
+            let event = new MouseEvent('mousedown', { target: document.querySelector('body') });
+            document.dispatchEvent(event);
+
+            expect(blur).toHaveBeenCalledTimes(1);
+
+            expect(blur).toHaveBeenCalledWith(expect.objectContaining({ date: expect.any(Date) }));
+        });
+        test('should call onBlur after leaving input', () => {
+            const blur = jest.fn();
+            const element = mount(<DatePicker onBlur={blur} />);
+
+            element.find('input[type="text"]').simulate('click', { type: 'input' });
+
+            let event = new MouseEvent('mousedown', { target: document.querySelector('body') });
+            document.dispatchEvent(event);
+
+            expect(blur).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the DatePicker component', () => {
             const element = mount(<DatePicker data-sample='Sample' />);


### PR DESCRIPTION
### Description

Without doing a full rewrite at the moment, this is as close to a functional callback as we can get. Tests were a nightmare, so I decided to forgo them for this bandaid. 

This behaves slightly erratically as the input is not wired up to the calendar/sharing validation. 

Known bugs: Changes to the input don't necessarily update the date/trigger any event.


fixes https://github.com/SAP/fundamental-react/issues/498