### PR TITLE
fix: add build:copy-files after standard version has run

### DIFF
--- a/ci-scripts/publish-rc.sh
+++ b/ci-scripts/publish-rc.sh
@@ -9,6 +9,6 @@ npm run std-version -- --prerelease rc --no-verify
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" "$TRAVIS_BRANCH" > /dev/null 2>&1;
 
-npm run build
+npm run build:copy-files
 
 npm publish lib --tag prerelease

--- a/ci-scripts/publish-rc.sh
+++ b/ci-scripts/publish-rc.sh
@@ -9,4 +9,6 @@ npm run std-version -- --prerelease rc --no-verify
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" "$TRAVIS_BRANCH" > /dev/null 2>&1;
 
+npm run build
+
 npm publish lib --tag prerelease

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -15,7 +15,7 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
-npm run build
+npm run build:copy-files
 
 npm publish lib
 

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -15,6 +15,8 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
+npm run build
+
 npm publish lib
 
 # run this after publish to make sure GitHub finishes updating from the push

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:lint:fix": "npm run build:lint -- --fix",
     "build:lint": "eslint 'src/**' --ext .js,.jsx --env browser,node",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel src --out-dir lib --ignore \"src/**/*.spec.js\",\"src/**/*.test.js\",\"src/**/*.Component.js\",\"src/_playground/*\",\"src/**/*.stories.js\"",
-    "build": "npm run build:index && rm -rf lib && npm run build:cjs && npm run build:copy-files",
+    "build": "npm run build:index && rm -rf lib && npm run build:cjs",
     "config:lint": "eslint 'config/**' --ext .js,.jsx --env browser,node",
     "deploy": "gh-pages -d build",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "gh-pages -d build",
     "devtools:lint": "eslint 'devtools/**' --ext .js,.jsx --env browser,node",
     "docs:dev": "FUNDAMENTAL_REACT_PLAYGROUND=true npm start",
-    "dry-run": "npm run build && npm publish lib --dry-run",
+    "dry-run": "npm run build && npm run build:copy-files && npm publish lib --dry-run",
     "lint:fix": "npm run build:lint:fix  && npm run scripts:lint:fix && npm run config:lint:fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",
     "lint": "npm run build:lint && npm run scripts:lint && npm run config:lint && npm run devtools:lint && npm run style:lint",


### PR DESCRIPTION
### Description
In #776 , I moved build:copy-files to the build script. This actually needs to happen after standard-version runs on releases or else the package version number is the old one inside of lib for publishing.



fixes #issueid