### PR TITLE
fix: refactor popper portal

### DIFF
--- a/src/utils/_Popper.js
+++ b/src/utils/_Popper.js
@@ -3,6 +3,7 @@ import CustomPropTypes from './CustomPropTypes/CustomPropTypes';
 import Foco from 'react-foco';
 import { getModalManager } from './modalManager';
 import keycode from 'keycode';
+import PopperContainer from './_PopperContainer';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -223,8 +224,11 @@ class Popper extends React.Component {
         );
 
         if (usePortal) {
-            // eslint-disable-next-line compat/compat
-            popper = ReactDOM.createPortal(popper, document.querySelector('body'));
+            popper = (
+                <PopperContainer>
+                    {popper}
+                </PopperContainer>
+            );
         }
 
         return (

--- a/src/utils/_PopperContainer.js
+++ b/src/utils/_PopperContainer.js
@@ -1,0 +1,19 @@
+import Portal from 'react-overlays/Portal';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const PopperContainer = ({ children }) => {
+    return (
+        <Portal>
+            {children}
+        </Portal>
+    );
+};
+
+PopperContainer.displayName = 'PopperContainer';
+
+PopperContainer.propTypes = {
+    children: PropTypes.node
+};
+
+export default PopperContainer;


### PR DESCRIPTION
### Description
The original way of creating a Portal in Popper would fail in server-side rendering due to the reference to `document`.