### PR TITLE
fix: Pull onClick off of props in pagination before spreading

### DIFF
--- a/src/Pagination/Pagination.js
+++ b/src/Pagination/Pagination.js
@@ -85,6 +85,7 @@ class Pagination extends Component {
             displayTotalProps,
             prevProps,
             nextProps,
+            onClick,
             initialPage,
             ...props
         } = this.props;

--- a/src/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/src/Pagination/__snapshots__/Pagination.test.js.snap
@@ -4,7 +4,6 @@ exports[`<Pagination /> create Pagination component with initial page set 1`] = 
 <div
   className="fd-pagination blue"
   initalPage={5}
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -125,7 +124,6 @@ exports[`<Pagination /> create Pagination component with initial page set 1`] = 
 exports[`<Pagination /> create Pagination component with item per page set 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -198,7 +196,6 @@ exports[`<Pagination /> create Pagination component with item per page set 1`] =
 exports[`<Pagination /> create Pagination component with item per page set to 0 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -319,7 +316,6 @@ exports[`<Pagination /> create Pagination component with item per page set to 0 
 exports[`<Pagination /> create Pagination component with total item hidden 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   
   <nav
@@ -434,7 +430,6 @@ exports[`<Pagination /> create Pagination component with total item hidden 1`] =
 exports[`<Pagination /> create Pagination component with total text set 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -555,7 +550,6 @@ exports[`<Pagination /> create Pagination component with total text set 1`] = `
 exports[`<Pagination /> create default Pagination component 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -676,7 +670,6 @@ exports[`<Pagination /> create default Pagination component 1`] = `
 exports[`<Pagination /> create default Pagination component with displayTotalProps 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"
@@ -798,7 +791,6 @@ exports[`<Pagination /> create default Pagination component with displayTotalPro
 exports[`<Pagination /> create default Pagination component with linkProps 1`] = `
 <div
   className="fd-pagination"
-  onClick={[MockFunction]}
 >
   <span
     className="fd-pagination__total"


### PR DESCRIPTION
### Description

`onClick` was being spread onto the container div and being called by each page.


fixes #747