### PR TITLE
fix: Checkbox classname

### DIFF
--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -15,7 +15,6 @@ const Checkbox = React.forwardRef(({
     ariaLabel,
     checked,
     children,
-    className,
     compact,
     defaultChecked,
     disabled,
@@ -39,8 +38,7 @@ const Checkbox = React.forwardRef(({
     });
 
 
-    const classes = classnames(
-        className,
+    const inputClassName = classnames(
         'fd-checkbox',
         {
             [`is-${state}`]: state,
@@ -72,7 +70,7 @@ const Checkbox = React.forwardRef(({
                 {...inputProps}
                 aria-label={ariaLabel}
                 checked={checked}
-                className={classes}
+                className={inputClassName}
                 defaultChecked={defaultChecked}
                 disabled={disabled}
                 id={checkId}

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -88,6 +88,26 @@ describe('<Checkbox />', () => {
                 element.find('.fd-form-label').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
+
+        test('should set className on FormItem', () => {
+            const wrapper = setup({
+                className: 'wonderful-styles'
+            });
+
+            expect(
+                wrapper.find('FormItem').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
+
+        test('should set labelClassName on FormLabel', () => {
+            const wrapper = setup({
+                labelClassName: 'wonderful-styles'
+            });
+
+            expect(
+                wrapper.find('FormLabel').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
     });
 
     test('forwards the ref', () => {

--- a/src/Forms/FormRadioItem.js
+++ b/src/Forms/FormRadioItem.js
@@ -10,7 +10,6 @@ import 'fundamental-styles/dist/radio.css';
 const FormRadioItem = React.forwardRef(({
     checked,
     children,
-    className,
     compact,
     defaultChecked,
     disabled,
@@ -37,7 +36,6 @@ const FormRadioItem = React.forwardRef(({
     return (
         <FormItem
             {...props}
-            className={className}
             isInline={inline}
             key={id}>
             <input

--- a/src/Forms/__stories__/Checkbox.stories.js
+++ b/src/Forms/__stories__/Checkbox.stories.js
@@ -3,7 +3,8 @@ import Checkbox from '../Checkbox';
 import React from 'react';
 import {
     boolean,
-    select
+    select,
+    text
 } from '@storybook/addon-knobs';
 
 export default {
@@ -40,6 +41,7 @@ export const validationState = () => (
 
 export const dev = () => (
     <Checkbox
+        className={text('className', '')}
         compact={boolean('compact', false)}
         disabled={boolean('disabled', false)}
         indeterminate={boolean('indeterminate', false)}


### PR DESCRIPTION
### Description
In this change, we update the Checkbox component to apply `className` value to the wrapping `FormItem` component instead of the internal `input`. This is to be consistent with the behavior in other Form components.

### Questions
Is this a breaking change?