### PR TITLE
fix: No Popover Arrow

### DIFF
--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -31,24 +31,39 @@ storiesOf('Components|Popover', module)
         <>
             <Popover
                 body={someText}
+                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
+                placement='top-start'
+                style={{ position: 'fixed', top: '10em', left: '35em' }} />
+            <Popover
+                body={someText}
                 control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
                 placement='top'
                 style={{ position: 'fixed', top: '10em', left: '50em' }} />
             <Popover
                 body={someText}
+                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
+                placement='top-end'
+                style={{ position: 'fixed', top: '10em', left: '65em' }} />
+            <Popover
+                body={someText}
                 control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
                 placement='right-start'
-                style={{ position: 'fixed', top: '15em', left: '60em' }} />
+                style={{ position: 'fixed', top: '15em', left: '65em' }} />
             <Popover
                 body={someText}
                 control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
                 placement='right'
-                style={{ position: 'fixed', top: '20em', left: '60em' }} />
+                style={{ position: 'fixed', top: '20em', left: '65em' }} />
             <Popover
                 body={someText}
                 control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
                 placement='right-end'
-                style={{ position: 'fixed', top: '25em', left: '60em' }} />
+                style={{ position: 'fixed', top: '25em', left: '65em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
+                placement='bottom-end'
+                style={{ position: 'fixed', top: '30em', left: '65em' }} />
             <Popover
                 body={someText}
                 control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
@@ -56,19 +71,24 @@ storiesOf('Components|Popover', module)
                 style={{ position: 'fixed', top: '30em', left: '50em' }} />
             <Popover
                 body={someText}
+                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
+                placement='bottom-start'
+                style={{ position: 'fixed', top: '30em', left: '35em' }} />
+            <Popover
+                body={someText}
                 control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
                 placement='left-end'
-                style={{ position: 'fixed', top: '25em', left: '40em' }} />
+                style={{ position: 'fixed', top: '25em', left: '35em' }} />
             <Popover
                 body={someText}
                 control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
                 placement='left'
-                style={{ position: 'fixed', top: '20em', left: '40em' }} />
+                style={{ position: 'fixed', top: '20em', left: '35em' }} />
             <Popover
                 body={someText}
                 control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
                 placement='left-start'
-                style={{ position: 'fixed', top: '15em', left: '40em' }} />
+                style={{ position: 'fixed', top: '15em', left: '35em' }} />
         </>
     ))
     .add('disable styles', () => (

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -29,66 +29,143 @@ storiesOf('Components|Popover', module)
     ))
     .add('Placement', () => (
         <>
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
-                placement='top-start'
-                style={{ position: 'fixed', top: '10em', left: '35em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
-                placement='top'
-                style={{ position: 'fixed', top: '10em', left: '50em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
-                placement='top-end'
-                style={{ position: 'fixed', top: '10em', left: '65em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
-                placement='right-start'
-                style={{ position: 'fixed', top: '15em', left: '65em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
-                placement='right'
-                style={{ position: 'fixed', top: '20em', left: '65em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
-                placement='right-end'
-                style={{ position: 'fixed', top: '25em', left: '65em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
-                placement='bottom-end'
-                style={{ position: 'fixed', top: '30em', left: '65em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
-                placement='bottom'
-                style={{ position: 'fixed', top: '30em', left: '50em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
-                placement='bottom-start'
-                style={{ position: 'fixed', top: '30em', left: '35em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
-                placement='left-end'
-                style={{ position: 'fixed', top: '25em', left: '35em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
-                placement='left'
-                style={{ position: 'fixed', top: '20em', left: '35em' }} />
-            <Popover
-                body={someText}
-                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
-                placement='left-start'
-                style={{ position: 'fixed', top: '15em', left: '35em' }} />
+            <style dangerouslySetInnerHTML={{ __html: `
+            td {
+                min-width: 3em;
+                min-height: 3em;
+            }
+            ` }} />
+            <table>
+                {/* start top padding for popover */}
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                {/* end top padding for popover */}
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
+                            placement='top-start' />
+                    </td>
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
+                            placement='top' />
+                    </td>
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
+                            placement='top-end' />
+                    </td>
+                    <td />
+                </tr>
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
+                            placement='left-start' />
+                    </td>
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
+                            placement='right-start' />
+                    </td>
+                </tr>
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
+                            placement='left' />
+                    </td>
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
+                            placement='right' />
+                    </td>
+                </tr>
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
+                            placement='left-end' />
+                    </td>
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
+                            placement='right-end' />
+                    </td>
+                </tr>
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
+                            placement='bottom-start' />
+                    </td>
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
+                            placement='bottom' />
+                    </td>
+                    <td>
+                        <Popover
+                            body={someText}
+                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
+                            placement='bottom-end' />
+                    </td>
+                    <td />
+                </tr>
+                {/* start bottom padding for popover */}
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                <tr ><td>&nbsp;</td></tr>
+                {/* end bottom padding for popover */}
+            </table>
         </>
     ))
     .add('disable styles', () => (

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -18,12 +18,58 @@ const bodyContent = (
     </Menu>
 );
 
+const someText = <p style={{ padding: '0.5em' }}>This is a simple popover.</p>;
+
 storiesOf('Components|Popover', module)
     .addDecorator(withKnobs)
     .add('Default', () => (
         <Popover
             body={bodyContent}
             control={<Button glyph='navigation-up-arrow' option='light' />} />
+    ))
+    .add('Placement', () => (
+        <>
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
+                placement='top'
+                style={{ position: 'fixed', top: '10em', left: '50em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
+                placement='right-start'
+                style={{ position: 'fixed', top: '15em', left: '60em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
+                placement='right'
+                style={{ position: 'fixed', top: '20em', left: '60em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
+                placement='right-end'
+                style={{ position: 'fixed', top: '25em', left: '60em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
+                placement='bottom'
+                style={{ position: 'fixed', top: '30em', left: '50em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
+                placement='left-end'
+                style={{ position: 'fixed', top: '25em', left: '40em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
+                placement='left'
+                style={{ position: 'fixed', top: '20em', left: '40em' }} />
+            <Popover
+                body={someText}
+                control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
+                placement='left-start'
+                style={{ position: 'fixed', top: '15em', left: '40em' }} />
+        </>
     ))
     .add('disable styles', () => (
         <Popover

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -99,7 +99,6 @@ class Popper extends React.Component {
                         <div
                             {...popperProps}
                             className={popperClasses}
-                            data-placement={placement}
                             ref={ref}
                             style={style}
                             // eslint-disable-next-line no-undefined

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -100,9 +100,11 @@ class Popper extends React.Component {
                             {...popperProps}
                             className={popperClasses}
                             data-placement={placement}
-                            data-x-out-of-boundaries={!!outOfBoundaries || undefined} // eslint-disable-line
                             ref={ref}
-                            style={style}>
+                            style={style}
+                            // eslint-disable-next-line no-undefined
+                            x-out-of-boundaries={!!outOfBoundaries || undefined}
+                            x-placement={placement}>
                             {children}
                             <span
                                 className={`${cssBlock}__arrow`}
@@ -175,8 +177,8 @@ Popper.defaultProps = {
         }
     },
     popperPlacement: 'bottom-start',
-    onClickOutside: () => {},
-    onKeyDown: () => {}
+    onClickOutside: () => { },
+    onKeyDown: () => { }
 };
 
 export default Popper;


### PR DESCRIPTION
### Description

Cause: Mismatch between FD-style expected attribute name and FD-react property applied leading to appropriate styles not being applied to the popover.

Solution: Change popover `<div>`'s property names to match FD-style attribute selectors seen [here](https://github.com/SAP/fundamental-styles/blob/master/src/popover.scss#L210). 
* `data-placement` becomes `x-placement`
* `data-x-out-of-boundaries` becomes `x-out-of-boundaries`
* Storybook entry for popover placement [added](http://localhost:12123/?path=/story/components-popover--placement)

**Before** (chrome)
![image](https://user-images.githubusercontent.com/43764832/68793394-00b84900-0602-11ea-9002-1adc1279f7d6.png)

**After** (chrome)
![image](https://user-images.githubusercontent.com/43764832/68793255-ba62ea00-0601-11ea-9ca3-19f6073d6463.png)


fixes #740