### PR TITLE
fix: datepicker onchange on calendar selection, popover props

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -130,6 +130,7 @@ class DatePicker extends Component {
     }
 
     _handleOnChange = (e) => {
+        e.stopPropagation();
         this.setState({
             formattedDate: e.target.value,
             isoFormattedDate: e.target.value ? moment(e.target.value).format(ISO_DATE_FORMAT) : '' },

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -132,7 +132,7 @@ class DatePicker extends Component {
     _handleOnChange = (e) => {
         this.setState({
             formattedDate: e.target.value,
-            isoFormattedDate: moment(e.target.value).format(ISO_DATE_FORMAT) },
+            isoFormattedDate: e.target.value ? moment(e.target.value).format(ISO_DATE_FORMAT) : '' },
         () => {
             this.props.onChange(this.getCallbackData());
         });
@@ -233,6 +233,8 @@ class DatePicker extends Component {
                 arrSelectedDates: date,
                 formattedDate: this.getFormattedDateRangeStr(date),
                 isoFormattedDate: isoFormatDate
+            }, () => {
+                this.props.onChange(this.getCallbackData());
             });
         } else {
             closeCalendar = true;
@@ -240,6 +242,8 @@ class DatePicker extends Component {
                 selectedDate: date,
                 formattedDate: this.getFormattedDateStr(date),
                 isoFormattedDate: date.format(ISO_DATE_FORMAT)
+            }, () => {
+                this.props.onChange(this.getCallbackData());
             });
         }
 
@@ -278,6 +282,7 @@ class DatePicker extends Component {
             locale,
             localizedText,
             onBlur,
+            popoverProps,
             readOnly,
             validationState,
             ...props
@@ -298,6 +303,7 @@ class DatePicker extends Component {
                 {...props}
                 className={className}>
                 <Popover
+                    {...popoverProps}
                     body={
                         <>
                             {
@@ -395,6 +401,7 @@ DatePicker.propTypes = {
     enableRangeSelection: PropTypes.bool,
     inputProps: PropTypes.object,
     locale: PropTypes.string,
+    popoverProps: PropTypes.object,
     readOnly: PropTypes.bool,
     validationState: PropTypes.shape({
         state: PropTypes.oneOf(FORM_MESSAGE_TYPES),

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -341,6 +341,16 @@ describe('<DatePicker />', () => {
 
             expect(change).toHaveBeenCalledWith(expect.objectContaining({ formattedDate: '04/14/2020' }));
         });
+
+        test('should call onChange on selecting a calendar item', () => {
+            const change = jest.fn();
+            const element = mount(<DatePicker defaultValue='2020-03-13' onChange={change} />);
+
+            element.find('button.fd-button--transparent.sap-icon--calendar').simulate('click');
+            element.find('.fd-calendar__text').at(1).simulate('click');
+
+            expect(change).toHaveBeenCalledWith(expect.objectContaining({ formattedDate: '03/02/2020' }));
+        });
     });
 
     describe('onFocus callback', () => {

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -120,7 +120,7 @@ class Popper extends React.Component {
                             {...popperProps}
                             className={popperClasses}
                             ref={ref}
-                            style={style}
+                            style={{ ...style, ...popperProps.style }}
                             // eslint-disable-next-line no-undefined
                             x-out-of-boundaries={!!outOfBoundaries || undefined}
                             x-placement={placement}>


### PR DESCRIPTION
### Description

Calls DatePicker onChange when a calendar item is selected. Before, it would never be called it all unless you typed in the field directly.

Adds spreadable `popoverProps`