### PR TITLE
chore: update readme to point to font downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For an existing react application, follow the steps below:
     > **NOTE:** Importing from specific component is recommended. Doing so will bring in only the component you are using instead of the whole library, which will reduce your bundle size significantly.
 
 
-1. This project does not contain fonts and icons - they must be added to your project separately. Fonts and icons can be found at [`@sap-theming/theming-base-content`](https://github.com/SAP/theming-base-content). After importing fonts and icons from [`@sap-theming/theming-base-content`](https://github.com/SAP/theming-base-content), add the following to your css:
+1. This project does not contain fonts and icons - they must be added to your project separately. Download [Font 72](https://experience.sap.com/fiori-design-web/downloads/#download-font-72) and [SAP icons](https://experience.sap.com/fiori-design-web/downloads/#sap-icon-font). After adding fonts and icons to your project, include the following in your css:
 
 ```css
     @font-face {


### PR DESCRIPTION
### Description
Getting fonts from `@sap-theming` has been confusing for consumers. We can now point to the downloadable font set. 


fixes #issueid