### PR TITLE
fix: Do not use defaultChecked if checked is false in Checkbox

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
+build
+lib
 !/.storybook

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -41,7 +41,7 @@ const Checkbox = React.forwardRef(({ checked, className, defaultChecked, disable
                 <input
                     {...inputProps}
                     aria-checked={getCheckStatus(checked, indeterminate)}
-                    checked={checked || defaultChecked}
+                    checked={typeof checked === 'undefined' ? defaultChecked : checked}
                     className={classes}
                     disabled={disabled}
                     id={id}

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -28,6 +28,8 @@ const Checkbox = React.forwardRef(({ checked, className, defaultChecked, disable
         'fd-checkbox'
     );
 
+    const isChecked = typeof checked === 'undefined' ? defaultChecked : checked;
+
     return (
         <FormItem
             {...props}
@@ -40,8 +42,8 @@ const Checkbox = React.forwardRef(({ checked, className, defaultChecked, disable
                 disabled={disabled}>
                 <input
                     {...inputProps}
-                    aria-checked={getCheckStatus(checked, indeterminate)}
-                    checked={typeof checked === 'undefined' ? defaultChecked : checked}
+                    aria-checked={getCheckStatus(isChecked, indeterminate)}
+                    checked={isChecked}
                     className={classes}
                     disabled={disabled}
                     id={id}

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -25,7 +25,26 @@ describe('<Checkbox />', () => {
                 onChange: () => {}
             });
 
-            expect(element.props().checked).toBe(true);
+            expect(element.find('input').props().checked).toBe(true);
+        });
+
+        test('should add checked attribute of false to override the defaultChecked', () => {
+            let element = setup({
+                checked: false,
+                defaultChecked: true,
+                onChange: () => {}
+            });
+
+            expect(element.find('input').props().checked).toBe(false);
+        });
+
+        test('should add checked attribute if defaultChecked is true', () => {
+            let element = setup({
+                defaultChecked: true,
+                onChange: () => {}
+            });
+
+            expect(element.find('input').props().checked).toBe(true);
         });
 
         test('should set disabled to true when passed', () => {
@@ -33,7 +52,7 @@ describe('<Checkbox />', () => {
                 disabled: true
             });
 
-            expect(element.props().disabled).toBe(true);
+            expect(element.find('input').props().disabled).toBe(true);
         });
 
         test('should add inline class when inline is passed', () => {

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -26,6 +26,7 @@ describe('<Checkbox />', () => {
             });
 
             expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').props()['aria-checked']).toBe('true');
         });
 
         test('should add checked attribute of false to override the defaultChecked', () => {
@@ -36,6 +37,7 @@ describe('<Checkbox />', () => {
             });
 
             expect(element.find('input').props().checked).toBe(false);
+            expect(element.find('input').props()['aria-checked']).toBe('false');
         });
 
         test('should add checked attribute if defaultChecked is true', () => {
@@ -45,6 +47,19 @@ describe('<Checkbox />', () => {
             });
 
             expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').props()['aria-checked']).toBe('true');
+        });
+
+        test('should add aria-checked attribute of "mixed" if indeterminate is true', () => {
+            let element = setup({
+                indeterminate: true,
+                checked: true,
+                defaultChecked: true,
+                onChange: () => {}
+            });
+
+            expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').props()['aria-checked']).toBe('mixed');
         });
 
         test('should set disabled to true when passed', () => {


### PR DESCRIPTION
@sjanota Thanks for the PR!  

I opened this one to get past the blocker in https://github.com/SAP/fundamental-react/pull/832 

### Description
Copied from https://github.com/SAP/fundamental-react/pull/832 

> I want to use in a controlled manner. If the checked value in Checkbox is initially set to false then defaultChecked is used instead. But as I want it to be a controlled component I never set the default value and undefined gets passed to underlying input. Because of that react assumes it's an uncontrolled component. When a user toggles the checkbox to checked an error is logged:
```
index.js:1 Warning: A component is changing an uncontrolled input of type checkbox to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components
    in input (created by Checkbox)
    in label (created by FormLabel)
    in FormLabel (created by FormLabel)
    in FormLabel (created by FormLabel)
    in FormLabel (created by Checkbox)
    in div (created by FormItem)
...
```

> Becuase checked is a boolean we need to explicitly check for undefined here.

