### PR TITLE
fix: DatePicker cleanup PropTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26952,7 +26952,7 @@
       }
     },
     "react-popper-2": {
-      "version": "npm:react-popper-2@2.2.3",
+      "version": "npm:react-popper@2.2.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.3.tgz",
       "integrity": "sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26952,7 +26952,7 @@
       }
     },
     "react-popper-2": {
-      "version": "2.2.3",
+      "version": "npm:react-popper-2@2.2.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.3.tgz",
       "integrity": "sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26952,7 +26952,7 @@
       }
     },
     "react-popper-2": {
-      "version": "npm:react-popper@2.2.3",
+      "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.3.tgz",
       "integrity": "sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==",
       "dev": true,
@@ -26995,6 +26995,11 @@
           }
         }
       }
+    },
+    "react-required-if": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-required-if/-/react-required-if-1.0.3.tgz",
+      "integrity": "sha1-akCnYbHVSBXB1OZhCRDL+StaqYc="
     },
     "react-router": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-focus-lock": "^2.3.1",
     "react-overlays": "^3.2.0",
     "react-popper": "^2.2.3",
+    "react-required-if": "^1.0.3",
     "shortid": "^2.2.14",
     "tabbable": "^4.0.0"
   },

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -8,6 +8,7 @@ import { isEnabledDate } from '../utils/dateUtils';
 import moment from 'moment';
 import Popover from '../Popover/Popover';
 import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
 import { validDateLookup } from './_validDateLookup';
 import { DATEPICKER_TODAY_ACTIONS_TYPES, FORM_MESSAGE_TYPES } from '../utils/constants';
 import React, { Component } from 'react';
@@ -541,7 +542,10 @@ DatePicker.propTypes = {
     */
     todayAction: PropTypes.shape({
         type: PropTypes.oneOf(DATEPICKER_TODAY_ACTIONS_TYPES),
-        label: PropTypes.string.isRequired
+        label: requiredIf(PropTypes.string, todayAction => {
+            const todayActionType = todayAction?.type?.trim();
+            return todayActionType === 'select' || todayActionType === 'navigate';
+        })
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`;
      * _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -576,6 +576,7 @@ DatePicker.defaultProps = {
     defaultValue: '',
     dateFormat: null,
     locale: 'en',
+    localizedText: Calendar.defaultProps.localizedText,
     todayAction: {
         type: 'none'
     },

--- a/src/utils/CustomPropTypes/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes/CustomPropTypes.js
@@ -95,8 +95,16 @@ const i18n = (obj) => {
         const valueKeys = Object.keys(value);
 
         if (valueKeys.length !== shapeKeys.length) {
-            let missingKeys = shapeKeys.filter(key => !valueKeys.some(k => key === k));
-            return new Error(`The ${location} \`${propFullName}\` supplied to \`${componentName}\` only has ${valueKeys.length} strings when ${shapeKeys.length} were expected. Missing ${missingKeys.map(key => `\`${key}\``).join(', ')}.`);
+            let missMatchType = '';
+            let missMatchKeys = [];
+            if (valueKeys.length < shapeKeys.length) {
+                missMatchType = 'Missing';
+                missMatchKeys = shapeKeys.filter(key => !valueKeys.some(k => key === k));
+            } else {
+                missMatchType = 'Extra';
+                missMatchKeys = valueKeys.filter(key => !shapeKeys.some(k => key === k));
+            }
+            return new Error(`The ${location} \`${propFullName}\` supplied to \`${componentName}\` has ${valueKeys.length} string(s) when ${shapeKeys.length} were expected. ${missMatchType} ${missMatchKeys.map(key => `\`${key}\``).join(', ')}.`);
         }
 
         return null;


### PR DESCRIPTION
### Description
Cleanup prop type warnings

## Before - [Primary DatePicker Story](https://sap.github.io/fundamental-react/?path=/story/component-api-datepicker--primary)
![image](https://user-images.githubusercontent.com/43764832/88112912-9fb81c00-cb65-11ea-96c4-a14d6c4162c9.png)


## After - [Primary DatePicker Story](https://deploy-preview-1131--fundamental-react.netlify.app/?path=/story/component-api-datepicker--primary)
![image](https://user-images.githubusercontent.com/43764832/88113027-d5f59b80-cb65-11ea-9dcc-e38b253080b2.png)
