### PR TITLE
fix: layoutgrid no-gap typo fix

### DIFF
--- a/src/LayoutGrid/LayoutGrid.js
+++ b/src/LayoutGrid/LayoutGrid.js
@@ -9,7 +9,7 @@ const LayoutGrid = React.forwardRef(({ nogap, cols, children, className, colSpan
     const layoutGridClasses = classnames(
         'fd-layout-grid',
         {
-            'fd-layout-grid--nogap': nogap,
+            'fd-layout-grid--no-gap': nogap,
             [`fd-layout-grid--col-${cols}`]: !!cols
         },
         className

--- a/src/LayoutGrid/__snapshots__/LayoutGrid.test.js.snap
+++ b/src/LayoutGrid/__snapshots__/LayoutGrid.test.js.snap
@@ -118,7 +118,7 @@ exports[`<LayoutGrid /> layoutGrid snapshots 2`] = `
 
 exports[`<LayoutGrid /> layoutGrid snapshots 3`] = `
 <div
-  className="fd-layout-grid fd-layout-grid--nogap"
+  className="fd-layout-grid fd-layout-grid--no-gap"
 >
   <div
     className="fd-panel"

--- a/src/LayoutGrid/__stories__/LayoutGrid.stories.js
+++ b/src/LayoutGrid/__stories__/LayoutGrid.stories.js
@@ -28,4 +28,11 @@ storiesOf('Components|LayoutGrid', module)
             <div>Default2</div>
             <div>Default3</div>
         </LayoutGrid>
+    ))
+    .add('nogap', () => (
+        <LayoutGrid nogap>
+            <div>Default1</div>
+            <div>Default2</div>
+            <div>Default3</div>
+        </LayoutGrid>
     ));


### PR DESCRIPTION
### Description
LayoutGrid class `fd-layout-grid--no-gap` had typo, `fd-layout-grid--nogap`


![Screen Shot 2019-11-22 at 2 51 24 PM](https://user-images.githubusercontent.com/29607818/69466148-0ca9b680-0d38-11ea-900a-85cc8bf4fe6b.png)


fixes #802 