### PR TITLE
chore: no longer require @sap-theming as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "@sap-theming/theming-base-content": "^11.1.17"
+    "react-dom": "^16.8.0"
   },
   "pre-commit": {
     "colors": true,


### PR DESCRIPTION
### Description

Because we now suggest adding fonts/icons from fiori-design-web, we no longer need to required @sap-theming as a peerDependency.

fixes #issueid