### PR TITLE
chore: Add tests to Checkbox for indeterminate and defaultChecked

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 build
 lib
 !/.storybook
-lib

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
+build
+lib
 !/.storybook
 lib

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -25,7 +25,31 @@ describe('<Checkbox />', () => {
                 onChange: () => {}
             });
 
-            expect(element.props().checked).toBe(true);
+            expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').props()['aria-checked']).toBe('true');
+        });
+
+        test('should add checked attribute if defaultChecked is true', () => {
+            let element = setup({
+                defaultChecked: true,
+                onChange: () => {}
+            });
+
+            expect(element.find('input').props().checked).toBe(true);
+
+            // TODO: The aria-checked does not reflect the current state of the checkbox if it is uncontrolled
+            // expect(element.find('input').props()['aria-checked']).toBe('true');
+        });
+
+        test('should add aria-checked attribute of "mixed" if indeterminate is true', () => {
+            let element = setup({
+                indeterminate: true,
+                defaultChecked: true,
+                onChange: () => {}
+            });
+
+            expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').props()['aria-checked']).toBe('mixed');
         });
 
         test('should set disabled to true when passed', () => {
@@ -33,7 +57,7 @@ describe('<Checkbox />', () => {
                 disabled: true
             });
 
-            expect(element.props().disabled).toBe(true);
+            expect(element.find('input').props().disabled).toBe(true);
         });
 
         test('should add inline class when inline is passed', () => {


### PR DESCRIPTION
# Description

We wanted to keep the unit tests that came out of this PR: https://github.com/SAP/fundamental-react/pull/849

## Note

Maybe we don't want to keep the TODO comment in the test, but I wanted to leave it in so reviewers could see the issue with using the component in an uncontrolled way.