### PR TITLE
fix: search addonBefore error and popover out boundaries

### DIFF
--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -133,19 +133,18 @@ class SearchInput extends Component {
                     {this.state.filteredResult && this.state.filteredResult.length > 0 ? (
                         this.state.filteredResult.map((item, index) => {
                             return (
-                                <li
-                                    className='fd-menu__item'
+                                <Menu.Item
                                     key={index}
                                     onClick={(e) => this.handleListItemClick(e, item)}>
                                     <strong>{this.state.value}</strong>
                                     {this.state.value && this.state.value.length
                                         ? item.text.substring(this.state.value.length)
                                         : item.text}
-                                </li>
+                                </Menu.Item>
                             );
                         })
                     ) : (
-                        <li className='fd-menu__item'>No result</li>
+                        <Menu.Item>No result</Menu.Item>
                     )}
                 </Menu.List>
             </Menu>

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -122,7 +122,7 @@ class Popper extends React.Component {
                             ref={ref}
                             style={{ ...style, ...popperProps.style }}
                             // eslint-disable-next-line no-undefined
-                            x-out-of-boundaries={!!outOfBoundaries || undefined}
+                            x-out-of-boundaries={!!outOfBoundaries ? 'true' : undefined}
                             x-placement={placement}>
                             {children}
                             <span


### PR DESCRIPTION
### Description
Fixes :
- Search error when popover is triggered. Cause by li element being created in SearchInput and passed to MenuList were it gets addonBefore prop appended. Used Menu.Item instead.
- Popover error when open and window scrolls down.

fixes #931 