### PR TITLE
fix: [DatePicker] Construct new moment objects with custom dateFormat

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -22,7 +22,9 @@ class DatePicker extends Component {
     constructor(props) {
         super(props);
         const formattedDate = props.defaultValue.length > 0 ? this.getFormattedDateStr(props.defaultValue) : '';
-        const isoFormattedDate = props.defaultValue.length > 0 ? moment(props.defaultValue).format(ISO_DATE_FORMAT) : '';
+        const isoFormattedDate = props.defaultValue.length > 0
+            ? moment(props.defaultValue, props.dateFormat).format(ISO_DATE_FORMAT)
+            : '';
         this.state = {
             isExpanded: false,
             selectedDate: formattedDate.length === 0 ? null : this.getMomentDateObj(formattedDate),
@@ -123,11 +125,13 @@ class DatePicker extends Component {
     }
 
     handleNewDefault = () => {
-        const { defaultValue } = this.props;
+        const { dateFormat, defaultValue } = this.props;
         const formattedNewDefault = defaultValue && defaultValue.length > 0 ? this.getFormattedDateStr(defaultValue) : '';
         this.setState({
             selectedDate: formattedNewDefault.length === 0 ? null : this.getMomentDateObj(formattedNewDefault),
-            isoFormattedDate: defaultValue && defaultValue.length > 0 ? moment(defaultValue).format(ISO_DATE_FORMAT) : '',
+            isoFormattedDate: defaultValue && defaultValue.length > 0
+                ? moment(defaultValue, dateFormat).format(ISO_DATE_FORMAT)
+                : '',
             formattedDate: formattedNewDefault
         }, () => {
             this.validateDates();
@@ -138,7 +142,9 @@ class DatePicker extends Component {
         e.stopPropagation();
         this.setState({
             formattedDate: e.target.value,
-            isoFormattedDate: e.target.value ? moment(e.target.value).format(ISO_DATE_FORMAT) : ''
+            isoFormattedDate: e.target.value
+                ? moment(e.target.value, this.props.dateFormat).format(ISO_DATE_FORMAT)
+                : ''
         }, () => {
             this.props.onChange(this.getCallbackData());
         });
@@ -202,7 +208,9 @@ class DatePicker extends Component {
                 this.setState({
                     selectedDate: newDate,
                     formattedDate: newFormattedDateStr,
-                    isoFormattedDate: formattedDate ? moment(formattedDate).format(ISO_DATE_FORMAT) : ''
+                    isoFormattedDate: formattedDate
+                        ? moment(formattedDate, this.props.dateFormat).format(ISO_DATE_FORMAT)
+                        : ''
                 }, () => {
                     if (formattedDate !== newFormattedDateStr) {
                         this.executeCallback(this.props.onChange);

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -284,6 +284,15 @@ describe('<DatePicker />', () => {
         expect(wrapper.state('isoFormattedDate')).toEqual('2020-04-14');
     });
 
+    test('provide ISO-8601 format date with custom dateFormat in props', () => {
+        wrapper = mount(<DatePicker dateFormat='DD-MM-YYYY' defaultValue='01-06-2020' />);
+        expect(wrapper.state('isoFormattedDate')).toEqual('2020-06-01');
+        wrapper
+            .find('input[type="text"]')
+            .simulate('change', { target: { value: '14-04-2020' } });
+        expect(wrapper.state('isoFormattedDate')).toEqual('2020-04-14');
+    });
+
     test('should update value if defaultValue prop is updated', () => {
         wrapper = mount(prePopulatedDatepicker);
         wrapper = wrapper.setProps({
@@ -300,6 +309,21 @@ describe('<DatePicker />', () => {
             element.find('input[type="text"]').simulate('blur');
 
             expect(blur).toHaveBeenCalledTimes(1);
+        });
+        test('should format isoFormattedDate when a custom dateFormat is passed in props', () => {
+            const blur = jest.fn();
+            const element = mount(<DatePicker
+                dateFormat='DD-MM-YYYY'
+                defaultValue='01-06-2020'
+                onBlur={blur} />).find('input[type="text"]');
+            element.find('input[type="text"]').simulate('click');
+            element.find('input[type="text"]').simulate('change', { target: { value: '30-06-2020' } });
+            element.find('input[type="text"]').simulate('blur');
+
+            expect(blur).toHaveBeenCalledTimes(1);
+            expect(blur).toHaveBeenCalledWith(expect.objectContaining({
+                isoFormattedDate: '2020-06-30'
+            }));
         });
         test('should call onBlur after leaving input, with validated data', () => {
             const blur = jest.fn();


### PR DESCRIPTION
### Description

Without these changes this test
```jsx
test('provide ISO-8601 format date with custom dateFormat in props', () => {
  wrapper = mount(<DatePicker dateFormat='DD-MM-YYYY' defaultValue='01-06-2020' />);
  expect(wrapper.state('isoFormattedDate')).toEqual('2020-06-01');
});
```
would fail with
```
Expected: "2020-06-01"
Received: "2020-01-06"
```
where the isoFormattedDate was created with switched month and day values


And this test
```jsx
        test('should format isoFormattedDate when a custom dateFormat is passed in props', () => {
            const blur = jest.fn();
            const element = mount(<DatePicker
                dateFormat='DD-MM-YYYY'
                defaultValue='01-06-2020'
                onBlur={blur} />).find('input[type="text"]');
            element.find('input[type="text"]').simulate('click');
            element.find('input[type="text"]').simulate('change', { target: { value: '30-06-2020' } });
            element.find('input[type="text"]').simulate('blur');

            expect(blur).toHaveBeenCalledTimes(1);
            expect(blur).toHaveBeenCalledWith(expect.objectContaining({
                isoFormattedDate: '2020-06-30'
            }));
        });
```
would fail with

```
Expected: ObjectContaining {"isoFormattedDate": "2020-06-30"}
Received: {"date": "2020-06-30T05:00:00.000Z", "formattedDate": "30-06-2020", "isoFormattedDate": "Invalid date"}
```

where it would just fail to create the isoFormattedDate
