### PR TITLE
feat:#1107 option to select productSwitchItem in Shellbar component

### DIFF
--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -487,7 +487,7 @@ Shellbar.propTypes = {
         label: PropTypes.string.isRequired
     }),
     /** Array of objects containing data about the products.
-     * Callback, title, and glyph are required; subtitle is optional. */
+     * Callback, title, and glyph are required; selected and subtitle are optional. */
     productSwitchList: PropTypes.arrayOf(
         PropTypes.shape({
             callback: PropTypes.func.isRequired,
@@ -495,6 +495,8 @@ Shellbar.propTypes = {
             title: PropTypes.string.isRequired,
             /** The icon to include. See the icon page for the list of icons */
             glyph: PropTypes.string.isRequired,
+            /** For pre-selecting an item in the switch list */
+            selected: PropTypes.bool,
             subtitle: PropTypes.string
         })
     ),

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -416,7 +416,7 @@ class Shellbar extends Component {
                                                 {productSwitchList.map((item, index) => {
                                                     return (
                                                         <li
-                                                            className='fd-product-switch__item'
+                                                            className={`fd-product-switch__item ${item.selected ? 'selected' : ''}`}
                                                             key={index}
                                                             onClick={item.callback}>
                                                             <div className={`fd-product-switch__icon sap-icon--${item.glyph}`} />

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -495,7 +495,7 @@ Shellbar.propTypes = {
             title: PropTypes.string.isRequired,
             /** The icon to include. See the icon page for the list of icons */
             glyph: PropTypes.string.isRequired,
-            /** For pre-selecting an item in the switch list */
+            /** For pre-selecting an item in the product switch list */
             selected: PropTypes.bool,
             subtitle: PropTypes.string
         })

--- a/src/Shellbar/__stories__/Shellbar.stories.js
+++ b/src/Shellbar/__stories__/Shellbar.stories.js
@@ -123,6 +123,7 @@ export const coPilot = () => (
                 title: 'Fiori Home',
                 subtitle: 'Central Home',
                 image: './assets/01.png',
+                selected: true,
                 glyph: 'home'
             },
             {


### PR DESCRIPTION
### Description

Product switch item in the Shellbar component does not have an option to show as preselected. Its available in fundamental-styles as below
https://sap.github.io/fundamental-styles/components/shellbar.html

fixes #issueid
#1107 
Added option to pre-select a product switch item in the Shellbar component.