### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,6 @@
 
 ### Versions
 **fundamental-react:**
-**fundamental-styles:**
 
 ---
 


### PR DESCRIPTION
### Description

As fundamental-styles is now a hard dependency instead of a peer dependency, we no longer need this information for issues.

fixes #issueid