### PR TITLE
Fix unique `key` prop error in Menu.Item and SearchInput

### DIFF
--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -141,6 +141,15 @@ describe('<Menu />', () => {
         });
     });
 
+    describe('MenuItem', () => {
+        test('create menu item with uniqueKey', () => {
+            const key = 'testkey';
+            const component = mount(<Menu.Item uniqueKey={key}></Menu.Item>).find('li');
+
+            expect(component.at(0).key()).toBe(key);
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Menu component', () => {
             const element = mount(<Menu data-sample='Sample' />);

--- a/src/Menu/_MenuItem.js
+++ b/src/Menu/_MenuItem.js
@@ -74,6 +74,7 @@ MenuItem.propDescriptions = {
     children: 'component - can be used to pass React Router <Link> or any other component which emits an <a>.',
     isLink: 'Set to **true** to style as a link.',
     separator: 'Set to **true** to add a horizontal line (separator).',
+    uniqueKey: 'A value that is used as React\'s `key` property in the inner `<li>` element.',
     url: 'Enables use of `<a>` element. Value to be applied to the anchor\'s `href` attribute. Should use either `link` or `url`, but not both.',
     urlProps: 'Additional props to be spread to the Menu Item links (when using `url`).'
 };

--- a/src/Menu/_MenuItem.js
+++ b/src/Menu/_MenuItem.js
@@ -2,7 +2,9 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const MenuItem = ({ url, isLink, separator, addon, children, onclick, className, addonProps, urlProps, ...props }) => {
+const MenuItem = ({ url, isLink, separator, addon, children, onclick, className, addonProps, urlProps, uniqueKey, ...props }) => {
+
+
     const menuItemLinkClasses = classnames(
         'fd-menu__item',
         {
@@ -39,7 +41,8 @@ const MenuItem = ({ url, isLink, separator, addon, children, onclick, className,
 
     return (
         <React.Fragment>
-            <li {...props} className={className}>
+            <li {...props} className={className}
+                key={uniqueKey}>
                 {addon &&
                     <div {...addonProps} className='fd-menu__addon-before'>{<span className={'sap-icon--' + addon} />}</div>
                 }
@@ -60,6 +63,7 @@ MenuItem.propTypes = {
     isLink: PropTypes.bool,
     onclick: PropTypes.func,
     separator: PropTypes.bool,
+    uniqueKey: PropTypes.any,
     url: PropTypes.string,
     urlProps: PropTypes.object
 };

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -171,6 +171,7 @@ class SearchInput extends Component {
                                 aria-expanded={this.state.searchExpanded}
                                 aria-haspopup='true'
                                 className='sap-icon--search fd-button--shell'
+                                key='search-in-shellbar'
                                 onClick={this.onSearchBtnHandler} />
                             <div
                                 aria-hidden={!this.state.searchExpanded}

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -50,6 +50,7 @@ class Toggle extends React.Component {
                             checked={this.state.checked}
                             disabled={disabled}
                             id={id}
+                            key='toggle-checkbox'
                             onChange={this.handleChange}
                             type='checkbox' />
                         <span className='fd-toggle__switch' role='presentation' />


### PR DESCRIPTION
### Description

### Changes
- add and document `uniqueKey` prop in Menu.Item (fixes error when used)
- add unique `key` prop to SearchInput's internal Button element (fixes error)
- Add key to input element inside Toggle component (fixes error)


fixes #512 