### PR TITLE
fix: Clear up DOM warnings

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -671,6 +671,7 @@ class Calendar extends Component {
             tableProps,
             tableHeaderProps,
             tableBodyProps,
+            showToday,
             specialDays,
             weekdayStart,
             ...props

--- a/src/InputGroup/InputGroup.js
+++ b/src/InputGroup/InputGroup.js
@@ -44,7 +44,7 @@ class InputGroup extends Component {
                 {...props}
                 className={inputGroupClasses}>
                 {React.Children.toArray(children).map(child => {
-                    if (child && child.type && child.type.displayName === InputGroupAddon.displayName) {
+                    if (child?.type?.displayName === InputGroupAddon.displayName) {
                         return React.cloneElement(child, {
                             compact,
                             disabled

--- a/src/InputGroup/InputGroup.js
+++ b/src/InputGroup/InputGroup.js
@@ -34,8 +34,7 @@ class InputGroup extends Component {
 
         const getClassName = (child) => classnames(
             {
-                'fd-input-group__input': child.type.displayName !== InputGroupAddon.displayName &&
-                    !child.props.className?.includes('fd-tokenizer')
+                'fd-input-group__input': !child.props.className?.includes('fd-tokenizer')
             },
             child.props.className
         );
@@ -45,6 +44,12 @@ class InputGroup extends Component {
                 {...props}
                 className={inputGroupClasses}>
                 {React.Children.toArray(children).map(child => {
+                    if (child && child.type && child.type.displayName === InputGroupAddon.displayName) {
+                        return React.cloneElement(child, {
+                            compact,
+                            disabled
+                        });
+                    }
                     return React.cloneElement(child, {
                         compact,
                         disabled,

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -233,9 +233,9 @@ Popper.displayName = 'Popper';
 Popper.propTypes = {
     children: PropTypes.node.isRequired,
     cssBlock: PropTypes.string.isRequired,
-    innerRef: PropTypes.func.isRequired,
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
+    innerRef: PropTypes.func,
     noArrow: PropTypes.bool,
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.array,

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -184,7 +184,8 @@ class Popper extends React.Component {
                             className={popperClasses}
                             ref={ref}
                             style={{ ...style, ...popperProps.style, ...fundamentalStyleOverrides }}
-                            x-out-of-boundaries={isReferenceHidden}
+                            // eslint-disable-next-line no-undefined
+                            x-out-of-boundaries={isReferenceHidden ? 'true' : undefined}
                             // This is needed for fundamental-styles even though popper-2 uses data-placement as well
                             x-placement={placement}>
                             <div ref={innerRef}>


### PR DESCRIPTION
### Description

```
Warning: Failed prop type: The prop `innerRef` is marked as required in `Popper`, but its value is `undefined`.
    in Popper (created by FormValidationOverlay)
    in FormValidationOverlay (created by InputGroup)
```

```
Warning: React does not recognize the `validationState` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `validationstate` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in span (created by InputGroup.Addon)
    in InputGroup.Addon (created by DatePicker)
```

```
Warning: Received `false` for a non-boolean attribute `x-out-of-boundaries`.

If you want to write it to the DOM, pass a string instead: x-out-of-boundaries="false" or x-out-of-boundaries={value.toString()}.

If you used to conditionally omit it with x-out-of-boundaries={condition && value}, pass x-out-of-boundaries={condition ? value : undefined} instead.
    in div (created by Popper)
    in Popper (created by Popper)
```

```
Warning: React does not recognize the `showToday` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `showtoday` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by Calendar)
    in Calendar (created by DatePicker)
```


fixes #issueid