### PR TITLE
fix: Add aria attributes to popover control

### DIFF
--- a/src/Dropdown/Dropdown.test.js
+++ b/src/Dropdown/Dropdown.test.js
@@ -23,7 +23,7 @@ describe('<Dropdown />', () => {
             <Popover
                 body={defaultMenu}
                 control={<Button className='fd-dropdown__control'>Select</Button>}
-                noArrow />
+                noArrow popperProps={{ id: 'fd-default-dropdown-popover' }} />
         </Dropdown>
     );
 
@@ -36,7 +36,7 @@ describe('<Dropdown />', () => {
                         Select
                     </Button>
                 }
-                noArrow />
+                noArrow popperProps={{ id: 'fd-compact-dropdown-popover' }} />
         </Dropdown>
     );
 
@@ -49,7 +49,7 @@ describe('<Dropdown />', () => {
                         Select
                     </Button>
                 }
-                noArrow />
+                noArrow popperProps={{ id: 'fd-toolbar-dropdown-popover' }} />
         </Dropdown>
     );
 
@@ -63,7 +63,7 @@ describe('<Dropdown />', () => {
                     </Button>
                 }
                 id='jhqD0557'
-                noArrow />
+                noArrow popperProps={{ id: 'fd-icon-dropdown-popover' }} />
         </Dropdown>
     );
 
@@ -80,7 +80,7 @@ describe('<Dropdown />', () => {
                 }
                 disabled
                 id='jhqD0561'
-                noArrow />
+                noArrow popperProps={{ id: 'fd-disable-dropdown-popover' }} />
         </Dropdown>
     );
 

--- a/src/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -16,6 +16,8 @@ exports[`<Dropdown /> create dropdown component 1`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-default-dropdown-popover"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button fd-dropdown__control"
           onClick={[Function]}
@@ -47,6 +49,8 @@ exports[`<Dropdown /> create dropdown component 2`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-compact-dropdown-popover"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button fd-button--compact fd-dropdown__control"
           onClick={[Function]}
@@ -78,6 +82,8 @@ exports[`<Dropdown /> create dropdown component 3`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-toolbar-dropdown-popover"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button fd-dropdown__control"
           onClick={[Function]}
@@ -110,6 +116,8 @@ exports[`<Dropdown /> create dropdown component 4`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-icon-dropdown-popover"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button sap-icon--filter fd-dropdown__control"
           onClick={[Function]}
@@ -142,6 +150,8 @@ exports[`<Dropdown /> create dropdown component 5`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-disable-dropdown-popover"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button sap-icon--filter is-disabled fd-dropdown__control"
           disabled={true}

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -2,9 +2,10 @@ import chain from 'chain-function';
 import classnames from 'classnames';
 import keycode from 'keycode';
 import Popper from '../utils/_Popper';
-import { POPPER_PLACEMENTS } from '../utils/constants';
 import PropTypes from 'prop-types';
+import shortId from '../utils/shortId';
 import withStyles from '../utils/WithStyles/WithStyles';
+import { POPOVER_TYPES, POPPER_PLACEMENTS } from '../utils/constants';
 import React, { Component } from 'react';
 
 class Popover extends Component {
@@ -14,6 +15,10 @@ class Popover extends Component {
         this.state = {
             isExpanded: false
         };
+
+        //A generated shortId as fallback, incase props.popperProps.id is unset.
+        //This ID binds the popover and it's control by 'aria-controls'.
+        this.ariaControls = shortId.generate();
     }
 
     isButton = (node) => {
@@ -71,12 +76,19 @@ class Popover extends Component {
             className,
             placement,
             popperProps,
+            type,
             ...rest
         } = this.props;
 
         let onClickFunctions = this.triggerBody;
         if (control.props.onClick) {
             onClickFunctions = chain(this.triggerBody, control.props.onClick);
+        }
+
+        let newPopperProps = !!popperProps ? popperProps : {};
+        // eslint-disable-next-line no-undefined
+        if (newPopperProps.id === undefined || newPopperProps.id === null) {
+            Object.assign(newPopperProps, { id: this.ariaControls });
         }
 
         let controlProps = {
@@ -88,7 +100,9 @@ class Popover extends Component {
                 ...controlProps,
                 tabIndex: 0,
                 role: 'button',
-                'aria-haspopup': true,
+                'aria-controls': newPopperProps.id,
+                'aria-expanded': this.state.isExpanded,
+                'aria-haspopup': !!type ? type : true,
                 onKeyPress: (event) => this.handleKeyPress(event, control, onClickFunctions)
             };
         }
@@ -106,7 +120,7 @@ class Popover extends Component {
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleOutsideClick, onEscapeKey)}
                     popperPlacement={placement}
-                    popperProps={popperProps}
+                    popperProps={newPopperProps}
                     referenceClassName='fd-popover__control'
                     referenceComponent={referenceComponent}
                     show={this.state.isExpanded && !disabled}
@@ -132,6 +146,7 @@ Popover.propTypes = {
     noArrow: PropTypes.bool,
     placement: PropTypes.oneOf(POPPER_PLACEMENTS),
     popperProps: PropTypes.object,
+    type: PropTypes.oneOf(POPOVER_TYPES),
     onClickOutside: PropTypes.func,
     onEscapeKey: PropTypes.func
 };
@@ -150,7 +165,8 @@ Popover.propDescriptions = {
     placement: 'Initial position of the `body` (overlay) related to the `control`.',
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
     onClickOutside: 'Callback for consumer clicking outside of popover body.',
-    onEscapeKey: 'Callback when escape key is pressed when popover body is visible.'
+    onEscapeKey: 'Callback when escape key is pressed when popover body is visible.',
+    type: 'Indicates the type of popup - "dialog", "grid", "listbox", "menu", or "tree". This value is attached to aria-haspopup and is useful to assistive tech.'
 };
 
 export { Popover as __Popover };

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -85,11 +85,7 @@ class Popover extends Component {
             onClickFunctions = chain(this.triggerBody, control.props.onClick);
         }
 
-        let newPopperProps = !!popperProps ? popperProps : {};
-        // eslint-disable-next-line no-undefined
-        if (newPopperProps.id === undefined || newPopperProps.id === null) {
-            Object.assign(newPopperProps, { id: this.ariaControls });
-        }
+        const id = popperProps.id || this.ariaControls;
 
         let controlProps = {
             onClick: onClickFunctions
@@ -100,7 +96,7 @@ class Popover extends Component {
                 ...controlProps,
                 tabIndex: 0,
                 role: 'button',
-                'aria-controls': newPopperProps.id,
+                'aria-controls': id,
                 'aria-expanded': this.state.isExpanded,
                 'aria-haspopup': !!type ? type : true,
                 onKeyPress: (event) => this.handleKeyPress(event, control, onClickFunctions)
@@ -120,7 +116,7 @@ class Popover extends Component {
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleOutsideClick, onEscapeKey)}
                     popperPlacement={placement}
-                    popperProps={newPopperProps}
+                    popperProps={{ ...popperProps, id }}
                     referenceClassName='fd-popover__control'
                     referenceComponent={referenceComponent}
                     show={this.state.isExpanded && !disabled}
@@ -152,6 +148,7 @@ Popover.propTypes = {
 };
 
 Popover.defaultProps = {
+    popperProps: {},
     onClickOutside: () => {},
     onEscapeKey: () => {}
 };
@@ -166,7 +163,7 @@ Popover.propDescriptions = {
     popperProps: 'Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a>.',
     onClickOutside: 'Callback for consumer clicking outside of popover body.',
     onEscapeKey: 'Callback when escape key is pressed when popover body is visible.',
-    type: 'Indicates the type of popup - "dialog", "grid", "listbox", "menu", or "tree". This value is attached to aria-haspopup and is useful to assistive tech.'
+    type: 'Indicates the type of popup - "dialog", "grid", "listbox", "menu", or "tree". This value is attached to aria-haspopup and is useful to assistive tech. Defaulted to boolean true.'
 };
 
 export { Popover as __Popover };

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -16,9 +16,9 @@ class Popover extends Component {
             isExpanded: false
         };
 
-        //A generated shortId as fallback, incase props.popperProps.id is unset.
-        //This ID binds the popover and it's control by 'aria-controls'.
-        this.ariaControls = shortId.generate();
+        //A generated shortId as fallback, in case props.popperProps.id is unset.
+        //This ID binds the popover and its control by 'aria-controls'.
+        this.popoverId = shortId.generate();
     }
 
     isButton = (node) => {
@@ -85,7 +85,7 @@ class Popover extends Component {
             onClickFunctions = chain(this.triggerBody, control.props.onClick);
         }
 
-        const id = popperProps.id || this.ariaControls;
+        const id = popperProps.id || this.popoverId;
 
         let controlProps = {
             onClick: onClickFunctions

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -19,7 +19,7 @@ describe('<Popover />', () => {
                     </Menu.List>
                 </Menu>
             }
-            control={<Icon glyph='cart' size='xl' />} />
+            control={<Icon glyph='cart' size='xl' />} popperProps={{ id: 'fd-default-popover' }} />
     );
 
     const popOverDisabled = (
@@ -36,7 +36,7 @@ describe('<Popover />', () => {
             }
             className='blue'
             control={<Icon glyph='cart' size='xl' />}
-            disabled />
+            disabled popperProps={{ id: 'fd-disabled-popover' }} />
     );
 
     const popOverWithAlignment = (
@@ -52,7 +52,7 @@ describe('<Popover />', () => {
                 </Menu>
             }
             control={<Icon glyph='cart' size='xl' />}
-            placement='right' />
+            placement='right' popperProps={{ id: 'fd-aligned-popover' }} />
     );
 
     const popOverNoArrow = (
@@ -68,7 +68,7 @@ describe('<Popover />', () => {
                 </Menu>
             }
             control={<Icon glyph='cart' size='xl' />}
-            noArrow />
+            noArrow popperProps={{ id: 'fd-arrowless-popover' }} />
     );
 
     const popOverDisableEdgeDetection = (
@@ -84,7 +84,7 @@ describe('<Popover />', () => {
                 </Menu>
             }
             control={<Icon glyph='cart' size='xl' />}
-            disableEdgeDetection />
+            disableEdgeDetection popperProps={{ id: 'fd-edge-undetected-popover' }} />
     );
 
     test('create Popover', () => {

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -190,11 +190,47 @@ describe('<Popover />', () => {
             expect(button.props().tabIndex).toEqual(0);
         });
 
-        test('adds aria-haspopup to the control', () => {
-            const wrapper = mountComponentWithStyles(popOver);
-            const button = wrapper.find('Icon').at(0);
-
+        test('adds appropriate aria-haspopup to the control', () => {
+            //check unset type
+            let wrapper = mountComponentWithStyles(popOver);
+            let button = wrapper.find('Icon').at(0);
             expect(button.props()['aria-haspopup']).toEqual(true);
+
+            //check valid string type
+            const dialogPopover = React.cloneElement(popOver, { type: 'dialog' });
+            wrapper = mountComponentWithStyles(dialogPopover);
+            button = wrapper.find('Icon').at(0);
+            expect(button.props()['aria-haspopup']).toEqual('dialog');
+        });
+
+        test('adds appropriate aria-expanded to the control, and updates it on state change', () => {
+            const wrapper = mountComponentWithStyles(popOver);
+            let button = wrapper.find('Icon').at(0);
+            expect(button.props()['aria-expanded']).toEqual(false);
+            wrapper.setState({ isExpanded: true }, () => {
+                button = wrapper.find('Icon').at(0);
+                expect(button.getDOMNode().getAttribute('aria-expanded')).toEqual('true');
+            });
+            wrapper.setState({ isExpanded: false }, () => {
+                button = wrapper.find('Icon').at(0);
+                expect(button.getDOMNode().getAttribute('aria-expanded')).toEqual('false');
+            });
+        });
+
+        test('adds appropriate aria-controls to the control', () => {
+            let wrapper = mountComponentWithStyles(popOver);
+            let button = wrapper.find('Icon').at(0);
+            expect(button.props()['aria-controls']).toEqual('fd-default-popover');
+
+            //check undefined popperProps
+            // eslint-disable-next-line no-undefined
+            const propLessPopover = React.cloneElement(popOver, { popperProps: undefined } );
+            wrapper = mountComponentWithStyles(propLessPopover);
+            wrapper.setState({ isExpanded: true }, () => {
+                const popoverContentId = document.querySelector('div.fd-popover__popper').id;
+                button = wrapper.find('Icon').at(0);
+                expect(button.props()['aria-controls']).toEqual(popoverContentId);
+            });
         });
 
         test('adds a role of button to the control', () => {

--- a/src/Popover/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__snapshots__/Popover.test.js.snap
@@ -13,6 +13,8 @@ exports[`<Popover /> create Popover 1`] = `
       className="fd-popover__control"
     >
       <span
+        aria-controls="fd-default-popover"
+        aria-expanded={false}
         aria-haspopup={true}
         className="sap-icon--cart sap-icon--xl"
         onClick={[Function]}
@@ -38,6 +40,8 @@ exports[`<Popover /> create Popover 2`] = `
       className="fd-popover__control"
     >
       <span
+        aria-controls="fd-disabled-popover"
+        aria-expanded={false}
         aria-haspopup={true}
         className="sap-icon--cart sap-icon--xl"
         onClick={[Function]}
@@ -63,6 +67,8 @@ exports[`<Popover /> create Popover 3`] = `
       className="fd-popover__control"
     >
       <span
+        aria-controls="fd-aligned-popover"
+        aria-expanded={false}
         aria-haspopup={true}
         className="sap-icon--cart sap-icon--xl"
         onClick={[Function]}
@@ -88,6 +94,8 @@ exports[`<Popover /> create Popover 4`] = `
       className="fd-popover__control"
     >
       <span
+        aria-controls="fd-arrowless-popover"
+        aria-expanded={false}
         aria-haspopup={true}
         className="sap-icon--cart sap-icon--xl"
         onClick={[Function]}

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -7,8 +7,8 @@ import {
     withKnobs
 } from '@storybook/addon-knobs';
 
-const bodyContent = (
-    <Menu>
+const someMenu = (
+    <Menu style={{ maxWidth: '10em', padding: '1em' }}>
         <Menu.List>
             <Menu.Item url='#'>Option 1</Menu.Item>
             <Menu.Item url='#'>Option 2</Menu.Item>
@@ -18,14 +18,12 @@ const bodyContent = (
     </Menu>
 );
 
-const someText = <p style={{ padding: '0.5em' }}>This is a simple popover.</p>;
-
 storiesOf('Components|Popover', module)
     .addDecorator(withKnobs)
     .add('Default', () => (
         <Popover
-            body={bodyContent}
-            control={<Button glyph='navigation-up-arrow' option='light' />} />
+            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' />}
+            type='menu' />
     ))
     .add('Placement', () => (
         <>
@@ -51,21 +49,21 @@ storiesOf('Components|Popover', module)
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
-                            placement='top-start' />
+                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
+                            placement='top-start'
+                            type='menu' />
                     </td>
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
-                            placement='top' />
+                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
+                            placement='top'
+                            type='menu' />
                     </td>
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
-                            placement='top-end' />
+                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
+                            placement='top-end'
+                            type='menu' />
                     </td>
                     <td />
                 </tr>
@@ -76,39 +74,18 @@ storiesOf('Components|Popover', module)
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
-                            placement='left-start' />
+                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
+                            placement='left-start'
+                            type='menu' />
                     </td>
                     <td />
                     <td />
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
-                            placement='right-start' />
-                    </td>
-                </tr>
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
-                            placement='left' />
-                    </td>
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
-                            placement='right' />
+                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
+                            placement='right-start'
+                            type='menu' />
                     </td>
                 </tr>
                 <tr>
@@ -118,18 +95,39 @@ storiesOf('Components|Popover', module)
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
-                            placement='left-end' />
+                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
+                            placement='left'
+                            type='menu' />
                     </td>
                     <td />
                     <td />
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
-                            placement='right-end' />
+                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
+                            placement='right'
+                            type='menu' />
+                    </td>
+                </tr>
+                <tr>
+                    <td />
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
+                            placement='left-end'
+                            type='menu' />
+                    </td>
+                    <td />
+                    <td />
+                    <td />
+                    <td>
+                        <Popover
+                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
+                            placement='right-end'
+                            type='menu' />
                     </td>
                 </tr>
                 <tr>
@@ -140,21 +138,21 @@ storiesOf('Components|Popover', module)
                     <td />
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
-                            placement='bottom-start' />
+                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
+                            placement='bottom-start'
+                            type='menu' />
                     </td>
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
-                            placement='bottom' />
+                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
+                            placement='bottom'
+                            type='menu' />
                     </td>
                     <td>
                         <Popover
-                            body={someText}
-                            control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
-                            placement='bottom-end' />
+                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
+                            placement='bottom-end'
+                            type='menu' />
                     </td>
                     <td />
                 </tr>
@@ -170,19 +168,19 @@ storiesOf('Components|Popover', module)
     ))
     .add('disable styles', () => (
         <Popover
-            body={bodyContent}
-            control={<Button
+            body={someMenu} control={<Button
                 disableStyles
                 glyph='navigation-up-arrow'
                 option='light' />}
-            disableStyles />
+            disableStyles
+            type='menu' />
     ))
     .add('custom styles', () => (
         <Popover
-            body={bodyContent}
-            control={<Button
+            body={someMenu} control={<Button
                 disableStyles
                 glyph='navigation-up-arrow'
                 option='light' />}
-            customStyles={require('../../utils/WithStyles/customStylesTest.css')} />
+            customStyles={require('../../utils/WithStyles/customStylesTest.css')}
+            type='menu' />
     ));

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -34,135 +34,138 @@ storiesOf('Components|Popover', module)
             }
             ` }} />
             <table>
-                {/* start top padding for popover */}
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                {/* end top padding for popover */}
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
-                            placement='top-start'
-                            type='menu' />
-                    </td>
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
-                            placement='top'
-                            type='menu' />
-                    </td>
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
-                            placement='top-end'
-                            type='menu' />
-                    </td>
-                    <td />
-                </tr>
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
-                            placement='left-start'
-                            type='menu' />
-                    </td>
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
-                            placement='right-start'
-                            type='menu' />
-                    </td>
-                </tr>
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
-                            placement='left'
-                            type='menu' />
-                    </td>
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
-                            placement='right'
-                            type='menu' />
-                    </td>
-                </tr>
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
-                            placement='left-end'
-                            type='menu' />
-                    </td>
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
-                            placement='right-end'
-                            type='menu' />
-                    </td>
-                </tr>
-                <tr>
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td />
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
-                            placement='bottom-start'
-                            type='menu' />
-                    </td>
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
-                            placement='bottom'
-                            type='menu' />
-                    </td>
-                    <td>
-                        <Popover
-                            body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
-                            placement='bottom-end'
-                            type='menu' />
-                    </td>
-                    <td />
-                </tr>
-                {/* start bottom padding for popover */}
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                <tr ><td>&nbsp;</td></tr>
-                {/* end bottom padding for popover */}
+                <tbody>
+                    {/* start top padding for popover */}
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    {/* end top padding for popover */}
+                    <tr>
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-Start</Button>}
+                                placement='top-start'
+                                popperProps={{ id: 'fd-top-start-popover-placement-story' }}
+                                type='menu' />
+                        </td>
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top</Button>}
+                                placement='top'
+                                type='menu' />
+                        </td>
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-up-arrow' option='light' >Pop to Top-End</Button>}
+                                placement='top-end'
+                                type='menu' />
+                        </td>
+                        <td />
+                    </tr>
+                    <tr>
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-Start</Button>}
+                                placement='left-start'
+                                type='menu' />
+                        </td>
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-Top</Button>}
+                                placement='right-start'
+                                type='menu' />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left</Button>}
+                                placement='left'
+                                type='menu' />
+                        </td>
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right</Button>}
+                                placement='right'
+                                type='menu' />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-left-arrow' option='light' >Pop to Left-End</Button>}
+                                placement='left-end'
+                                type='menu' />
+                        </td>
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-right-arrow' option='light' >Pop to Right-End</Button>}
+                                placement='right-end'
+                                type='menu' />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td />
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-Start</Button>}
+                                placement='bottom-start'
+                                type='menu' />
+                        </td>
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom</Button>}
+                                placement='bottom'
+                                type='menu' />
+                        </td>
+                        <td>
+                            <Popover
+                                body={someMenu} control={<Button glyph='navigation-down-arrow' option='light' >Pop to Bottom-End</Button>}
+                                placement='bottom-end'
+                                type='menu' />
+                        </td>
+                        <td />
+                    </tr>
+                    {/* start bottom padding for popover */}
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    <tr ><td>&nbsp;</td></tr>
+                    {/* end bottom padding for popover */}
+                </tbody>
             </table>
         </>
     ))

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -158,7 +158,8 @@ class Shellbar extends Component {
                                     </button>
                                 }
                                 disableStyles={disableStyles}
-                                noArrow />
+                                noArrow
+                                popperProps={{ id: 'fd-shellbar-product-popover' }} />
                         </div>
                     )}
                     {subtitle && <div className='fd-shellbar__subtitle'>{subtitle}</div>}
@@ -208,7 +209,8 @@ class Shellbar extends Component {
                                                     </Button>
                                                 }
                                                 disableStyles={disableStyles}
-                                                placement='bottom-end' />
+                                                placement='bottom-end'
+                                                popperProps={{ id: `fd-shellbar-actions-popover-${index}` }} />
                                         ) : (
                                             <Button
                                                 aria-label={action.label}
@@ -256,7 +258,8 @@ class Shellbar extends Component {
                                     </div>
                                 }
                                 disableStyles={disableStyles}
-                                placement='bottom-end' />
+                                placement='bottom-end'
+                                popperProps={{ id: 'fd-shellbar-notifications-popover' }} />
                         ) : (
                             <div className='fd-shellbar__action fd-shellbar__action--desktop'>
                                 <Button
@@ -332,7 +335,8 @@ class Shellbar extends Component {
                                     </div>
                                 }
                                 disableStyles={disableStyles}
-                                placement='bottom-end' />
+                                placement='bottom-end'
+                                popperProps={{ id: 'fd-shellbar-mobile-action-popover' }} />
                         </div>
                     }
                     {profile && (
@@ -384,7 +388,8 @@ class Shellbar extends Component {
                                         )
                                     }
                                     disableStyles={disableStyles}
-                                    placement='bottom-end' />
+                                    placement='bottom-end'
+                                    popperProps={{ id: 'fd-shellbar-profile-popover' }} />
                             </div>
                         </div>
                     )}
@@ -420,7 +425,8 @@ class Shellbar extends Component {
                                         glyph='grid' />}
                                     disableEdgeDetection
                                     disableStyles={disableStyles}
-                                    placement='bottom-end' />
+                                    placement='bottom-end'
+                                    popperProps={{ id: 'fd-shellbar-product-switcher-popover' }} />
                             </div>
                         </div>
                     )}

--- a/src/Shellbar/__snapshots__/Shellbar.test.js.snap
+++ b/src/Shellbar/__snapshots__/Shellbar.test.js.snap
@@ -42,6 +42,8 @@ exports[`<Shellbar /> create shellbar 1`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
                 onClick={[Function]}
@@ -102,6 +104,8 @@ exports[`<Shellbar /> create shellbar 2`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
                 onClick={[Function]}
@@ -150,6 +154,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-product-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-product-menu__control"
               onClick={[Function]}
@@ -245,6 +251,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-actions-popover-0"
+              aria-expanded={false}
               aria-haspopup={true}
               aria-label="Settings"
               className="fd-button sap-icon--settings fd-shellbar__button"
@@ -276,6 +284,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
           className="fd-popover__control"
         >
           <div
+            aria-controls="fd-shellbar-notifications-popover"
+            aria-expanded={false}
             aria-haspopup={true}
             className="fd-shellbar__action fd-shellbar__action--desktop"
             onClick={[Function]}
@@ -313,6 +323,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
             className="fd-popover__control"
           >
             <div
+              aria-controls="fd-shellbar-mobile-action-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-shellbar-collapse--control"
               onClick={[Function]}
@@ -355,6 +367,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
                 onClick={[Function]}
@@ -387,6 +401,8 @@ exports[`<Shellbar /> create shellbar 3`] = `
               className="fd-popover__control"
             >
               <button
+                aria-controls="fd-shellbar-product-switcher-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-button sap-icon--grid fd-shellbar__button"
                 onClick={[Function]}
@@ -433,6 +449,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-product-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-product-menu__control"
               onClick={[Function]}
@@ -528,6 +546,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-actions-popover-0"
+              aria-expanded={false}
               aria-haspopup={true}
               aria-label="Settings"
               className="fd-button sap-icon--settings fd-shellbar__button"
@@ -559,6 +579,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
           className="fd-popover__control"
         >
           <div
+            aria-controls="fd-shellbar-notifications-popover"
+            aria-expanded={false}
             aria-haspopup={true}
             className="fd-shellbar__action fd-shellbar__action--desktop"
             onClick={[Function]}
@@ -589,6 +611,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
             className="fd-popover__control"
           >
             <div
+              aria-controls="fd-shellbar-mobile-action-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-shellbar-collapse--control"
               onClick={[Function]}
@@ -631,6 +655,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
                 onClick={[Function]}
@@ -663,6 +689,8 @@ exports[`<Shellbar /> create shellbar 4`] = `
               className="fd-popover__control"
             >
               <button
+                aria-controls="fd-shellbar-product-switcher-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-button sap-icon--grid fd-shellbar__button"
                 onClick={[Function]}
@@ -709,6 +737,8 @@ exports[`<Shellbar /> create shellbar 5`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-product-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-product-menu__control"
               onClick={[Function]}
@@ -817,6 +847,8 @@ exports[`<Shellbar /> create shellbar 5`] = `
           className="fd-popover__control"
         >
           <div
+            aria-controls="fd-shellbar-notifications-popover"
+            aria-expanded={false}
             aria-haspopup={true}
             className="fd-shellbar__action fd-shellbar__action--desktop"
             onClick={[Function]}
@@ -847,6 +879,8 @@ exports[`<Shellbar /> create shellbar 5`] = `
             className="fd-popover__control"
           >
             <div
+              aria-controls="fd-shellbar-mobile-action-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-shellbar-collapse--control"
               onClick={[Function]}
@@ -889,6 +923,8 @@ exports[`<Shellbar /> create shellbar 5`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-has-background-color-accent-8"
                 onClick={[Function]}
@@ -921,6 +957,8 @@ exports[`<Shellbar /> create shellbar 5`] = `
               className="fd-popover__control"
             >
               <button
+                aria-controls="fd-shellbar-product-switcher-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-button sap-icon--grid fd-shellbar__button"
                 onClick={[Function]}
@@ -967,6 +1005,8 @@ exports[`<Shellbar /> create shellbar 6`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-product-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-product-menu__control"
               onClick={[Function]}
@@ -1062,6 +1102,8 @@ exports[`<Shellbar /> create shellbar 6`] = `
             className="fd-popover__control"
           >
             <button
+              aria-controls="fd-shellbar-actions-popover-0"
+              aria-expanded={false}
               aria-haspopup={true}
               aria-label="Settings"
               className="fd-button sap-icon--settings fd-shellbar__button"
@@ -1112,6 +1154,8 @@ exports[`<Shellbar /> create shellbar 6`] = `
             className="fd-popover__control"
           >
             <div
+              aria-controls="fd-shellbar-mobile-action-popover"
+              aria-expanded={false}
               aria-haspopup={true}
               className="fd-shellbar-collapse--control"
               onClick={[Function]}
@@ -1154,6 +1198,8 @@ exports[`<Shellbar /> create shellbar 6`] = `
               className="fd-popover__control"
             >
               <span
+                aria-controls="fd-shellbar-profile-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail"
                 onClick={[Function]}
@@ -1189,6 +1235,8 @@ exports[`<Shellbar /> create shellbar 6`] = `
               className="fd-popover__control"
             >
               <button
+                aria-controls="fd-shellbar-product-switcher-popover"
+                aria-expanded={false}
                 aria-haspopup={true}
                 className="fd-button sap-icon--grid fd-shellbar__button"
                 onClick={[Function]}

--- a/src/Tile/Tile.test.js
+++ b/src/Tile/Tile.test.js
@@ -52,7 +52,8 @@ describe('<Tile />', () => {
                             </Menu.List>
                         </Menu>
                     }
-                    control={<Button glyph='vertical-grip' type='standard' />} />
+                    control={<Button glyph='vertical-grip' type='standard' />}
+                    popperProps={{ id: 'fd-tile-actions' }} />
             </Tile.Actions>
         </Tile>
     );
@@ -84,7 +85,8 @@ describe('<Tile />', () => {
                             </Menu.List>
                         </Menu>
                     }
-                    control={<Button glyph='vertical-grip' type='standard' />} />
+                    control={<Button glyph='vertical-grip' type='standard' />}
+                    popperProps={{ id: 'fd-tile-actions-no-class' }} />
             </Tile.Actions>
         </Tile>
     );

--- a/src/Tile/TileActions.test.js
+++ b/src/Tile/TileActions.test.js
@@ -20,7 +20,8 @@ describe('<Tile.Actions />', () => {
                         </Menu.List>
                     </Menu>
                 }
-                control={<Button glyph='vertical-grip' type='standard' />} />
+                control={<Button glyph='vertical-grip' type='standard' />}
+                popperProps={{ id: 'fd-tile-actions' }} />
         </Tile.Actions>
     );
 

--- a/src/Tile/__snapshots__/Tile.test.js.snap
+++ b/src/Tile/__snapshots__/Tile.test.js.snap
@@ -95,6 +95,8 @@ exports[`<Tile /> create tile component 4`] = `
           className="fd-popover__control"
         >
           <button
+            aria-controls="fd-tile-actions"
+            aria-expanded={false}
             aria-haspopup={true}
             className="fd-button fd-button--standard sap-icon--vertical-grip"
             onClick={[Function]}
@@ -164,6 +166,8 @@ exports[`<Tile /> create tile component 6`] = `
           className="fd-popover__control"
         >
           <button
+            aria-controls="fd-tile-actions-no-class"
+            aria-expanded={false}
             aria-haspopup={true}
             className="fd-button fd-button--standard sap-icon--vertical-grip"
             onClick={[Function]}

--- a/src/Tile/__snapshots__/TileActions.test.js.snap
+++ b/src/Tile/__snapshots__/TileActions.test.js.snap
@@ -16,6 +16,8 @@ exports[`<Tile.Actions /> create Tile.Actions component 1`] = `
         className="fd-popover__control"
       >
         <button
+          aria-controls="fd-tile-actions"
+          aria-expanded={false}
           aria-haspopup={true}
           className="fd-button fd-button--standard sap-icon--vertical-grip"
           onClick={[Function]}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -108,6 +108,14 @@ export const TOGGLE_SIZES = [
     'l'
 ];
 
+export const POPOVER_TYPES = [
+    'dialog',
+    'grid',
+    'listbox',
+    'menu',
+    'tree'
+];
+
 export const POPPER_PLACEMENTS = [
     'bottom-start',
     'bottom',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -109,6 +109,7 @@ export const TOGGLE_SIZES = [
 ];
 
 export const POPOVER_TYPES = [
+    true,
     'dialog',
     'grid',
     'listbox',


### PR DESCRIPTION
### Description
Add following aria attributes to popover control/target.
* [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls)
* [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded)
* [aria-haspopup](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup)

This allows screen readers and other assistive technologies to understand the popover interactions semantically.

fixes #791 