### PR TITLE
fix: minimal weekday abbreviations

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -523,7 +523,7 @@ class Calendar extends Component {
 
     generateWeekdays = () => {
         const weekDays = [];
-        const daysName = moment.localeData(this.props.locale).weekdaysMin().map(day => day.charAt(0));
+        const daysName = moment.localeData(this.props.locale).weekdaysMin();
         const shiftedDaysName = this.shiftDays(this.normalizedWeekdayStart(), daysName);
 
         for (let index = 0; index < 7; index++) {

--- a/src/Calendar/Calendar.test.js
+++ b/src/Calendar/Calendar.test.js
@@ -464,7 +464,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('S');
+            expect(firstWeekday).toBe('Su');
             expect(firstDate).toBe('31'); // May 31, 2020
         });
         test('should render weekday start as Monday', () => {
@@ -472,7 +472,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('M');
+            expect(firstWeekday).toBe('Mo');
             expect(firstDate).toBe('1'); // June 1, 2020
         });
         test('should render weekday start as Tuesday', () => {
@@ -480,7 +480,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('T');
+            expect(firstWeekday).toBe('Tu');
             expect(firstDate).toBe('26'); // May 26, 2020 because our starting weekday is now after the first day of the month
         });
         test('should render weekday start as Wednesday', () => {
@@ -488,7 +488,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('W');
+            expect(firstWeekday).toBe('We');
             expect(firstDate).toBe('27'); // May 27, 2020
         });
         test('should render weekday start as Thursday', () => {
@@ -496,7 +496,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('T');
+            expect(firstWeekday).toBe('Th');
             expect(firstDate).toBe('28'); // May 28, 2020
         });
         test('should render weekday start as Friday', () => {
@@ -504,7 +504,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('F');
+            expect(firstWeekday).toBe('Fr');
             expect(firstDate).toBe('29'); // May 29, 2020
         });
         test('should render weekday start as Saturday', () => {
@@ -512,7 +512,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('S');
+            expect(firstWeekday).toBe('Sa');
             expect(firstDate).toBe('30'); // May 30, 2020
         });
         test('should render even when number as a string is passed in', () => {
@@ -520,7 +520,7 @@ describe('<Calendar />', () => {
             wrapper.setState({ currentDateDisplayed: date });
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
-            expect(firstWeekday).toBe('S');
+            expect(firstWeekday).toBe('Sa');
             expect(firstDate).toBe('30'); // May 30, 2020
         });
         test('should default to Sunday view when prop is not a number or a number as a string', () => {
@@ -530,7 +530,7 @@ describe('<Calendar />', () => {
             const firstWeekday = wrapper.find('th.fd-calendar__item .fd-calendar__text').first().text();
             const firstDate = wrapper.find('td').first().text();
             expect(consoleSpy).toHaveBeenCalled();
-            expect(firstWeekday).toBe('S');
+            expect(firstWeekday).toBe('Su');
             expect(firstDate).toBe('31'); // May 31, 2020
         });
     });


### PR DESCRIPTION
### Description

In this change, we use the complete minimal weekday abbreviations for all locales from moment.js in the Calendar component. There isn't a recommended length for weekday name abbreviations in the [Fiori design guidelines for datepicker](https://experience.sap.com/fiori-design-web/date-picker/).

Demo:
![UICOMP-1116](https://user-images.githubusercontent.com/43764832/85630682-ed09a200-b628-11ea-9b7a-c2092ceb3a55.gif)


fixes #1103 