### PR TITLE
feat: allow adding classes to both modal body and backdrop

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -35,8 +35,8 @@ class Modal extends Component {
         const {
             actions,
             bodyProps,
+            backdropClassName,
             children,
-            className,
             closeProps,
             contentProps,
             disableStyles,
@@ -44,6 +44,7 @@ class Modal extends Component {
             headingLevel,
             footerProps,
             localizedText,
+            modalClassName,
             onClose,
             show,
             titleProps,
@@ -51,10 +52,15 @@ class Modal extends Component {
             ...rest
         } = this.props;
 
-        const modalClasses = classnames(
+        const backdropClasses = classnames(
             'fd-overlay',
             'fd-overlay--modal',
-            className
+            backdropClassName
+        );
+
+        const modalClasses = classnames(
+            'modal-demo-bg',
+            modalClassName
         );
 
         const HeadingTag = `h${headingLevel}`;
@@ -64,9 +70,9 @@ class Modal extends Component {
         }
 
         return ReactDOM.createPortal(
-            <FocusLock as='div' className={modalClasses}
+            <FocusLock as='div' className={backdropClasses}
                 lockProps={{ ...rest }}>
-                <div className='modal-demo-bg'>
+                <div className={modalClasses}>
                     <span data-autofocus tabIndex='-1' />
                     <div
                         aria-label={title}
@@ -116,9 +122,9 @@ Modal.displayName = 'Modal';
 Modal.propTypes = {
     title: PropTypes.string.isRequired,
     actions: PropTypes.node,
+    backdropClassName: PropTypes.string,
     bodyProps: PropTypes.object,
     children: PropTypes.node,
-    className: PropTypes.string,
     closeProps: PropTypes.object,
     contentProps: PropTypes.object,
     customStyles: PropTypes.object,
@@ -129,6 +135,7 @@ Modal.propTypes = {
     localizedText: CustomPropTypes.i18n({
         closeButton: PropTypes.string
     }),
+    modalClassName: PropTypes.string,
     show: PropTypes.bool,
     titleProps: PropTypes.object,
     onClose: PropTypes.func
@@ -144,11 +151,13 @@ Modal.defaultProps = {
 
 Modal.propDescriptions = {
     actions: 'Node(s) to render within the footer of the dialog.',
+    backdropClassName: 'CSS class(es) to add to the modal backdrop.',
     bodyProps: 'Additional props to be spread to the body section of the dialog.',
     closeProps: 'Additional props to be spread to the close `<button>` element.',
     contentProps: 'Additional props to be spread to the content section of the dialog.',
     footerProps: 'Additional props to be spread to the footer of the dialog.',
     headerProps: 'Additional props to be spread to the header of the dialog.',
+    modalClassName: 'CSS class(es) to add to the modal body.',
     localizedTextShape: {
         closeButton: 'Aria-label for <button> element.'
     },

--- a/src/Modal/Modal.test.js
+++ b/src/Modal/Modal.test.js
@@ -10,7 +10,7 @@ describe('<Modal />', () => {
     const modalFormTitle = 'Invite User';
     const infoModal = (
         <Modal
-            className='blue'
+            backdropClassName='blue'
             onClose={mockOnClose}
             show={bShow}
             title={modalInfoTitle}>
@@ -250,6 +250,22 @@ describe('<Modal />', () => {
                 component.find('button').getDOMNode().attributes['data-sample']
                     .value
             ).toBe('Sample Button');
+        });
+    });
+
+    describe('Custom class names', () => {
+        test('should allow classes to be added to backdrop', () => {
+            component = mount(<Modal backdropClassName='sample' show
+                title='Title' />);
+
+            expect(component.find('div.fd-overlay--modal').hasClass('sample')).toBe(true);
+        });
+
+        test('should allow classes to be added to modal', () => {
+            component = mount(<Modal modalClassName='sample' show
+                title='Title' />);
+
+            expect(component.find('div.modal-demo-bg').hasClass('sample')).toBe(true);
         });
     });
 });


### PR DESCRIPTION
### Description
* Improve `Modal` by allowing the user to add CSS classes to modal body. Previously, it was possible to add the class only to the backdrop. It could be worked around as described [here](https://github.com/SAP/fundamental-react/issues/800#issue-527365760).
* I've changed the current prop name from `className` to `backdropClassName` to avoid confusion.

fixes #800