### PR TITLE
fix: checkbox a11y

### DIFF
--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -61,8 +61,9 @@ const Checkbox = React.forwardRef(({
             ref={ref}>
             <input
                 {...inputProps}
-                checked={checked || defaultChecked}
+                checked={checked}
                 className={classes}
+                defaultChecked={defaultChecked}
                 disabled={disabled}
                 id={checkId}
                 name={name}

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -7,16 +7,6 @@ import shortId from '../utils/shortId';
 import React, { useEffect, useRef } from 'react';
 import 'fundamental-styles/dist/checkbox.css';
 
-const getCheckStatus = (checked, indeterminate) => {
-    if (indeterminate) {
-        return 'mixed';
-    } else if (checked) {
-        return 'true';
-    } else {
-        return 'false';
-    }
-};
-
 /** With a **Checkbox**, all options are visible and the user can make one or more selections.
 This component can also be disabled and displayed in a row */
 
@@ -71,7 +61,6 @@ const Checkbox = React.forwardRef(({
             ref={ref}>
             <input
                 {...inputProps}
-                aria-checked={getCheckStatus(checked, indeterminate)}
                 checked={checked || defaultChecked}
                 className={classes}
                 disabled={disabled}

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -14,7 +14,7 @@ describe('<Checkbox />', () => {
                 onChange: () => {}
             });
 
-            expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').getDOMNode().checked).toBe(true);
         });
 
         test('should add checked attribute if defaultChecked is true', () => {
@@ -23,7 +23,7 @@ describe('<Checkbox />', () => {
                 onChange: () => {}
             });
 
-            expect(element.find('input').props().checked).toBe(true);
+            expect(element.find('input').getDOMNode().checked).toBe(true);
         });
 
         test('should add indeterminate property when indeterminate is passed', () => {
@@ -32,8 +32,7 @@ describe('<Checkbox />', () => {
                 onChange: () => {}
             });
 
-            const checkbox = element.find('input').getDOMNode();
-            expect(checkbox.indeterminate).toBe(true);
+            expect(element.find('input').getDOMNode().indeterminate).toBe(true);
         });
 
         test('should set disabled to true when passed', () => {
@@ -41,7 +40,7 @@ describe('<Checkbox />', () => {
                 disabled: true
             });
 
-            expect(element.find('input').props().disabled).toBe(true);
+            expect(element.find('input').getDOMNode().disabled).toBe(true);
         });
 
         test('should add inline class when inline is passed', () => {

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -15,7 +15,6 @@ describe('<Checkbox />', () => {
             });
 
             expect(element.find('input').props().checked).toBe(true);
-            expect(element.find('input').props()['aria-checked']).toBe('true');
         });
 
         test('should add checked attribute if defaultChecked is true', () => {
@@ -25,20 +24,16 @@ describe('<Checkbox />', () => {
             });
 
             expect(element.find('input').props().checked).toBe(true);
-
-            // TODO: The aria-checked does not reflect the current state of the checkbox if it is uncontrolled
-            // expect(element.find('input').props()['aria-checked']).toBe('true');
         });
 
-        test('should add aria-checked attribute of "mixed" if indeterminate is true', () => {
+        test('should add indeterminate property when indeterminate is passed', () => {
             let element = setup({
                 indeterminate: true,
-                defaultChecked: true,
                 onChange: () => {}
             });
 
-            expect(element.find('input').props().checked).toBe(true);
-            expect(element.find('input').props()['aria-checked']).toBe('mixed');
+            const checkbox = element.find('input').getDOMNode();
+            expect(checkbox.indeterminate).toBe(true);
         });
 
         test('should set disabled to true when passed', () => {

--- a/src/Forms/__stories__/Checkbox.stories.js
+++ b/src/Forms/__stories__/Checkbox.stories.js
@@ -16,6 +16,12 @@ export const primary = () => (<Checkbox>Default Checkbox</Checkbox>);
 export const indeterminate = () => (
     <Checkbox indeterminate>Text Option</Checkbox>
 );
+export const controlledChecked = () => (
+    <Checkbox checked={boolean('checked (controlled)', false)}>Text Option</Checkbox>
+);
+export const defaultChecked = () => (
+    <Checkbox defaultChecked>Text Option</Checkbox>
+);
 export const disabled = () => (
     <Checkbox disabled>Text Option</Checkbox>
 );
@@ -46,5 +52,5 @@ export const dev = () => (
         })}>Text Option</Checkbox>
 );
 
-
+controlledChecked.parameters = { docs: { disable: true } };
 dev.parameters = { docs: { disable: true } };

--- a/src/Forms/__stories__/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Forms/__stories__/__snapshots__/Checkbox.stories.storyshot
@@ -23,6 +23,54 @@ exports[`Storyshots Component API/Forms/Checkbox Compact 1`] = `
 </div>
 `;
 
+exports[`Storyshots Component API/Forms/Checkbox Controlled Checked 1`] = `
+<div
+  dir="ltr"
+>
+  <div
+    className="fd-form-item"
+  >
+    <input
+      checked={false}
+      className="fd-checkbox"
+      id="fd-mocked-short-id"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className="fd-form-label fd-checkbox__label"
+      htmlFor="fd-mocked-short-id"
+    >
+      Text Option
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Component API/Forms/Checkbox Default Checked 1`] = `
+<div
+  dir="ltr"
+>
+  <div
+    className="fd-form-item"
+  >
+    <input
+      className="fd-checkbox"
+      defaultChecked={true}
+      id="fd-mocked-short-id"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <label
+      className="fd-form-label fd-checkbox__label"
+      htmlFor="fd-mocked-short-id"
+    >
+      Text Option
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Component API/Forms/Checkbox Dev 1`] = `
 <div
   dir="ltr"

--- a/src/Forms/__stories__/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Forms/__stories__/__snapshots__/Checkbox.stories.storyshot
@@ -8,7 +8,6 @@ exports[`Storyshots Component API/Forms/Checkbox Compact 1`] = `
     className="fd-form-item"
   >
     <input
-      aria-checked="false"
       className="fd-checkbox fd-checkbox--compact"
       id="fd-mocked-short-id"
       onChange={[Function]}
@@ -33,7 +32,6 @@ exports[`Storyshots Component API/Forms/Checkbox Dev 1`] = `
     disabled={false}
   >
     <input
-      aria-checked="false"
       className="fd-checkbox"
       disabled={false}
       id="fd-mocked-short-id"
@@ -59,7 +57,6 @@ exports[`Storyshots Component API/Forms/Checkbox Disabled 1`] = `
     disabled={true}
   >
     <input
-      aria-checked="false"
       className="fd-checkbox"
       disabled={true}
       id="fd-mocked-short-id"
@@ -84,7 +81,6 @@ exports[`Storyshots Component API/Forms/Checkbox Indeterminate 1`] = `
     className="fd-form-item"
   >
     <input
-      aria-checked="mixed"
       className="fd-checkbox"
       id="fd-mocked-short-id"
       onChange={[Function]}
@@ -108,7 +104,6 @@ exports[`Storyshots Component API/Forms/Checkbox Primary 1`] = `
     className="fd-form-item"
   >
     <input
-      aria-checked="false"
       className="fd-checkbox"
       id="fd-mocked-short-id"
       onChange={[Function]}
@@ -135,7 +130,6 @@ exports[`Storyshots Component API/Forms/Checkbox Validation State 1`] = `
       className="fd-form-item"
     >
       <input
-        aria-checked="false"
         className="fd-checkbox is-error"
         id="fd-mocked-short-id"
         onChange={[Function]}
@@ -152,7 +146,6 @@ exports[`Storyshots Component API/Forms/Checkbox Validation State 1`] = `
       className="fd-form-item"
     >
       <input
-        aria-checked="false"
         className="fd-checkbox is-warning"
         id="fd-mocked-short-id"
         onChange={[Function]}
@@ -169,7 +162,6 @@ exports[`Storyshots Component API/Forms/Checkbox Validation State 1`] = `
       className="fd-form-item"
     >
       <input
-        aria-checked="false"
         className="fd-checkbox is-success"
         id="fd-mocked-short-id"
         onChange={[Function]}
@@ -186,7 +178,6 @@ exports[`Storyshots Component API/Forms/Checkbox Validation State 1`] = `
       className="fd-form-item"
     >
       <input
-        aria-checked="false"
         className="fd-checkbox is-information"
         id="fd-mocked-short-id"
         onChange={[Function]}

--- a/src/List/__stories__/__snapshots__/List.stories.storyshot
+++ b/src/List/__stories__/__snapshots__/List.stories.storyshot
@@ -713,7 +713,6 @@ exports[`Storyshots Component API/List Selection 1`] = `
           className="fd-form-item fd-form-item--inline"
         >
           <input
-            aria-checked="false"
             className="fd-checkbox"
             id="fd-mocked-short-id"
             onChange={[Function]}
@@ -743,7 +742,6 @@ exports[`Storyshots Component API/List Selection 1`] = `
           className="fd-form-item fd-form-item--inline"
         >
           <input
-            aria-checked="false"
             className="fd-checkbox"
             id="fd-mocked-short-id"
             onChange={[Function]}
@@ -773,7 +771,6 @@ exports[`Storyshots Component API/List Selection 1`] = `
           className="fd-form-item fd-form-item--inline"
         >
           <input
-            aria-checked="false"
             className="fd-checkbox"
             id="fd-mocked-short-id"
             onChange={[Function]}
@@ -803,7 +800,6 @@ exports[`Storyshots Component API/List Selection 1`] = `
           className="fd-form-item fd-form-item--inline"
         >
           <input
-            aria-checked="false"
             className="fd-checkbox"
             id="fd-mocked-short-id"
             onChange={[Function]}

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -25,6 +25,8 @@ class MultiInput extends Component {
             bShowList: false,
             tags: []
         };
+
+        this.multiInputId = shortid.generate();
     }
 
     // create tags to display in dropdown list
@@ -35,8 +37,8 @@ class MultiInput extends Component {
                     checked={this.isChecked(item)}
                     className='fd-list__input'
                     compact={this.props.compact}
-                    id={index + `_${shortid.generate()}`}
-                    labelClasses='fd-list__label'
+                    id={index + `_${this.multiInputId}`}
+                    labelClassName='fd-list__label'
                     onChange={() => this.updateSelectedTags(item)}
                     value={item}>
                     <List.Text>{item}</List.Text>

--- a/src/Table/__stories__/__snapshots__/Table.stories.storyshot
+++ b/src/Table/__stories__/__snapshots__/Table.stories.storyshot
@@ -111,7 +111,6 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
             className="fd-form-item"
           >
             <input
-              aria-checked="false"
               className="fd-checkbox"
               id="fd-mocked-short-id"
               onChange={[Function]}
@@ -168,7 +167,6 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
             className="fd-form-item"
           >
             <input
-              aria-checked="false"
               className="fd-checkbox"
               id="fd-mocked-short-id"
               onChange={[Function]}
@@ -258,7 +256,6 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
             className="fd-form-item"
           >
             <input
-              aria-checked="false"
               className="fd-checkbox"
               id="fd-mocked-short-id"
               onChange={[Function]}
@@ -348,7 +345,6 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
             className="fd-form-item"
           >
             <input
-              aria-checked="false"
               className="fd-checkbox"
               id="fd-mocked-short-id"
               onChange={[Function]}
@@ -438,7 +434,6 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
             className="fd-form-item"
           >
             <input
-              aria-checked="false"
               className="fd-checkbox"
               id="fd-mocked-short-id"
               onChange={[Function]}


### PR DESCRIPTION
### Description

- `aria-checked` is unneeded on a native `input type="checkbox"` and was not properly reflecting the state of the checkbox
- `checked` and `defaultChecked` should be set independently
- MultiInput was changing Checkbox ids on every render

Out of Scope:
- clicking checkbox fast 3+ times results in a crash in Chrome only (see https://github.com/SAP/fundamental-styles/issues/1197)