### PR TITLE
feat: Use the popperPlacement prop to allow fallbackPlacements

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -97,7 +97,6 @@ class Popover extends Component {
             disableEdgeDetection,
             disableKeyPressHandler,
             disableTriggerOnClick,
-            fallbackPlacements,
             flipContainer,
             firstFocusIndex,
             onClickOutside,
@@ -173,7 +172,6 @@ class Popover extends Component {
                 <Popper
                     cssBlock='fd-popover'
                     disableEdgeDetection={disableEdgeDetection}
-                    fallbackPlacements={fallbackPlacements}
                     flipContainer={flipContainer}
                     innerRef={innerRef}
                     noArrow={noArrow}
@@ -213,8 +211,6 @@ Popover.propTypes = {
     /** Set to **true** to remove default triggerBody handler used in onClick.
      * Useful for when a custom method is desired to open the Popover */
     disableTriggerOnClick: PropTypes.bool,
-    /** Where else to position the popover when the original placement is out of bounds */
-    fallbackPlacements: PropTypes.arrayOf(PropTypes.oneOf(POPPER_PLACEMENTS)),
     /** Index of the focusable item to focus first within the Popover */
     firstFocusIndex: PropTypes.number,
     /** The bounding container to use when determining if the popover is out of bounds */
@@ -224,7 +220,10 @@ Popover.propTypes = {
     ]),
     /** Set to **true** to render a popover without an arrow */
     noArrow: PropTypes.bool,
-    /** 'bottom-start',
+    /** The options are 'auto',
+    'auto-start',
+    'auto-end',
+    'bottom-start',
     'bottom',
     'bottom-end',
     'left-start',
@@ -235,8 +234,13 @@ Popover.propTypes = {
     'right-end',
     'top-start',
     'top',
-    'top-end' */
-    placement: PropTypes.oneOf(POPPER_PLACEMENTS),
+    'top-end'
+    You can also pass an array of these to specify which placements to fallback to
+    */
+    placement: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.oneOf(POPPER_PLACEMENTS)),
+        PropTypes.oneOf(POPPER_PLACEMENTS)
+    ]),
     /** Additional classeNames to be spread to the overlay element */
     popperClassName: PropTypes.string,
     /** Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a> */

--- a/src/Popover/Popover.test.js
+++ b/src/Popover/Popover.test.js
@@ -250,8 +250,8 @@ describe('<Popover />', () => {
             expect(flipModifier.enabled).not.toBeDefined();
         });
 
