### PR TITLE
fix: a few issues caused by directly using fundamental-styles classes instead of the respective components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -133,8 +133,6 @@ class DatePicker extends Component {
             blockedDates,
             buttonLabel,
             buttonProps,
-            popoverStyle,
-            popoverProps,
             className,
             compact,
             disableAfterDate,
@@ -150,6 +148,7 @@ class DatePicker extends Component {
             locale,
             localizedText,
             onBlur,
+            popoverStyle,
             ...props
         } = this.props;
 
@@ -218,34 +217,33 @@ DatePicker.propTypes = {
     ...Calendar.basePropTypes,
     buttonLabel: PropTypes.string,
     buttonProps: PropTypes.object,
-    popoverStyle: PropTypes.object,
-    popoverProps: PropTypes.object,
     compact: PropTypes.bool,
     defaultValue: PropTypes.string,
     enableRangeSelection: PropTypes.bool,
     inputProps: PropTypes.object,
     locale: PropTypes.string,
-    onBlur: PropTypes.func
+    onBlur: PropTypes.func,
+    popoverStyle: PropTypes.object
 };
 
 DatePicker.defaultProps = {
     buttonLabel: 'Choose date',
+    defaultValue: '',
+    locale: 'en',
+    onBlur: () => {},
     popoverStyle: {
       width: '100%'
     },
-    defaultValue: '',
-    locale: 'en',
-    onBlur: () => {}
 };
 
 DatePicker.propDescriptions = {
     ...Calendar.propDescriptions,
     buttonLabel: 'aria-label for datepicker button',
-    popoverStyle: 'Styles applied to child Popover',
     defaultValue: 'Default value to be shown in the Datepicker. The only accepted format is the ISO format, i.e. YYYY-MM-DD',
     enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).',
     locale: 'Language code to set the locale.',
-    onBlur: 'Callback function for onBlur events. In the object returned, `date` is the date object and `formattedDate` is the formatted date.'
+    onBlur: 'Callback function for onBlur events. In the object returned, `date` is the date object and `formattedDate` is the formatted date.',
+    popoverStyle: 'Styles applied to child Popover'
 };
 
 export default DatePicker;

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -241,6 +241,7 @@ DatePicker.defaultProps = {
 DatePicker.propDescriptions = {
     ...Calendar.propDescriptions,
     buttonLabel: 'aria-label for datepicker button',
+    popoverStyle: 'Styles applied to child Popover',
     defaultValue: 'Default value to be shown in the Datepicker. The only accepted format is the ISO format, i.e. YYYY-MM-DD',
     enableRangeSelection: 'Set to **true** to enable the selection of a date range (begin and end).',
     locale: 'Language code to set the locale.',

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -133,6 +133,8 @@ class DatePicker extends Component {
             blockedDates,
             buttonLabel,
             buttonProps,
+            popoverStyle,
+            popoverProps,
             className,
             compact,
             disableAfterDate,
@@ -157,6 +159,7 @@ class DatePicker extends Component {
                 className={className}
                 ref={component => (this.component = component)}>
                 <Popover
+                    style={popoverStyle}
                     body={
                         <Calendar
                             blockedDates={blockedDates}
@@ -215,6 +218,8 @@ DatePicker.propTypes = {
     ...Calendar.basePropTypes,
     buttonLabel: PropTypes.string,
     buttonProps: PropTypes.object,
+    popoverStyle: PropTypes.object,
+    popoverProps: PropTypes.object,
     compact: PropTypes.bool,
     defaultValue: PropTypes.string,
     enableRangeSelection: PropTypes.bool,
@@ -225,6 +230,9 @@ DatePicker.propTypes = {
 
 DatePicker.defaultProps = {
     buttonLabel: 'Choose date',
+    popoverStyle: {
+      width: '100%'
+    },
     defaultValue: '',
     locale: 'en',
     onBlur: () => {}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -158,7 +158,6 @@ class DatePicker extends Component {
                 className={className}
                 ref={component => (this.component = component)}>
                 <Popover
-                    style={popoverStyle}
                     body={
                         <Calendar
                             blockedDates={blockedDates}
@@ -205,7 +204,8 @@ class DatePicker extends Component {
                     noArrow
                     onClickOutside={this.clickOutside}
                     placement='bottom-end'
-                    ref={this.popoverRef} />
+                    ref={this.popoverRef}
+                    style={popoverStyle} />
             </div>
         );
     }
@@ -222,8 +222,8 @@ DatePicker.propTypes = {
     enableRangeSelection: PropTypes.bool,
     inputProps: PropTypes.object,
     locale: PropTypes.string,
-    onBlur: PropTypes.func,
-    popoverStyle: PropTypes.object
+    popoverStyle: PropTypes.object,
+    onBlur: PropTypes.func
 };
 
 DatePicker.defaultProps = {
@@ -232,8 +232,8 @@ DatePicker.defaultProps = {
     locale: 'en',
     onBlur: () => {},
     popoverStyle: {
-      width: '100%'
-    },
+        width: '100%'
+    }
 };
 
 DatePicker.propDescriptions = {

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -128,6 +128,7 @@ class SearchInput extends Component {
             inputProps,
             listProps,
             searchBtnProps,
+            popoverStyle,
             popoverProps,
             state,
             ...rest
@@ -136,6 +137,7 @@ class SearchInput extends Component {
         return (
             <div {...rest} className={className}>
                 <Popover
+                    style={popoverStyle}
                     {...popoverProps}
                     body={
                         (<Menu disableStyles={disableStyles}>
@@ -203,6 +205,7 @@ SearchInput.propTypes = {
     listProps: PropTypes.object,
     noSearchBtn: PropTypes.bool,
     placeholder: PropTypes.string,
+    popoverStyle: PropTypes.object,
     popoverProps: PropTypes.object,
     searchBtnProps: PropTypes.object,
     searchList: PropTypes.arrayOf(
@@ -217,11 +220,15 @@ SearchInput.propTypes = {
 };
 
 SearchInput.defaultProps = {
+    popoverStyle: {
+      width: '100%'
+    },
     onChange: () => { },
     onEnter: () => { }
 };
 
 SearchInput.propDescriptions = {
+    popoverStyle: 'Styles applied to child Popover',
     noSearchBtn: 'Set to **true** to render without a search button.',
     onEnter: 'Callback function when the user hits the <Enter> key.',
     searchBtnProps: 'Additional props to be spread to the search `<button>` element.',

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -145,19 +145,18 @@ class SearchInput extends Component {
                                 {this.state.filteredResult && this.state.filteredResult.length > 0 ? (
                                     this.state.filteredResult.map((item, index) => {
                                         return (
-                                            <li
-                                                className='fd-menu__item'
+                                            <Menu.Item
                                                 key={index}
                                                 onClick={(e) => this.listItemClickHandler(e, item)}>
                                                 <strong>{this.state.value}</strong>
                                                 {this.state.value && this.state.value.length
                                                     ? item.text.substring(this.state.value.length)
                                                     : item.text}
-                                            </li>
+                                            </Menu.Item>
                                         );
                                     })
                                 ) : (
-                                    <li className='fd-menu__item'>No result</li>
+                                    <Menu.Item >No result</Menu.Item>
                                 )}
                             </Menu.List>
                         </Menu>)

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -204,8 +204,8 @@ SearchInput.propTypes = {
     listProps: PropTypes.object,
     noSearchBtn: PropTypes.bool,
     placeholder: PropTypes.string,
-    popoverStyle: PropTypes.object,
     popoverProps: PropTypes.object,
+    popoverStyle: PropTypes.object,
     searchBtnProps: PropTypes.object,
     searchList: PropTypes.arrayOf(
         PropTypes.shape({
@@ -220,16 +220,16 @@ SearchInput.propTypes = {
 
 SearchInput.defaultProps = {
     popoverStyle: {
-      width: '100%'
+        width: '100%'
     },
     onChange: () => { },
     onEnter: () => { }
 };
 
 SearchInput.propDescriptions = {
-    popoverStyle: 'Styles applied to child Popover',
     noSearchBtn: 'Set to **true** to render without a search button.',
     onEnter: 'Callback function when the user hits the <Enter> key.',
+    popoverStyle: 'Styles applied to child Popover',
     searchBtnProps: 'Additional props to be spread to the search `<button>` element.',
     searchList: 'Collection of items to display in the dropdown list.'
 };

--- a/src/SearchInput/__snapshots__/SearchInput.test.js.snap
+++ b/src/SearchInput/__snapshots__/SearchInput.test.js.snap
@@ -6,6 +6,11 @@ exports[`<SearchInput /> create SearchInput 1`] = `
 >
   <div
     className="fd-popover"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       onFocus={[Function]}
@@ -48,6 +53,11 @@ exports[`<SearchInput /> create SearchInput 2`] = `
 <div>
   <div
     className="fd-popover"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       onFocus={[Function]}
@@ -90,6 +100,11 @@ exports[`<SearchInput /> create SearchInput 3`] = `
 <div>
   <div
     className="fd-popover"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       onFocus={[Function]}
@@ -132,6 +147,11 @@ exports[`<SearchInput /> create SearchInput 4`] = `
 <div>
   <div
     className="fd-popover"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       onFocus={[Function]}

--- a/src/Shellbar/__snapshots__/Shellbar.test.js.snap
+++ b/src/Shellbar/__snapshots__/Shellbar.test.js.snap
@@ -200,6 +200,11 @@ exports[`<Shellbar /> create shellbar 3`] = `
       >
         <div
           className="fd-popover"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
         >
           <div
             onFocus={[Function]}
@@ -500,6 +505,11 @@ exports[`<Shellbar /> create shellbar 4`] = `
       >
         <div
           className="fd-popover"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
         >
           <div
             onFocus={[Function]}
@@ -793,6 +803,11 @@ exports[`<Shellbar /> create shellbar 5`] = `
       >
         <div
           className="fd-popover"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
         >
           <div
             onFocus={[Function]}
@@ -1066,6 +1081,11 @@ exports[`<Shellbar /> create shellbar 6`] = `
       >
         <div
           className="fd-popover"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
         >
           <div
             onFocus={[Function]}


### PR DESCRIPTION
### Description

Fix a few issues caused by directly using fundamental-styles classes instead of the respective components.


### Fixed issues:

* fix ```DatePicker``` popover hidden by following components (caused by not rendering the popover with the ```Popover``` compoment);
* DatePicker, SearchInput: set default width to "100%" to match parent element width;
* SearchInput: render Menu.Item instead of ```<li>``` tag to prevent the react-dom props check warnings (passing unknown props to ```<li>``` tag);

