### PR TITLE
fix: create modal manager, for Popover, on demand as a singleton

### DIFF
--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import Foco from 'react-foco';
+import { getModalManager } from './modalManager';
 import keycode from 'keycode';
-import { modalManager } from './modalManager';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -11,6 +11,7 @@ import { POPPER_PLACEMENTS, POPPER_SIZING_TYPES } from './constants';
 class Popper extends React.Component {
     constructor(props) {
         super(props);
+        this.modalManager = getModalManager();
     }
 
     componentDidMount() {
@@ -36,19 +37,19 @@ class Popper extends React.Component {
     _onShow() {
         const container = ReactDOM.findDOMNode(this) || document.body;
 
-        modalManager.add(this, container);
+        this.modalManager.add(this, container);
 
         document.addEventListener('keydown', this._handleDocumentKeyDown);
     }
 
     _onHide() {
-        modalManager.remove(this);
+        this.modalManager.remove(this);
 
         document.removeEventListener('keydown', this._handleDocumentKeyDown);
     }
 
     _handleDocumentKeyDown = (e) => {
-        if (modalManager.isTopModal(this)) {
+        if (this.modalManager.isTopModal(this)) {
             this.props.onKeyDown(e);
 
             if (e.keyCode === keycode.codes.esc && this.props.onEscapeKey) {

--- a/src/utils/modalManager.js
+++ b/src/utils/modalManager.js
@@ -1,3 +1,11 @@
 import ModalManager from 'react-overlays/ModalManager';
 
-export let modalManager = new ModalManager({ hideSiblingNodes: false, handleContainerOverflow: false });
+let modalManager;
+
+export const getModalManager = () => {
+    if (modalManager) {
+        return modalManager;
+    }
+    modalManager = new ModalManager({ hideSiblingNodes: false, handleContainerOverflow: false });
+    return modalManager;
+};

--- a/src/utils/modalManager.test.js
+++ b/src/utils/modalManager.test.js
@@ -1,0 +1,9 @@
+import { getModalManager } from './modalManager';
+
+describe('modal manager', () => {
+    it('is a singleton created on demand', () => {
+        const manager1 = getModalManager();
+        const manager2 = getModalManager();
+        expect(manager1).toBe(manager2);
+    });
+});


### PR DESCRIPTION
### Description

When a script tag containing fundamental react was included in the `<head>` of the document it was throwing an error.  

It looks like this was happening because the version of react-overlays that fundamental-react is using in the Popover depends on `document.body.appendChild` to calculate the scrollbar width from the ModalManager's constructor.

This change ensures that the calculation for `document.body.appendChild` will only happen when it is available.