### PR TITLE
fix: datepicker onBur callback validation

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -158,7 +158,7 @@ class DatePicker extends Component {
         };
     }
 
-    validateDates = () => {
+    validateDates = (postValidationCallback) => {
         const { formattedDate } = this.state;
 
         if (this.props.enableRangeSelection) {
@@ -176,9 +176,13 @@ class DatePicker extends Component {
                     selectedDate: null,
                     arrSelectedDates: arrSelected,
                     formattedDate: this.getFormattedDateRangeStr(arrSelected)
+                }, () => {
+                    postValidationCallback
+                    && typeof postValidationCallback === 'function'
+                    && postValidationCallback(this.getCallbackData());
                 });
             } else {
-                this.resetState();
+                this.resetState(postValidationCallback);
             }
         } else {
             const newDate = this.getMomentDateObj(formattedDate);
@@ -186,19 +190,27 @@ class DatePicker extends Component {
                 this.setState({
                     selectedDate: newDate,
                     formattedDate: this.getFormattedDateStr(formattedDate)
+                }, () => {
+                    postValidationCallback
+                    && typeof postValidationCallback === 'function'
+                    && postValidationCallback(this.getCallbackData());
                 });
             } else {
-                this.resetState();
+                this.resetState(postValidationCallback);
             }
         }
     }
 
-    resetState = () => {
+    resetState = (postValidationCallback) => {
         this.setState({
             formattedDate: '',
             isoFormattedDate: '',
             selectedDate: null,
             arrSelectedDates: []
+        }, () => {
+            postValidationCallback
+            && typeof postValidationCallback === 'function'
+            && postValidationCallback(this.getCallbackData());
         });
     }
 
@@ -254,9 +266,16 @@ class DatePicker extends Component {
             });
         }
     }
+    /**
+     * First validates the inputted dates,
+     * then sets state,
+     * finally calls props.onBlur with callback data
+     * i.e. the  validated state
+     *
+     * @returns {undefined}
+     */
     _handleBlur = () => {
-        this.validateDates();
-        this.props.onBlur(this.getCallbackData());
+        this.validateDates(this.props.onBlur);
     };
 
     render() {

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -158,6 +158,12 @@ class DatePicker extends Component {
         };
     }
 
+    executeCallback = (callbackFunction) => {
+        callbackFunction
+        && typeof callbackFunction === 'function'
+        && callbackFunction(this.getCallbackData());
+    }
+
     validateDates = (postValidationCallback) => {
         const { formattedDate } = this.state;
 
@@ -177,9 +183,8 @@ class DatePicker extends Component {
                     arrSelectedDates: arrSelected,
                     formattedDate: this.getFormattedDateRangeStr(arrSelected)
                 }, () => {
-                    postValidationCallback
-                    && typeof postValidationCallback === 'function'
-                    && postValidationCallback(this.getCallbackData());
+                    this.executeCallback(this.props.onChange);
+                    this.executeCallback(postValidationCallback);
                 });
             } else {
                 this.resetState(postValidationCallback);
@@ -192,9 +197,8 @@ class DatePicker extends Component {
                     formattedDate: this.getFormattedDateStr(formattedDate),
                     isoFormattedDate: formattedDate ? moment(formattedDate).format(ISO_DATE_FORMAT) : ''
                 }, () => {
-                    postValidationCallback
-                    && typeof postValidationCallback === 'function'
-                    && postValidationCallback(this.getCallbackData());
+                    this.executeCallback(this.props.onChange);
+                    this.executeCallback(postValidationCallback);
                 });
             } else {
                 this.resetState(postValidationCallback);
@@ -209,9 +213,8 @@ class DatePicker extends Component {
             selectedDate: null,
             arrSelectedDates: []
         }, () => {
-            postValidationCallback
-            && typeof postValidationCallback === 'function'
-            && postValidationCallback(this.getCallbackData());
+            this.executeCallback(this.props.onChange);
+            this.executeCallback(postValidationCallback);
         });
     }
 

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -189,7 +189,8 @@ class DatePicker extends Component {
             if (this.isDateValid(newDate)) {
                 this.setState({
                     selectedDate: newDate,
-                    formattedDate: this.getFormattedDateStr(formattedDate)
+                    formattedDate: this.getFormattedDateStr(formattedDate),
+                    isoFormattedDate: formattedDate ? moment(formattedDate).format(ISO_DATE_FORMAT) : ''
                 }, () => {
                     postValidationCallback
                     && typeof postValidationCallback === 'function'

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -340,8 +340,11 @@ describe('<DatePicker />', () => {
 
         test('should call onChange on selecting a calendar item', () => {
             const change = jest.fn();
-            const element = mount(<DatePicker defaultValue='2020-03-13' onChange={change} />);
-
+            let element = mount(<DatePicker dateFormat='YYYY-MM-DD' defaultValue='2020-03-13'
+                onChange={change} />);
+            element = element.setProps({
+                dateFormat: 'MM/DD/YYYY'
+            });
             element.find('button.fd-button--transparent.sap-icon--calendar').simulate('click');
             element.find('.fd-calendar__text').at(1).simulate('click');
 

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -300,6 +300,18 @@ describe('<DatePicker />', () => {
 
             expect(blur).toHaveBeenCalledTimes(1);
         });
+        test('should call onBlur after leaving input, with validated data', () => {
+            const blur = jest.fn();
+            const element = mount(<DatePicker onBlur={blur} />).find('input[type="text"]');
+            element.simulate('change', { target: { value: 'rubbish' } });
+            element.find('input[type="text"]').simulate('blur');
+
+            expect(blur).toHaveBeenCalledWith(expect.objectContaining({
+                date: null,
+                formattedDate: '',
+                isoFormattedDate: ''
+            }));
+        });
     });
 
     describe('onDatePickerClose callback', () => {

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -232,7 +232,7 @@ describe('<DatePicker />', () => {
         input.simulate('change', { target: { value: '3.16.20' } }); // input format D.MM.YY
         input.simulate('blur');
 
-        //expect date value to be auto formated
+        //expect date value to be auto formatted
         expect(wrapper.state('formattedDate')).toEqual('03/16/2020');
     });
 
@@ -258,7 +258,7 @@ describe('<DatePicker />', () => {
         //trigger onBlur by clicking outside
         simulateBlur();
 
-        //expect date value to be auto formated
+        //expect date value to be auto formatted
         expect(wrapper.state('formattedDate')).toEqual('17/03/2020');
     });
 
@@ -270,7 +270,7 @@ describe('<DatePicker />', () => {
         input.simulate('change', { target: { value: '3.16.20 - 3.11.20' } }); // input format D.MM.YY
         input.simulate('blur');
 
-        //expect date value to be auto formated
+        //expect date value to be auto formatted
         expect(wrapper.state('formattedDate')).toEqual('03/11/2020 - 03/16/2020');
     });
 


### PR DESCRIPTION
### Description
Changes
* Validation ends up updating the Datepicker's state. Since state updates are asynchronous the `onBlur` should be called AFTER state updates as a callback. Otherwise, the consumer ends up with stale data.

* update `state.isoFormattedDate` after validation

* call `props.onChange` after validation, as auto-formatting may change `state.formattedDate`


Before
![fr-onblur-issue](https://user-images.githubusercontent.com/43764832/78086630-61f37580-7373-11ea-8952-815805e65a27.gif)

After
![fr-onblur-fixed](https://user-images.githubusercontent.com/43764832/78086608-5607b380-7373-11ea-8338-82c9709a5983.gif)