### PR TITLE
feat: width adjustments for popover based components, class changes, MultiInput changes

### DIFF
--- a/src/ComboboxInput/ComboboxInput.js
+++ b/src/ComboboxInput/ComboboxInput.js
@@ -71,7 +71,7 @@ const ComboboxInput = React.forwardRef(({
                         {validationState.text}
                     </FormMessage>
                     }
-                    <List>
+                    <List className='fd-list--dropdown'>
                         {options.map(option => (
                             <List.Item
                                 key={option.key}
@@ -116,7 +116,7 @@ const ComboboxInput = React.forwardRef(({
             onClickOutside={handleClickOutside}
             show={isExpanded}
             useArrowKeyNavigation
-            widthSizingType='matchTarget' />
+            widthSizingType='minTarget' />
     );
 });
 

--- a/src/InputGroup/InputGroup.js
+++ b/src/InputGroup/InputGroup.js
@@ -40,7 +40,8 @@ class InputGroup extends Component {
 
         const getClassName = (child) => classnames(
             {
-                'fd-input-group__input': child.type.displayName !== InputGroupAddon.displayName
+                'fd-input-group__input': child.type.displayName !== InputGroupAddon.displayName &&
+                    !child.props.className?.includes('fd-tokenizer')
             },
             child.props.className
         );

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -228,7 +228,8 @@ class MultiInput extends Component {
                 disabled={disabled}
                 disableStyles={disableStyles}
                 noArrow
-                onClickOutside={this.handleClickOutside} />
+                onClickOutside={this.handleClickOutside}
+                widthSizingType='matchTarget' />
         );
     }
 }

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -48,13 +48,23 @@ class MultiInput extends Component {
 
     // create tag elements to display below input box
     createTags = () => {
-        return this.state.tags.map((tag, index) => (
-            <Token
-                key={index}
-                onClick={() => this.removeTag(tag)}>
-                {tag}
-            </Token>
-        ));
+        return this.state.tags.map((tag, index) => {
+            if (index < 3) {
+                return (
+                    <Token
+                        key={index}
+                        onClick={() => this.removeTag(tag)}>
+                        {tag}
+                    </Token>
+                );
+            } else if (index >= this.state.tags.length - 1) {
+                return (
+                    <span className='fd-tokenizer__indicator'>{this.state.tags.length - 3} more</span>
+                );
+            } else {
+                return null;
+            }
+        });
     };
 
     // add/remove tag to tag collection
@@ -95,7 +105,6 @@ class MultiInput extends Component {
 
     // remove/close tag
     removeTag = (tag) => {
-
         this.setState(
             prevState => {
                 const tags = prevState.tags.filter(item => {
@@ -201,7 +210,7 @@ class MultiInput extends Component {
                                 {this.state.tags.length > 0 && this.createTags()}
                                 <FormInput
                                     {...inputProps}
-                                    className='fd-tokenizer__input'
+                                    className='fd-input-group__input fd-tokenizer__input'
                                     compact={compact}
                                     disableStyles={disableStyles}
                                     placeholder={placeholder} />

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -219,8 +219,7 @@ class MultiInput extends Component {
                 disabled={disabled}
                 disableStyles={disableStyles}
                 noArrow
-                onClickOutside={this.handleClickOutside}
-                widthSizingType='matchTarget' />
+                onClickOutside={this.handleClickOutside} />
         );
     }
 }

--- a/src/MultiInput/MultiInput.test.js
+++ b/src/MultiInput/MultiInput.test.js
@@ -136,6 +136,38 @@ describe('<MultiInput />', () => {
         );
     });
 
+    test('tag list is truncated when more than 3 options are selected', () => {
+        wrapper = mount(multiInput);
+        wrapper
+            .find('button.fd-button--transparent')
+            .simulate('click');
+
+        // add 4 tags to list
+        wrapper
+            .find('.fd-checkbox').first()
+            .simulate('change', { target: { value: data[0] } });
+        wrapper
+            .find('.fd-checkbox').at(1)
+            .simulate('change', { target: { value: data[0] } });
+        wrapper
+            .find('.fd-checkbox').at(2)
+            .simulate('change', { target: { value: data[0] } });
+        wrapper
+            .find('.fd-checkbox').at(3)
+            .simulate('change', { target: { value: data[0] } });
+
+        // check that tag list contains value
+        expect(wrapper.state(['tags'])).toHaveLength(4);
+
+        // check to see that only 3 tags are created
+        expect(wrapper.find('span.fd-token[role="button"]')).toHaveLength(3);
+
+        // check that truncated text is correct
+        expect(wrapper.find('span.fd-tokenizer__indicator').text()).toEqual(
+            '1 more'
+        );
+    });
+
     test('remove tag from taglist by unchecking', () => {
         wrapper = mount(multiInput);
         wrapper

--- a/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
+++ b/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
@@ -33,7 +33,7 @@ exports[`Storyshots Component API/MultiInput Compact 1`] = `
               className="fd-tokenizer__inner"
             >
               <input
-                className="fd-input fd-input--compact fd-tokenizer__input"
+                className="fd-input fd-input--compact fd-input-group__input fd-tokenizer__input"
                 placeholder="Placeholder"
                 type="text"
               />
@@ -88,7 +88,7 @@ exports[`Storyshots Component API/MultiInput Dev 1`] = `
               className="fd-tokenizer__inner"
             >
               <input
-                className="fd-input fd-tokenizer__input"
+                className="fd-input fd-input-group__input fd-tokenizer__input"
                 placeholder="Select a Fruit"
                 type="text"
               />
@@ -143,7 +143,7 @@ exports[`Storyshots Component API/MultiInput Disabled 1`] = `
               className="fd-tokenizer__inner"
             >
               <input
-                className="fd-input fd-tokenizer__input"
+                className="fd-input fd-input-group__input fd-tokenizer__input"
                 placeholder="Placeholder"
                 type="text"
               />
@@ -197,7 +197,7 @@ exports[`Storyshots Component API/MultiInput Primary 1`] = `
               className="fd-tokenizer__inner"
             >
               <input
-                className="fd-input fd-tokenizer__input"
+                className="fd-input fd-input-group__input fd-tokenizer__input"
                 placeholder="Placeholder"
                 type="text"
               />
@@ -253,7 +253,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                 className="fd-tokenizer__inner"
               >
                 <input
-                  className="fd-input fd-tokenizer__input"
+                  className="fd-input fd-input-group__input fd-tokenizer__input"
                   placeholder="Error"
                   type="text"
                 />
@@ -306,7 +306,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                 className="fd-tokenizer__inner"
               >
                 <input
-                  className="fd-input fd-tokenizer__input"
+                  className="fd-input fd-input-group__input fd-tokenizer__input"
                   placeholder="Warning"
                   type="text"
                 />
@@ -359,7 +359,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                 className="fd-tokenizer__inner"
               >
                 <input
-                  className="fd-input fd-tokenizer__input"
+                  className="fd-input fd-input-group__input fd-tokenizer__input"
                   placeholder="Success"
                   type="text"
                 />
@@ -412,7 +412,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                 className="fd-tokenizer__inner"
               >
                 <input
-                  className="fd-input fd-tokenizer__input"
+                  className="fd-input fd-input-group__input fd-tokenizer__input"
                   placeholder="Information"
                   type="text"
                 />

--- a/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
+++ b/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots Component API/MultiInput Compact 1`] = `
           tabIndex={0}
         >
           <div
-            className="fd-input-group__input fd-tokenizer fd-tokenizer--compact"
+            className="fd-tokenizer fd-tokenizer--compact"
             compact={true}
           >
             <div
@@ -80,7 +80,7 @@ exports[`Storyshots Component API/MultiInput Dev 1`] = `
           tabIndex={0}
         >
           <div
-            className="fd-input-group__input fd-tokenizer"
+            className="fd-tokenizer"
             compact={false}
             disabled={false}
           >
@@ -136,7 +136,7 @@ exports[`Storyshots Component API/MultiInput Disabled 1`] = `
           tabIndex={0}
         >
           <div
-            className="fd-input-group__input fd-tokenizer"
+            className="fd-tokenizer"
             disabled={true}
           >
             <div
@@ -191,7 +191,7 @@ exports[`Storyshots Component API/MultiInput Primary 1`] = `
           tabIndex={0}
         >
           <div
-            className="fd-input-group__input fd-tokenizer"
+            className="fd-tokenizer"
           >
             <div
               className="fd-tokenizer__inner"
@@ -247,7 +247,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
             tabIndex={0}
           >
             <div
-              className="fd-input-group__input fd-tokenizer"
+              className="fd-tokenizer"
             >
               <div
                 className="fd-tokenizer__inner"
@@ -300,7 +300,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
             tabIndex={0}
           >
             <div
-              className="fd-input-group__input fd-tokenizer"
+              className="fd-tokenizer"
             >
               <div
                 className="fd-tokenizer__inner"
@@ -353,7 +353,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
             tabIndex={0}
           >
             <div
-              className="fd-input-group__input fd-tokenizer"
+              className="fd-tokenizer"
             >
               <div
                 className="fd-tokenizer__inner"
@@ -406,7 +406,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
             tabIndex={0}
           >
             <div
-              className="fd-input-group__input fd-tokenizer"
+              className="fd-tokenizer"
             >
               <div
                 className="fd-tokenizer__inner"

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -206,7 +206,7 @@ class SearchInput extends Component {
                     noArrow
                     onClickOutside={this.handleClickOutside}
                     show={this.state.isExpanded}
-                    widthSizingType='matchTarget' />
+                    widthSizingType='minTarget' />
             </div>
         );
     }

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -125,7 +125,7 @@ const Select = React.forwardRef(({
             placement='bottom-start'
             popperProps={{ id }}
             show={isExpanded}
-            widthSizingType='matchTarget' />
+            widthSizingType='minTarget' />
     );
 });
 


### PR DESCRIPTION
### Description
- adjust `widthSizingType` for popover-based components, mainly to account for the max 37.5rem width for list
- add missing `fd-list--dropdown` class to ComboboxInput
- `fd-input-group__input` class incorrectly applied to child div tokenizer in MultiInput, instead applied manually to `input`
- truncate MultiInput when more than 3 items are selected

### MultiInput many options
#### Before
![multiinput_long-target-before](https://user-images.githubusercontent.com/22511993/81977210-85e6df80-95de-11ea-959e-d36b321597f9.png)
#### After
![multiinput_long-target-after](https://user-images.githubusercontent.com/22511993/81977617-263d0400-95df-11ea-9e3f-112afc3be818.png)


### MultiInput long options
#### Before
![multiinput-long-popper-before](https://user-images.githubusercontent.com/22511993/81977167-78315a00-95de-11ea-9101-4ea4c9a18e39.png)
#### After
![multiinput_long-popper-after](https://user-images.githubusercontent.com/22511993/81977202-84b5b280-95de-11ea-8a83-bd00cb331792.png)

### Select
#### Before
![select-before](https://user-images.githubusercontent.com/22511993/81977677-3ce35b00-95df-11ea-84f7-ae530c2ddfb7.png)

#### After
![select-after](https://user-images.githubusercontent.com/22511993/81977683-3f45b500-95df-11ea-828c-e5e91944bd0a.png)

### Known Issues
- MultiInput still doesn't instantly update when setting a `widthSizingType`, which causes the width to be 'one step behind' when selecting/deselecting items.