-        test('fallback placements props', () => {
-            const popoverWithParent = mount(popOver).setProps({ fallbackPlacements: ['top'] });
+        test('fallback placements', () => {
+            const popoverWithParent = mount(popOver).setProps({ placement: ['right', 'top'] });
             const popperComponent = popoverWithParent.find(ReactPopper);
             const flipModifier = popperComponent.props().modifiers.find(m => m.name === 'flip');
             expect(flipModifier.options.fallbackPlacements).toEqual(['top']);
@@ -261,7 +261,7 @@ describe('<Popover />', () => {
             const popoverWithParent = mount(popOver).setProps({ });
             const popperComponent = popoverWithParent.find(ReactPopper);
             const flipModifier = popperComponent.props().modifiers.find(m => m.name === 'flip');
-            expect(flipModifier.options.fallbackPlacements).toEqual(Popper.defaultProps.fallbackPlacements);
+            expect(flipModifier.options.fallbackPlacements).toEqual(Popper.defaultProps.popperPlacement.slice(1));
         });
 
         test('flip container props', () => {

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -5,10 +5,8 @@ import Dialog from '../../Dialog/Dialog';
 import Icon from '../../Icon/Icon';
 import Menu from '../../Menu/Menu';
 import Popover from '../Popover';
-import Popper from '../../utils/_Popper';
 import { POPPER_PLACEMENTS } from '../../utils/constants';
 import {
-    array,
     boolean,
     select
 } from '@storybook/addon-knobs';
@@ -230,9 +228,8 @@ export const withCustomFlipContainer = () => {
                 <Popover
                     body={bodyContent}
                     control={<Button glyph='navigation-up-arrow' option='transparent' />}
-                    fallbackPlacements={['left', 'right', 'top']}
                     flipContainer={container}
-                    placement='bottom' />
+                    placement={['bottom', 'left', 'right', 'top']} />
             </div>
         </div>
     );
@@ -351,9 +348,6 @@ export const dev = () => {
             disableEdgeDetection={boolean('disableEdgeDetection', false)}
             disableKeyPressHandler={boolean('disableKeyPressHandler', false)}
             disabled={boolean('disabled', false)}
-            fallbackPlacements={array('fallbackPlacements',
-                Popper.defaultProps.fallbackPlacements
-            )}
             // eslint-disable-next-line no-undefined
             flipContainer={useContainer ? container : undefined}
             noArrow={boolean('noArrow', false)}

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -28,7 +28,7 @@ const defaultModifiers = [
 
 const createFlipModifier = ({
     disableEdgeDetection,
-    fallbackPlacements,
+    popperPlacement,
     flipContainer
 }) => {
     if (disableEdgeDetection) {
@@ -38,12 +38,15 @@ const createFlipModifier = ({
         };
     }
 
+    const options = {
+        boundary: flipContainer
+    };
+    if (Array.isArray(popperPlacement)) {
+        options.fallbackPlacements = popperPlacement.slice(1);
+    }
     return {
         name: 'flip',
-        options: {
-            fallbackPlacements,
-            boundary: flipContainer
-        }
+        options
     };
 };
 
@@ -140,7 +143,6 @@ class Popper extends React.Component {
             children,
             cssBlock,
             disableEdgeDetection,
-            fallbackPlacements,
             flipContainer,
             innerRef,
             noArrow,
@@ -159,7 +161,7 @@ class Popper extends React.Component {
 
         const modifiers = [
             ...defaultModifiers,
-            createFlipModifier({ disableEdgeDetection, fallbackPlacements, flipContainer }),
+            createFlipModifier({ disableEdgeDetection, popperPlacement, flipContainer }),
             ...popperModifiers
         ];
         if (widthSizingType === 'matchTarget') {
@@ -175,10 +177,14 @@ class Popper extends React.Component {
             [`${cssBlock}__popper--no-arrow`]: !!noArrow
         });
 
+        const basePlacement = Array.isArray(popperPlacement)
+            ? popperPlacement[0]
+            : popperPlacement;
+
         let popper = (
             <ReactPopper
                 modifiers={modifiers}
-                placement={popperPlacement}>
+                placement={basePlacement}>
                 {({ ref, style, isReferenceHidden, arrowProps, placement }) => {
                     if (!show) {
                         return null;
@@ -247,7 +253,6 @@ Popper.propTypes = {
     cssBlock: PropTypes.string.isRequired,
     referenceComponent: PropTypes.element.isRequired,
     disableEdgeDetection: PropTypes.bool,
-    fallbackPlacements: PropTypes.arrayOf(PropTypes.oneOf(POPPER_PLACEMENTS)),
     flipContainer: PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.instanceOf(Element)),
         PropTypes.instanceOf(Element)
@@ -256,7 +261,10 @@ Popper.propTypes = {
     noArrow: PropTypes.bool,
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.array,
-    popperPlacement: PropTypes.oneOf(POPPER_PLACEMENTS),
+    popperPlacement: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.oneOf(POPPER_PLACEMENTS)),
+        PropTypes.oneOf(POPPER_PLACEMENTS)
+    ]),
     popperProps: PropTypes.object,
     referenceClassName: PropTypes.string,
     referenceProps: PropTypes.object,
@@ -269,9 +277,8 @@ Popper.propTypes = {
 };
 
 Popper.defaultProps = {
-    fallbackPlacements: ['bottom-start', 'top-start', 'bottom-end', 'top-end'],
     popperModifiers: [],
-    popperPlacement: 'bottom-start',
+    popperPlacement: ['bottom-start', 'top-start', 'bottom-end', 'top-end'],
     onClickOutside: () => { },
     onKeyDown: () => { }
 };


### PR DESCRIPTION
### Description

This came up as an improved way to implement fallback placements for popper components.  Basically the popperPlacement prop can be a single string and utilize Popper's default of flipping to the opposite placement
i.e. "bottom-end" would flip to "top-end" by default

or they can specify an array of placements to use.  `popperPlacement={['bottom-end', 'right', 'top']}`

This needed to be implemented to better support flip containers, DOM elements which the popper should stay within, in this PR https://github.com/SAP/fundamental-react/pull/1122. 

NOTE: The exposed `fallbackPlacements` prop has only been in an rc release, so it's not a breaking change outside of the current rc


fixes #issueid