### PR TITLE
chore: change main file path for bundlephobia

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "description": "SAP Fundamentals, implemented in React",
   "license": "Apache-2.0",
-  "main": "lib/index.js",
+  "main": "index.js",
   "homepage": "https://sap.github.io/fundamental-react",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

I believe this change might fix the bundlephobia errors we've been having. Because we `cd lib` then `npm publish`, there is no `lib/index.js`, just `index.js`.

I don't know how to test this besides merging and checking the build in bundlephobia 🤷‍♀

This might also fix the problem  @parostatkiem had in codepen.

fixes #issueid