### PR TITLE
fix: Use client-only-require for css imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,8 +9,7 @@ const defaultPresets = [
 
 const defaultPlugins = [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-transform-runtime', { corejs: 3, proposals: true }],
-    ['client-only-require', { 'extensions': ['less', 'scss', 'css'] }]
+    ['@babel/plugin-transform-runtime', { corejs: 3, proposals: true }]
 ];
 
 const productionPlugins = [
@@ -20,7 +19,8 @@ const productionPlugins = [
         {
             mode: 'unsafe-wrap'
         }
-    ]
+    ],
+    ['client-only-require', { 'extensions': ['less', 'scss', 'css'] }]
 ];
 
 module.exports = {

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,8 @@ const defaultPresets = [
 
 const defaultPlugins = [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-transform-runtime', { corejs: 3, proposals: true }]
+    ['@babel/plugin-transform-runtime', { corejs: 3, proposals: true }],
+    ['client-only-require', { 'extensions': ['less', 'scss', 'css'] }]
 ];
 
 const productionPlugins = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9294,6 +9294,12 @@
         "@mdx-js/util": "^1.6.5"
       }
     },
+    "babel-plugin-client-only-require": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-client-only-require/-/babel-plugin-client-only-require-1.0.1.tgz",
+      "integrity": "sha1-A86q5kiJ7s4nKbpZz7gQKYxVFUk=",
+      "dev": true
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.8.0",
     "babel-loader": "8.1.0",
+    "babel-plugin-client-only-require": "^1.0.1",
     "babel-plugin-named-asset-import": "^0.3.2",
     "babel-plugin-require-context-hook": "^1.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.23",


### PR DESCRIPTION
### Description

https://github.com/ValeryG/babel-plugin-client-only-require

fixes #issueid