### PR TITLE
fix: allow custom modal manager for DatePicker

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -364,6 +364,7 @@ class DatePicker extends Component {
             todayAction,
             validationState,
             weekdayStart,
+            modalManager,
             ...props
         } = this.props;
 
@@ -476,6 +477,7 @@ class DatePicker extends Component {
                     disableKeyPressHandler
                     disableTriggerOnClick
                     disabled={disableButton}
+                    modalManager={modalManager}
                     noArrow
                     onClickOutside={this.handleOutsideClickAndEscape}
                     onEscapeKey={this.handleOutsideClickAndEscape}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -517,6 +517,8 @@ DatePicker.propTypes = {
     inputProps: PropTypes.object,
     /** Language code to set the locale */
     locale: PropTypes.string,
+    /** If DatePicker is to be rendered in a modal, the parent modal manager can be passed as a prop */
+    modalManager: PropTypes.object,
     /** Additional props to be spread to the Popover component */
     popoverProps: PropTypes.object,
     /** Set to **true** to mark component as readonly */

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -114,6 +114,7 @@ class Popover extends Component {
             useArrowKeyNavigation,
             type,
             show,
+            modalManager,
             ...rest
         } = this.props;
 
@@ -175,6 +176,7 @@ class Popover extends Component {
                     disableEdgeDetection={disableEdgeDetection}
                     flipContainer={flipContainer}
                     innerRef={innerRef}
+                    modalManager={modalManager}
                     noArrow={noArrow}
                     onClickOutside={chain(this.handleOutsideClick, onClickOutside)}
                     onEscapeKey={chain(this.handleEscapeKey, onEscapeKey)}
@@ -216,6 +218,8 @@ Popover.propTypes = {
     firstFocusIndex: PropTypes.number,
     /** The bounding container to use when determining if the popover is out of bounds */
     flipContainer: CustomPropTypes.elementOrArrayOfElements(),
+    /** If Popover is to be rendered in a modal, the parent modal manager can be passed as a prop */
+    modalManager: PropTypes.object,
     /** Set to **true** to render a popover without an arrow */
     noArrow: PropTypes.bool,
     /** The options are 'auto',

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -91,7 +91,7 @@ const maxTargetModifier = {
 class Popper extends React.Component {
     constructor(props) {
         super(props);
-        this.modalManager = getModalManager();
+        this.modalManager = props.modalManager ? props.modalManager : getModalManager();
     }
 
     componentDidMount() {
@@ -133,8 +133,10 @@ class Popper extends React.Component {
             this.props.onKeyDown(e);
 
             if (e.keyCode === keycode.codes.esc && this.props.onEscapeKey) {
+                e.preventDefault();
                 e.stopPropagation();
-                this.props.onEscapeKey();
+
+                this.props.onEscapeKey(e);
             }
         }
     }
@@ -256,6 +258,7 @@ Popper.propTypes = {
     disableEdgeDetection: PropTypes.bool,
     flipContainer: CustomPropTypes.elementOrArrayOfElements(),
     innerRef: PropTypes.func,
+    modalManager: PropTypes.object,
     noArrow: PropTypes.bool,
     popperClassName: PropTypes.string,
     popperModifiers: PropTypes.array,

--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -136,7 +136,7 @@ class Popper extends React.Component {
                 e.preventDefault();
                 e.stopPropagation();
 
-                this.props.onEscapeKey(e);
+                this.props.onEscapeKey();
             }
         }
     }


### PR DESCRIPTION
### Description

If a DatePicker component is included in a modal, pressing escape will close both the DatePicker and modal as they have different modal managers. This PR allows for a custom modal manager to be passed down from a parent component.