### PR TITLE
fix: provided a 'defaultValue' prop to the DatePicker

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -10,12 +10,14 @@ import React, { Component } from 'react';
 class DatePicker extends Component {
     constructor(props) {
         super(props);
-
+        const ISO_DATE_FORMAT = 'YYYY-MM-DD';
+        const formattedDate = props.defaultValue.length > 0 ?
+            moment(props.defaultValue, ISO_DATE_FORMAT).format(this.getLocaleDateFormat()) : '';
         this.state = {
             hidden: true,
-            selectedDate: null,
+            selectedDate: formattedDate.length === 0 ? null : moment(formattedDate, this.getLocaleDateFormat()),
             arrSelectedDates: [],
-            formattedDate: ''
+            formattedDate
         };
 
         this.calendarRef = React.createRef();
@@ -61,7 +63,7 @@ class DatePicker extends Component {
     }
 
     validateDates = () => {
-        const longDateFormat = moment.localeData(this.props.locale).longDateFormat('L');
+        const longDateFormat = this.getLocaleDateFormat();
 
         if (this.props.enableRangeSelection) {
             const dateRange = this.state.formattedDate.split('-');
@@ -114,7 +116,7 @@ class DatePicker extends Component {
     };
 
     updateDate = (date) => {
-        const longDateFormat = moment.localeData(this.props.locale).longDateFormat('L');
+        const longDateFormat = this.getLocaleDateFormat();
 
         if (this.props.enableRangeSelection) {
             let formatDate = date[0].format(longDateFormat);
@@ -132,6 +134,8 @@ class DatePicker extends Component {
             });
         }
     }
+
+    getLocaleDateFormat = () => moment.localeData(this.props.locale).longDateFormat('L');
 
     _handleBlur = () => {
         this.props.onBlur({
@@ -175,7 +179,7 @@ class DatePicker extends Component {
                                 onChange={this.modifyDate}
                                 onClick={() => this.openCalendar('input')}
                                 onKeyPress={this.sendUpdate}
-                                placeholder={moment.localeData(this.props.locale).longDateFormat('L')}
+                                placeholder={this.getLocaleDateFormat()}
                                 value={this.state.formattedDate} />
                             <InputGroup.Addon isButton>
                                 <Button {...buttonProps}
@@ -221,6 +225,7 @@ DatePicker.propTypes = {
     ...Calendar.basePropTypes,
     buttonProps: PropTypes.object,
     compact: PropTypes.bool,
+    defaultValue: PropTypes.string,
     enableRangeSelection: PropTypes.bool,
     inputProps: PropTypes.object,
     locale: PropTypes.string,
@@ -228,12 +233,14 @@ DatePicker.propTypes = {
 };
 
 DatePicker.defaultProps = {
+    defaultValue: '',
     locale: 'en',
     onBlur: () => {}
 };
 
 DatePicker.propDescriptions = {
     ...Calendar.propDescriptions,
+    defaultValue: 'Default value to be shown in the Datepicker. The only accepted format is the ISO format, i.e. YYYY-MM-DD',
     enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).',
     locale: 'Language code to set the locale.',
     onBlur: 'Callback function for onBlur events. In the object returned, `date` is the date object and `formattedDate` is the formatted date.'

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -11,6 +11,7 @@ describe('<DatePicker />', () => {
     const compactDatePicker = <DatePicker className='blue' compact />;
     const rangeDatePicker = <DatePicker enableRangeSelection />;
     const compactRangeDatepicker = <DatePicker compact enableRangeSelection />;
+    const prePopulatedDatepicker = <DatePicker defaultValue='2020-03-13' />;
     let wrapper;
 
     afterAll(() => {
@@ -289,6 +290,15 @@ describe('<DatePicker />', () => {
             .find('input[type="text"]')
             .simulate('change', { target: { value: '05/04/2018' } });
         expect(wrapper.state('formattedDate')).toEqual('05/04/2018');
+    });
+
+    test('pre-populated value for date', () => {
+        wrapper = mountComponentWithStyles(prePopulatedDatepicker);
+        expect(wrapper.state('formattedDate')).toEqual('03/13/2020');
+        wrapper
+            .find('input[type="text"]')
+            .simulate('change', { target: { value: '04/14/2020' } });
+        expect(wrapper.state('formattedDate')).toEqual('04/14/2020');
     });
 
     describe('onBlur callback', () => {


### PR DESCRIPTION
### Added the 'defaultValue' prop to the DatePicker component, where a date string can be passed in the ISO format to get a default date on the DatePicker, also includes some minor refactoring by extracting out a method out of a line of code that is repeated several times.




fixes #822