### PR TITLE
Fix: #1129 Fixing error in showing + button for readOnly StepInput

### DIFF
--- a/src/StepInput/StepInput.js
+++ b/src/StepInput/StepInput.js
@@ -119,6 +119,7 @@ const StepInput = React.forwardRef(({
                 value={inputValue} />
             <Button
                 aria-label={localizedText.stepUpLabel}
+                className='fd-step-input__button'
                 compact={compact}
                 disabled={disabled}
                 glyph='add'

--- a/src/StepInput/__stories__/StepInput.stories.js
+++ b/src/StepInput/__stories__/StepInput.stories.js
@@ -25,6 +25,10 @@ export const disabled = () => (
     <StepInput disabled />
 );
 
+export const readOnly = () => (
+    <StepInput readOnly />
+);
+
 export const validationStates = () => (
     <>
         <StepInput placeholder='Error'

--- a/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
+++ b/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
@@ -36,7 +36,7 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent fd-button--compact sap-icon--add"
+            className="fd-button fd-button--transparent fd-button--compact sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
@@ -87,7 +87,7 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             disabled={false}
             onClick={[Function]}
             tabIndex="-1"
@@ -138,7 +138,7 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add is-disabled"
+            className="fd-button fd-button--transparent sap-icon--add is-disabled fd-step-input__button"
             disabled={true}
             onClick={[Function]}
             tabIndex="-1"
@@ -187,7 +187,55 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            onClick={[Function]}
+            tabIndex="-1"
+            type="button"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Component API/StepInput Read Only 1`] = `
+<div
+  dir="ltr"
+>
+  <div
+    className="fd-popover"
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="fd-popover__control"
+      >
+        <div
+          className="fd-step-input is-readonly"
+          onKeyDown={[Function]}
+        >
+          <button
+            aria-label="Step Down"
+            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            onClick={[Function]}
+            tabIndex="-1"
+            type="button"
+          />
+          <input
+            className="fd-input fd-input--no-number-spinner fd-step-input__input"
+            onChange={[Function]}
+            type="text"
+            value={0}
+          />
+          <button
+            aria-label="Step Up"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
@@ -236,7 +284,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
@@ -278,7 +326,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
@@ -320,7 +368,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
@@ -362,7 +410,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add"
+            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"


### PR DESCRIPTION
### Description
Issue #1129
when stepInput is rendered as readonly, (+) button is shown. No buttons should be shown in readonly mode. 

https://sap.github.io/fundamental-styles/?path=/docs/components-stepinput--primary#read-only


fixes #issueid