### PR TITLE
fix: make popover usable within components having focus

### DIFF
--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -143,8 +143,7 @@ class Popper extends React.Component {
             <Manager>
                 <Foco
                     component='div'
-                    onClickOutside={onClickOutside}
-                    onFocusOutside={onClickOutside}>
+                    onClickOutside={onClickOutside}>
                     <Reference>
                         {({ ref }) => (
                             <div


### PR DESCRIPTION
the 'onFocusOutside' handler of react-foco was removed. Using this trigger causes react-foco to handle the events in the capturing event phase which therefore then can't be handled by the component as the handler closes the Popover. As the Popover uses the onClickOutside function as a trigger to close the Popover content the onFocusOutside handler is not needed

### Description
As far as I can tell, the onFocusOutside handler is unnecessary. 
With mouse navigation, the Popver will close as soon as the use interacts with another component. 
With keyboard navigation, the popover can be closed with the Escape key(good luck Touchbar users 😂). This is the same behavior as before: When the Popover is opened with Space, subsequent Tab presses would cycle through options within the Popover.

fixes #877