### PR TITLE
fix: prevent disabled and readonly select from opening

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -39,6 +39,12 @@ const Select = React.forwardRef(({
 
     let [selectedOptionKey, setSelectedOptionKey] = useState(selectedKey);
 
+    const handleClick = (e) => {
+        if (!disabled && !readOnly) {
+            onClick(e);
+        }
+    };
+
     const handleSelect = (e, option) => {
         const popover = popoverRef && popoverRef.current;
         popover && popover.handleEscapeKey();
@@ -114,6 +120,7 @@ const Select = React.forwardRef(({
             aria-disabled={disabled}
             aria-readonly={readOnly}
             control={selectControl}
+            onClick={handleClick}
             role={'combobox'}
             tabIndex={tabIndex}
             validationState={validationState} />

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -39,9 +39,29 @@ const Select = React.forwardRef(({
 
     let [selectedOptionKey, setSelectedOptionKey] = useState(selectedKey);
 
+    const openPopover = () => {
+        const popover = popoverRef && popoverRef.current;
+        popover && popover.triggerBody();
+    };
+
     const handleClick = (e) => {
         if (!disabled && !readOnly) {
+            openPopover();
+
             onClick(e);
+        }
+    };
+
+    const handleKeyDown = (e) => {
+        if (!disabled && !readOnly) {
+            switch (keycode(e)) {
+                case 'enter':
+                case 'space':
+                    e.preventDefault();
+                    openPopover();
+                    break;
+                default:
+            }
         }
     };
 
@@ -105,7 +125,6 @@ const Select = React.forwardRef(({
             {...props}
             className={selectClasses}
             id={id}
-            onClick={handleClick}
             ref={divRef}>
             <div className={selectControlClasses}>
                 <span aria-label={selectAriaLabel} className='fd-select__text-content'>{textContent}</span>
@@ -114,12 +133,17 @@ const Select = React.forwardRef(({
         </div>
     );
 
+    const tabIndex = disabled ? -1 : 0;
+
     const wrappedSelectControl = (
         <FormValidationOverlay
             aria-disabled={disabled}
             aria-readonly={readOnly}
             control={selectControl}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
             role={'combobox'}
+            tabIndex={tabIndex}
             validationState={validationState} />
     );
 
@@ -162,6 +186,8 @@ const Select = React.forwardRef(({
                     </List>
                 </>)}
             control={wrappedSelectControl}
+            disableKeyPressHandler
+            disableTriggerOnClick
             firstFocusIndex={firstFocusIndex}
             noArrow
             placement='bottom-start'

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -39,32 +39,6 @@ const Select = React.forwardRef(({
 
     let [selectedOptionKey, setSelectedOptionKey] = useState(selectedKey);
 
-    const openPopover = () => {
-        const popover = popoverRef && popoverRef.current;
-        popover && popover.triggerBody();
-    };
-
-    const handleClick = (e) => {
-        if (!disabled && !readOnly) {
-            openPopover();
-
-            onClick(e);
-        }
-    };
-
-    const handleKeyDown = (e) => {
-        if (!disabled && !readOnly) {
-            switch (keycode(e)) {
-                case 'enter':
-                case 'space':
-                    e.preventDefault();
-                    openPopover();
-                    break;
-                default:
-            }
-        }
-    };
-
     const handleSelect = (e, option) => {
         const popover = popoverRef && popoverRef.current;
         popover && popover.handleEscapeKey();
@@ -140,8 +114,6 @@ const Select = React.forwardRef(({
             aria-disabled={disabled}
             aria-readonly={readOnly}
             control={selectControl}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
             role={'combobox'}
             tabIndex={tabIndex}
             validationState={validationState} />
@@ -186,8 +158,8 @@ const Select = React.forwardRef(({
                     </List>
                 </>)}
             control={wrappedSelectControl}
-            disableKeyPressHandler
-            disableTriggerOnClick
+            disableKeyPressHandler={disabled || readOnly}
+            disableTriggerOnClick={disabled || readOnly}
             firstFocusIndex={firstFocusIndex}
             noArrow
             placement='bottom-start'

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -29,9 +29,12 @@ exports[`Storyshots Component API/Select Compact 1`] = `
               className="fd-popover__control"
             >
               <div
+                aria-controls="fd-mocked-short-id"
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="fd-select fd-select--compact"
                 onClick={[Function]}
-                onKeyDown={[Function]}
+                onKeyPress={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -87,10 +90,13 @@ exports[`Storyshots Component API/Select Dev 1`] = `
               className="fd-popover__control"
             >
               <div
+                aria-controls="fd-mocked-short-id"
                 aria-disabled={false}
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyDown={[Function]}
+                onKeyPress={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -148,8 +154,6 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
               <div
                 aria-disabled={true}
                 className="fd-select"
-                onClick={[Function]}
-                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={-1}
               >
@@ -205,9 +209,12 @@ exports[`Storyshots Component API/Select Empty Option 1`] = `
               className="fd-popover__control"
             >
               <div
+                aria-controls="fd-mocked-short-id"
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyDown={[Function]}
+                onKeyPress={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -261,9 +268,12 @@ exports[`Storyshots Component API/Select Primary 1`] = `
               className="fd-popover__control"
             >
               <div
+                aria-controls="fd-mocked-short-id"
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyDown={[Function]}
+                onKeyPress={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -321,8 +331,6 @@ exports[`Storyshots Component API/Select Read Only 1`] = `
               <div
                 aria-readonly={true}
                 className="fd-select"
-                onClick={[Function]}
-                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -378,9 +386,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -429,9 +440,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -480,9 +494,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -531,9 +548,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -29,12 +29,9 @@ exports[`Storyshots Component API/Select Compact 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="fd-select fd-select--compact"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -90,13 +87,10 @@ exports[`Storyshots Component API/Select Dev 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
                 aria-disabled={false}
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -152,15 +146,12 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
                 aria-disabled={true}
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
-                tabIndex={0}
+                tabIndex={-1}
               >
                 <div
                   className="fd-select__control is-disabled"
@@ -214,12 +205,9 @@ exports[`Storyshots Component API/Select Empty Option 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -273,12 +261,9 @@ exports[`Storyshots Component API/Select Primary 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -334,13 +319,10 @@ exports[`Storyshots Component API/Select Read Only 1`] = `
               className="fd-popover__control"
             >
               <div
-                aria-controls="fd-mocked-short-id"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 aria-readonly={true}
                 className="fd-select"
                 onClick={[Function]}
-                onKeyPress={[Function]}
+                onKeyDown={[Function]}
                 role="combobox"
                 tabIndex={0}
               >
@@ -396,12 +378,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyPress={[Function]}
+                  onKeyDown={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -450,12 +429,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyPress={[Function]}
+                  onKeyDown={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -504,12 +480,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyPress={[Function]}
+                  onKeyDown={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >
@@ -558,12 +531,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                 className="fd-popover__control"
               >
                 <div
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="fd-select"
                   onClick={[Function]}
-                  onKeyPress={[Function]}
+                  onKeyDown={[Function]}
                   role="combobox"
                   tabIndex={0}
                 >

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -154,6 +154,7 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
               <div
                 aria-disabled={true}
                 className="fd-select"
+                onClick={[Function]}
                 role="combobox"
                 tabIndex={-1}
               >
@@ -331,6 +332,7 @@ exports[`Storyshots Component API/Select Read Only 1`] = `
               <div
                 aria-readonly={true}
                 className="fd-select"
+                onClick={[Function]}
                 role="combobox"
                 tabIndex={0}
               >


### PR DESCRIPTION
### Description

- disable Popover triggers on disabled and readonly Select
- move onClick to right component