### PR TITLE
docs: do not document disableStyles in props table

### DIFF
--- a/.storybook/custom/components/DocsPage.js
+++ b/.storybook/custom/components/DocsPage.js
@@ -46,7 +46,7 @@ const DocsPage = () => {
         <Primary />
         <Stories />
         <h2 className='sbdocs-h2' id='properties'>Properties</h2>
-        <Props />
+        <Props exclude={['disableStyles']} />
         <Community />
         <Footer />
       </>


### PR DESCRIPTION
### Description
This removes `disableStyles` from the documented props tables. Unfortunately, we can't just look for "internal use only" as it filters by prop name, not description. 


fixes #393 