### PR TITLE
fix: Only add the className prop to DatePicker children once

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -340,7 +340,6 @@ class DatePicker extends Component {
             buttonLabel,
             buttonProps,
             calendarProps,
-            className,
             compact,
             dateFormat,
             disabled,
@@ -372,8 +371,7 @@ class DatePicker extends Component {
             'fd-input-group--control',
             {
                 [`is-${validationState?.state}`]: validationState?.state
-            },
-            className
+            }
         );
 
         const datepickerFooterClassName = classnames(
@@ -418,8 +416,7 @@ class DatePicker extends Component {
 
         return (
             <div
-                {...props}
-                className={className}>
+                {...props}>
                 <Popover
                     {...popoverProps}
                     body={

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -26,6 +26,11 @@ describe('<DatePicker />', () => {
         mount(compactRangeDatepicker);
     });
 
+    test('adds a custom className to the outermost div', () => {
+        wrapper = mount(<DatePicker className='my-class-name' />);
+        expect(wrapper.find('div.my-class-name').length).toBe(1);
+    });
+
     test('start date and end date range', () => {
         wrapper = mount(rangeDatePicker);
         // set dates


### PR DESCRIPTION
### Description

The className prop for the DatePicker shouldn't be applied to the nested InputGroup in addition to the outer div.  I could see having a different prop `inputClassName` (or something) for this.

I see the convention as adding the className prop to the outermost wrapper.

fixes #1135