### PR TITLE
fix: Align popover inside dropdown

### DIFF
--- a/src/Dropdown/Dropdown.Component.js
+++ b/src/Dropdown/Dropdown.Component.js
@@ -152,7 +152,7 @@ export const DropdownComponent = () => {
             </Example>
             <Example
                 centered
-                description="Assign a reference (useRef) to <Dropdown> and use it as the 'parentElement' property of <Popover>"
+                description="Assign a reference (useRef) to <Dropdown> and use it as the 'parentRef' property of <Popover>"
                 title="Width limited to parent's">
                 <Dropdown ref={dropdownRef}>
                     <Popover
@@ -169,7 +169,7 @@ export const DropdownComponent = () => {
                         control={<Button className='fd-dropdown__control'>Select</Button>}
                         id='jhqD0555'
                         noArrow
-                        parentElement={dropdownRef} />
+                        parentRef={dropdownRef} />
                 </Dropdown>
             </Example>
 

--- a/src/Dropdown/Dropdown.Component.js
+++ b/src/Dropdown/Dropdown.Component.js
@@ -1,9 +1,13 @@
 import path from 'path';
 import React from 'react';
+import { useRef } from 'react';
 import { Button, Dropdown, Menu, Popover } from '../';
 import { ComponentPage, Example } from '../_playground';
 
+
 export const DropdownComponent = () => {
+    const dropdownRef = useRef(null);
+
     return (
         <ComponentPage
             description={`The **Dropdown** component lets the user select one of the different options.
@@ -45,7 +49,7 @@ export const DropdownComponent = () => {
                         }
                         control={
                             <Button className='fd-dropdown__control' compact>
-                                    Select
+                                Select
                             </Button>
                         }
                         id='jhqD0556'
@@ -71,7 +75,7 @@ export const DropdownComponent = () => {
                         }
                         control={
                             <Button className='fd-dropdown__control' glyph='filter'>
-                                    Select
+                                Select
                             </Button>
                         }
                         id='jhqD0557'
@@ -93,7 +97,7 @@ export const DropdownComponent = () => {
                         control={
                             <Button className='fd-dropdown__control' compact
                                 glyph='filter'>
-                                    Select
+                                Select
                             </Button>
                         }
                         id='jhqD0558'
@@ -118,7 +122,7 @@ export const DropdownComponent = () => {
                         }
                         control={
                             <Button className='fd-dropdown__control'>
-                                    Select
+                                Select
                             </Button>
                         }
                         id='jhqD0559'
@@ -139,13 +143,36 @@ export const DropdownComponent = () => {
                         }
                         control={
                             <Button className='fd-dropdown__control' compact>
-                                    Select
+                                Select
                             </Button>
                         }
                         id='jhqD0560'
                         noArrow />
                 </Dropdown>
             </Example>
+            <Example
+                centered
+                description="Assign a reference (useRef) to <Dropdown> and use it as the 'parentElement' property of <Popover>"
+                title="Width limited to parent's">
+                <Dropdown ref={dropdownRef}>
+                    <Popover
+                        body={
+                            <Menu>
+                                <Menu.List>
+                                    <Menu.Item url='#'>Option 1</Menu.Item>
+                                    <Menu.Item url='#'>Option 2</Menu.Item>
+                                    <Menu.Item url='#'>Option 3</Menu.Item>
+                                    <Menu.Item url='#'>Option 4</Menu.Item>
+                                </Menu.List>
+                            </Menu>
+                        }
+                        control={<Button className='fd-dropdown__control'>Select</Button>}
+                        id='jhqD0555'
+                        noArrow
+                        parentElement={dropdownRef} />
+                </Dropdown>
+            </Example>
+
 
             <Example
                 centered
@@ -165,7 +192,7 @@ export const DropdownComponent = () => {
                         control={
                             <Button className='fd-dropdown__control' disabled
                                 glyph='filter'>
-                                    Select
+                                Select
                             </Button>
                         }
                         disabled

--- a/src/Dropdown/Dropdown.Component.js
+++ b/src/Dropdown/Dropdown.Component.js
@@ -1,12 +1,10 @@
 import path from 'path';
 import React from 'react';
-import { useRef } from 'react';
 import { Button, Dropdown, Menu, Popover } from '../';
 import { ComponentPage, Example } from '../_playground';
 
 
 export const DropdownComponent = () => {
-    const dropdownRef = useRef(null);
 
     return (
         <ComponentPage
@@ -150,29 +148,33 @@ export const DropdownComponent = () => {
                         noArrow />
                 </Dropdown>
             </Example>
+
             <Example
                 centered
-                description="Assign a reference (useRef) to <Dropdown> and use it as the 'parentRef' property of <Popover>"
-                title="Width limited to parent's">
-                <Dropdown ref={dropdownRef}>
+                title='Popover width limited to Dropdown'>
+                <Dropdown>
                     <Popover
                         body={
                             <Menu>
                                 <Menu.List>
-                                    <Menu.Item url='#'>One</Menu.Item>
-                                    <Menu.Item url='#'>Two</Menu.Item>
-                                    <Menu.Item url='#'>Three</Menu.Item>
-                                    <Menu.Item url='#'>Four</Menu.Item>
+                                    <Menu.Item url='#'>Option 1</Menu.Item>
+                                    <Menu.Item url='#'>Option 2</Menu.Item>
+                                    <Menu.Item url='#'>Option 3</Menu.Item>
+                                    <Menu.Item url='#'>Option 4</Menu.Item>
                                 </Menu.List>
                             </Menu>
                         }
-                        control={<Button className='fd-dropdown__control'>Select</Button>}
-                        id='jhqD0555'
+                        control={
+                            <Button className='fd-dropdown__control'
+                                glyph='navigation-down-arrow'>
+                                Open the dropdown
+                            </Button>
+                        }
+                        id='jhqD0561'
                         noArrow
-                        parentRef={dropdownRef} />
+                        widthSizingType='matchTarget' />
                 </Dropdown>
             </Example>
-
 
             <Example
                 centered

--- a/src/Dropdown/Dropdown.Component.js
+++ b/src/Dropdown/Dropdown.Component.js
@@ -159,10 +159,10 @@ export const DropdownComponent = () => {
                         body={
                             <Menu>
                                 <Menu.List>
-                                    <Menu.Item url='#'>Option 1</Menu.Item>
-                                    <Menu.Item url='#'>Option 2</Menu.Item>
-                                    <Menu.Item url='#'>Option 3</Menu.Item>
-                                    <Menu.Item url='#'>Option 4</Menu.Item>
+                                    <Menu.Item url='#'>One</Menu.Item>
+                                    <Menu.Item url='#'>Two</Menu.Item>
+                                    <Menu.Item url='#'>Three</Menu.Item>
+                                    <Menu.Item url='#'>Four</Menu.Item>
                                 </Menu.List>
                             </Menu>
                         }

--- a/src/Popover/Popover.Component.js
+++ b/src/Popover/Popover.Component.js
@@ -1,8 +1,10 @@
 import 'fundamental-styles/dist/layout.css'; //needed for layout container class for placement example
 import path from 'path';
+import { POPPER_SIZING_TYPES } from '../utils/constants';
 import React from 'react';
 import { Button, Icon, Identifier, Image, Menu, Modal, Popover } from '../';
 import { ComponentPage, Example } from '../_playground';
+
 
 const bodyContent = (
     <Menu>
@@ -11,6 +13,17 @@ const bodyContent = (
             <Menu.Item url='#'>Option 2</Menu.Item>
             <Menu.Item url='#'>Option 3</Menu.Item>
             <Menu.Item url='#'>Option 4</Menu.Item>
+        </Menu.List>
+    </Menu>
+);
+
+const longBodyContent = (
+    <Menu>
+        <Menu.List>
+            <Menu.Item url='#'>Lorem ipsum dolor sit amet</Menu.Item>
+            <Menu.Item url='#'>consectetur adipiscing elit</Menu.Item>
+            <Menu.Item url='#'>sed do eiusmod tempor</Menu.Item>
+            <Menu.Item url='#'>incididunt ut labore et dolore</Menu.Item>
         </Menu.List>
     </Menu>
 );
@@ -176,6 +189,20 @@ export class PopoverComponent extends React.Component {
                         control={<Button glyph='navigation-down-arrow' option='light' />}
                         disableEdgeDetection
                         placement='bottom' />
+                </Example>
+
+                <Example
+                    centered
+                    title='Width Sizing Type'>
+                    {POPPER_SIZING_TYPES.map(type =>
+                        (<Popover
+                            body={longBodyContent}
+                            control={<Button>widthizingType: <strong>'{type}'</strong></Button>}
+                            disableEdgeDetection
+                            placement='bottom'
+                            widthSizingType={type} />)
+                    )}
+
                 </Example>
 
                 <Example

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,9 +1,9 @@
 import chain from 'chain-function';
 import classnames from 'classnames';
 import Popper from '../utils/_Popper';
-import { POPPER_PLACEMENTS } from '../utils/constants';
 import PropTypes from 'prop-types';
 import withStyles from '../utils/WithStyles/WithStyles';
+import { POPPER_PLACEMENTS, POPPER_SIZING_TYPES, POPPER_SIZING_TYPES_DESCRIPTION } from '../utils/constants';
 import React, { Component } from 'react';
 
 class Popover extends Component {
@@ -13,6 +13,7 @@ class Popover extends Component {
         this.state = {
             isExpanded: false
         };
+        this.placementTargetRef = React.createRef();
     }
 
     triggerBody = () => {
@@ -44,7 +45,7 @@ class Popover extends Component {
             className,
             placement,
             popperProps,
-            parentRef,
+            widthSizingType,
             ...rest
         } = this.props;
 
@@ -54,8 +55,10 @@ class Popover extends Component {
         }
 
         const referenceComponent = React.cloneElement(control, {
-            onClick: onClickFunctions
+            onClick: onClickFunctions,
+            ref: this.placementTargetRef
         });
+
         const popoverClasses = classnames('fd-popover', className);
 
         return (
@@ -66,13 +69,14 @@ class Popover extends Component {
                     noArrow={noArrow}
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleOutsideClick, onEscapeKey)}
-                    parentRef={parentRef}
+                    placementTargetRef={this.placementTargetRef}
                     popperPlacement={placement}
                     popperProps={popperProps}
                     referenceClassName='fd-popover__control'
                     referenceComponent={referenceComponent}
                     show={this.state.isExpanded && !disabled}
-                    usePortal>
+                    usePortal
+                    widthSizingType={widthSizingType}>
                     {body}
                 </Popper>
             </div>
@@ -91,14 +95,15 @@ Popover.propTypes = {
     disableEdgeDetection: PropTypes.bool,
     disableStyles: PropTypes.bool,
     noArrow: PropTypes.bool,
-    parentRef: PropTypes.shape({ current: PropTypes.any }),
     placement: PropTypes.oneOf(POPPER_PLACEMENTS),
     popperProps: PropTypes.object,
+    widthSizingType: PropTypes.oneOf(POPPER_SIZING_TYPES),
     onClickOutside: PropTypes.func,
     onEscapeKey: PropTypes.func
 };
 
 Popover.defaultProps = {
+    widthSizingType: 'none',
     onClickOutside: () => { },
     onEscapeKey: () => { }
 };
@@ -108,9 +113,9 @@ Popover.propDescriptions = {
     control: 'Node to render as the reference element (that the `body` will be placed in relation to).',
     disableEdgeDetection: 'Set to **true** to render popover without edge detection so popover will not flip from top to bottom with scroll.',
     noArrow: 'Set to **true** to render a popover without an arrow.',
-    parentRef: 'A reference (useRef) to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
     placement: 'Initial position of the `body` (overlay) related to the `control`.',
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
+    widthSizingType: POPPER_SIZING_TYPES_DESCRIPTION,
     onClickOutside: 'Callback for consumer clicking outside of popover body.',
     onEscapeKey: 'Callback when escape key is pressed when popover body is visible.'
 };

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -44,6 +44,7 @@ class Popover extends Component {
             className,
             placement,
             popperProps,
+            parentElement,
             ...rest
         } = this.props;
 
@@ -66,6 +67,7 @@ class Popover extends Component {
                     noArrow={noArrow}
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleOutsideClick, onEscapeKey)}
+                    parentElement={parentElement}
                     popperPlacement={placement}
                     popperProps={popperProps}
                     referenceClassName='fd-popover__control'
@@ -90,6 +92,7 @@ Popover.propTypes = {
     disableEdgeDetection: PropTypes.bool,
     disableStyles: PropTypes.bool,
     noArrow: PropTypes.bool,
+    parentElement: PropTypes.node,
     placement: PropTypes.oneOf(POPPER_PLACEMENTS),
     popperProps: PropTypes.object,
     onClickOutside: PropTypes.func,
@@ -97,8 +100,8 @@ Popover.propTypes = {
 };
 
 Popover.defaultProps = {
-    onClickOutside: () => {},
-    onEscapeKey: () => {}
+    onClickOutside: () => { },
+    onEscapeKey: () => { }
 };
 
 Popover.propDescriptions = {
@@ -106,6 +109,7 @@ Popover.propDescriptions = {
     control: 'Node to render as the reference element (that the `body` will be placed in relation to).',
     disableEdgeDetection: 'Set to **true** to render popover without edge detection so popover will not flip from top to bottom with scroll.',
     noArrow: 'Set to **true** to render a popover without an arrow.',
+    parentElement: 'A reference to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
     placement: 'Initial position of the `body` (overlay) related to the `control`.',
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
     onClickOutside: 'Callback for consumer clicking outside of popover body.',

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -56,7 +56,6 @@ class Popover extends Component {
         const referenceComponent = React.cloneElement(control, {
             onClick: onClickFunctions
         });
-
         const popoverClasses = classnames('fd-popover', className);
 
         return (

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -44,7 +44,7 @@ class Popover extends Component {
             className,
             placement,
             popperProps,
-            parentElement,
+            parentRef,
             ...rest
         } = this.props;
 
@@ -66,7 +66,7 @@ class Popover extends Component {
                     noArrow={noArrow}
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleOutsideClick, onEscapeKey)}
-                    parentElement={parentElement}
+                    parentRef={parentRef}
                     popperPlacement={placement}
                     popperProps={popperProps}
                     referenceClassName='fd-popover__control'
@@ -91,7 +91,7 @@ Popover.propTypes = {
     disableEdgeDetection: PropTypes.bool,
     disableStyles: PropTypes.bool,
     noArrow: PropTypes.bool,
-    parentElement: PropTypes.shape({ current: PropTypes.any }),
+    parentRef: PropTypes.shape({ current: PropTypes.any }),
     placement: PropTypes.oneOf(POPPER_PLACEMENTS),
     popperProps: PropTypes.object,
     onClickOutside: PropTypes.func,
@@ -108,7 +108,7 @@ Popover.propDescriptions = {
     control: 'Node to render as the reference element (that the `body` will be placed in relation to).',
     disableEdgeDetection: 'Set to **true** to render popover without edge detection so popover will not flip from top to bottom with scroll.',
     noArrow: 'Set to **true** to render a popover without an arrow.',
-    parentElement: 'A reference (useRef) to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
+    parentRef: 'A reference (useRef) to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
     placement: 'Initial position of the `body` (overlay) related to the `control`.',
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
     onClickOutside: 'Callback for consumer clicking outside of popover body.',

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -91,7 +91,7 @@ Popover.propTypes = {
     disableEdgeDetection: PropTypes.bool,
     disableStyles: PropTypes.bool,
     noArrow: PropTypes.bool,
-    parentElement: PropTypes.node,
+    parentElement: PropTypes.shape({ current: PropTypes.any }),
     placement: PropTypes.oneOf(POPPER_PLACEMENTS),
     popperProps: PropTypes.object,
     onClickOutside: PropTypes.func,

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -108,7 +108,7 @@ Popover.propDescriptions = {
     control: 'Node to render as the reference element (that the `body` will be placed in relation to).',
     disableEdgeDetection: 'Set to **true** to render popover without edge detection so popover will not flip from top to bottom with scroll.',
     noArrow: 'Set to **true** to render a popover without an arrow.',
-    parentElement: 'A reference to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
+    parentElement: 'A reference (useRef) to an element of which the Popover will be positioned and sized relatively. Leave it empty to let it be done automatically.',
     placement: 'Initial position of the `body` (overlay) related to the `control`.',
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
     onClickOutside: 'Callback for consumer clicking outside of popover body.',

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -167,6 +167,20 @@ describe('<Popover />', () => {
         expect(wrapper.state('isExpanded')).toBeFalsy();
     });
 
+    test('position and size is set when "parentRef" is set', () => {
+        const parentBoundaries = { x: 123, bottom: 456, width: 789 };
+        const popoverWithParent = mount(popOver).setProps(
+            { parentRef: { current: { getBoundingClientRect: () => parentBoundaries } } }
+        );
+        popoverWithParent.find('.sap-icon--cart').simulate('click');
+        const popoverStyle = popoverWithParent.find('.fd-popover__popper').prop('style');
+
+        expect(popoverStyle).toHaveProperty('left', parentBoundaries.x);
+        expect(popoverStyle).toHaveProperty('top', parentBoundaries.bottom);
+        expect(popoverStyle).toHaveProperty('width', parentBoundaries.width);
+    });
+
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Popover component', () => {
             const element = mount(

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -167,17 +167,50 @@ describe('<Popover />', () => {
         expect(wrapper.state('isExpanded')).toBeFalsy();
     });
 
-    test('position and size is set when "parentRef" is set', () => {
-        const parentBoundaries = { x: 123, bottom: 456, width: 789 };
-        const popoverWithParent = mount(popOver).setProps(
-            { parentRef: { current: { getBoundingClientRect: () => parentBoundaries } } }
-        );
-        popoverWithParent.find('.sap-icon--cart').simulate('click');
-        const popoverStyle = popoverWithParent.find('.fd-popover__popper').prop('style');
 
-        expect(popoverStyle).toHaveProperty('left', parentBoundaries.x);
-        expect(popoverStyle).toHaveProperty('top', parentBoundaries.bottom);
-        expect(popoverStyle).toHaveProperty('width', parentBoundaries.width);
+
+    describe('widthSizingType', () => {
+        const targetBoundaries = { left: 123, right: 456 };
+        beforeAll(()=>{
+            Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRectTest', {
+                // because of getBoundingClientRectTest cannot be redefined
+                value: () => targetBoundaries,
+                writable: true
+            });
+        });
+
+        test('matchTarget', () => {
+            const popoverWithParent = mount(popOver).setProps({ widthSizingType: 'matchTarget' });
+            popoverWithParent.find('div.fd-popover__control .sap-icon--cart').simulate('click');
+            const popoverStyle = popoverWithParent.find('.fd-popover__popper').prop('style');
+
+            expect(popoverStyle).toHaveProperty('left', targetBoundaries.left);
+            expect(popoverStyle).toHaveProperty('width', targetBoundaries.right - targetBoundaries.left);
+        });
+
+        test('minTarget', () => {
+            const popoverWithParent = mount(popOver).setProps({ widthSizingType: 'minTarget' });
+            popoverWithParent.find('div.fd-popover__control .sap-icon--cart').simulate('click');
+            const popoverStyle = popoverWithParent.find('.fd-popover__popper').prop('style');
+
+            expect(popoverStyle).toHaveProperty('left');
+            const { left } = popoverStyle;
+            expect(popoverStyle).toHaveProperty('minWidth', targetBoundaries.right - left);
+        });
+
+        test('maxTarget', () => {
+            const popoverWithParent = mount(popOver).setProps({ widthSizingType: 'maxTarget' });
+            popoverWithParent.find('div.fd-popover__control .sap-icon--cart').simulate('click');
+            const popoverStyle = popoverWithParent.find('.fd-popover__popper').prop('style');
+
+            expect(popoverStyle).toHaveProperty('left');
+            const { left } = popoverStyle;
+            expect(popoverStyle).toHaveProperty('maxWidth', targetBoundaries.right - left);
+        });
+
+        afterAll(()=>{
+            delete window.HTMLElement.prototype.getBoundingClientRectTest;
+        });
     });
 
 

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -65,6 +65,7 @@ class Popper extends React.Component {
             disableEdgeDetection,
             noArrow,
             onClickOutside,
+            parentElement,
             popperClassName,
             popperModifiers,
             popperPlacement,
@@ -93,6 +94,11 @@ class Popper extends React.Component {
                 {({ ref, style, placement, outOfBoundaries, arrowProps }) => {
                     if (!show) {
                         return null;
+                    }
+                    const currentParentElement = parentElement && parentElement.current;
+                    if (currentParentElement) {
+                        const { offsetWidth, offsetHeight, offsetLeft, offsetTop } = currentParentElement;
+                        style = { ...style, left: offsetLeft, top: offsetTop + offsetHeight, width: offsetWidth }
                     }
 
                     return (
@@ -149,6 +155,7 @@ Popper.propTypes = {
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
     noArrow: PropTypes.bool,
+    parentElement: PropTypes.node,
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.object,
     popperPlacement: PropTypes.oneOf(POPPER_PLACEMENTS),
@@ -175,8 +182,8 @@ Popper.defaultProps = {
         }
     },
     popperPlacement: 'bottom-start',
-    onClickOutside: () => {},
-    onKeyDown: () => {}
+    onClickOutside: () => { },
+    onKeyDown: () => { }
 };
 
 export default Popper;

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -97,8 +97,8 @@ class Popper extends React.Component {
                     }
                     const currentParentElement = parentElement && parentElement.current;
                     if (currentParentElement) {
-                        const { offsetWidth, offsetHeight, offsetLeft, offsetTop } = currentParentElement;
-                        style = { ...style, left: offsetLeft, top: offsetTop + offsetHeight, width: offsetWidth };
+                        const { x: left, bottom: top, width } = currentParentElement.getBoundingClientRect();
+                        style = { ...style, left, top, width };
                     }
 
                     return (
@@ -155,7 +155,7 @@ Popper.propTypes = {
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
     noArrow: PropTypes.bool,
-    parentElement: PropTypes.node,
+    parentElement: PropTypes.shape({ current: PropTypes.any }),
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.object,
     popperPlacement: PropTypes.oneOf(POPPER_PLACEMENTS),

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -65,7 +65,7 @@ class Popper extends React.Component {
             disableEdgeDetection,
             noArrow,
             onClickOutside,
-            parentElement,
+            parentRef,
             popperClassName,
             popperModifiers,
             popperPlacement,
@@ -95,9 +95,9 @@ class Popper extends React.Component {
                     if (!show) {
                         return null;
                     }
-                    const currentParentElement = parentElement && parentElement.current;
-                    if (currentParentElement) {
-                        const { x: left, bottom: top, width } = currentParentElement.getBoundingClientRect();
+                    const currentParentRef = parentRef && parentRef.current;
+                    if (currentParentRef) {
+                        const { x: left, bottom: top, width } = currentParentRef.getBoundingClientRect();
                         style = { ...style, left, top, width };
                     }
 
@@ -155,7 +155,7 @@ Popper.propTypes = {
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
     noArrow: PropTypes.bool,
-    parentElement: PropTypes.shape({ current: PropTypes.any }),
+    parentRef: PropTypes.shape({ current: PropTypes.any }),
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.object,
     popperPlacement: PropTypes.oneOf(POPPER_PLACEMENTS),

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -98,7 +98,7 @@ class Popper extends React.Component {
                     const currentParentElement = parentElement && parentElement.current;
                     if (currentParentElement) {
                         const { offsetWidth, offsetHeight, offsetLeft, offsetTop } = currentParentElement;
-                        style = { ...style, left: offsetLeft, top: offsetTop + offsetHeight, width: offsetWidth }
+                        style = { ...style, left: offsetLeft, top: offsetTop + offsetHeight, width: offsetWidth };
                     }
 
                     return (

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -122,3 +122,11 @@ export const POPPER_PLACEMENTS = [
     'top',
     'top-end'
 ];
+
+export const POPPER_SIZING_TYPES = ['none', 'matchTarget', 'minTarget', 'maxTarget'];
+
+export const POPPER_SIZING_TYPES_DESCRIPTION = `<ul>
+<li>"matchTarget" - left and right edges align with the target</li>
+<li>"minTarget" - right edge aligns with target unless Popover content is bigger</li>
+<li>"maxTarget" - right edge aligns with target unless Popover content is smaller</li>
+</ul>`;


### PR DESCRIPTION
#### This is a temporary solution.
The whole problem requires a major refactoring on popovers, as @jbadan said on Slack (100% agree).
This is just a "patch" to make Popover working with Dropdown or any other element.
⚠️ It **does not** introduce any backwards-incompatible changes.
### Description
- Add ability to align Popover left and right edge with its parent control element edges. 
- Add ability to set Popover right edge to be not-further-left or not-further-right than parent control right edge.

 It works well with Dropdown as well as any other type. ~Sadly, the solution requires creating a reference on the client side.~


#### Before:
![image](https://user-images.githubusercontent.com/22825433/68368064-740c1780-0137-11ea-8a03-991f93cf2f1a.png)

#### After:
![image](https://user-images.githubusercontent.com/22825433/68368077-81c19d00-0137-11ea-88e8-8506f2bd8ed2.png)


fixes #788 