### PR TITLE
fix: Use `.days(0)` instead of `.startOf("week")` for datepicker

### DIFF
--- a/devtools/buildVisualStories.js
+++ b/devtools/buildVisualStories.js
@@ -4,7 +4,7 @@ const path = require('path');
 const srcPath = path.join(__dirname, '../src');
 
 const isComponentDirectory = (source) => {
-    const ignoredDirectories = ['utils', 'Docs'];
+    const ignoredDirectories = ['utils', 'Docs', 'Identifier', 'Image', 'Panel'];
     return lstatSync(source).isDirectory() && !ignoredDirectories.some(ignored => source.includes(ignored));
 };
 

--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -547,7 +547,7 @@ class Calendar extends Component {
         const enableRangeSelection = this.props.enableRangeSelection;
 
         const firstDayMonth = moment(currentDateDisplayed).startOf('month');
-        const firstDayWeekMonth = moment(firstDayMonth).startOf('week').weekday(this.normalizedWeekdayStart());
+        const firstDayWeekMonth = moment(firstDayMonth).day(0).day(this.normalizedWeekdayStart());
         const isAfterFirstDayMonth = moment(firstDayWeekMonth).isAfter(firstDayMonth);
 
         const rows = [];

--- a/src/Calendar/__stories__/Calendar.stories.js
+++ b/src/Calendar/__stories__/Calendar.stories.js
@@ -73,7 +73,7 @@ export const rangeSelection = () => (
 
 export const weekdayStart = () => {
     const _weekdayStart = number('weekdayStart', 1);
-    return <Calendar weekdayStart={_weekdayStart} />;
+    return <Calendar locale='es' weekdayStart={_weekdayStart} />;
 };
 
 export const dev = () => (

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -351,6 +351,39 @@ describe('<DatePicker />', () => {
         });
     });
 
+    describe('first displayed day', () => {
+        afterEach(() => {
+            document.body.innerHTML = '';
+        });
+        test('should be the first sunday before the start of the month in locale "es"', () => {
+            const element = mount(<DatePicker
+                dateFormat='DD/MM/YYYY'
+                defaultValue='20/06/2020'
+                locale='es' />);
+            element.find('button').simulate('click');
+            const firstDisplayedDay = document.body.querySelectorAll('.fd-calendar__item--other-month')[0].textContent;
+            expect(firstDisplayedDay).toBe('31'); // May 31st is the first day shown
+        });
+        test('should be the first sunday before the start of the month in locale "fr"', () => {
+            const element = mount(<DatePicker
+                dateFormat='DD/MM/YYYY'
+                defaultValue='01/07/2020'
+                locale='fr' />);
+            element.find('button').simulate('click');
+            const firstDisplayedDay = document.body.querySelectorAll('.fd-calendar__item--other-month')[0].textContent;
+            expect(firstDisplayedDay).toBe('28'); // June 28th is the first day shown
+        });
+        test('should be the first sunday before the start of the month in locale "fr"', () => {
+            const element = mount(<DatePicker
+                dateFormat='DD/MM/YYYY'
+                defaultValue='01/11/2020'
+                locale='fr' />);
+            element.find('button').simulate('click');
+            const firstDisplayedDay = document.body.querySelectorAll('.fd-calendar__item--other-month')[0].textContent;
+            expect(firstDisplayedDay).toBe('1'); // In this case December 1st is the first other-month date shown
+        });
+    });
+
     describe('onChange callback', () => {
         test('should call onChange on entering text input', () => {
             const change = jest.fn();

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -87,8 +87,14 @@ readOnly.storyName = 'ReadOnly';
 
 export const localized = () => (
     <div className='fddocs-container'>
-        <DatePicker locale='es' />
-        <DatePicker locale='fr' />
+        <DatePicker
+            dateFormat='DD/MM/YYYY'
+            defaultValue='20/07/2020'
+            locale='es' />
+        <DatePicker
+            dateFormat='DD/MM/YYYY'
+            defaultValue='20/06/2020'
+            locale='fr' />
     </div>
 );
 


### PR DESCRIPTION
### Description

Locales that are not "en" were returning the wrong values for `.startOf('week')`.  Similar to this issue with moment: https://github.com/moment/moment/issues/3593

But `.day(0)` does not have the same issue.
