### PR TITLE
feat: validation class prop

### DIFF
--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -144,7 +144,7 @@ Please ensure you are either using a visible \`FormLabel\` or an \`aria-label\` 
     /** Sets the `name` for the checkbox input */
     name: PropTypes.string,
     /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
-    validationOverlayProps: PropTypes.object,
+    validationOverlayProps: PropTypes.string,
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -29,8 +29,8 @@ const Checkbox = React.forwardRef(({
     name,
     onChange,
     value,
+    validationClassName,
     validationState,
-    validationOverlayProps,
     ...props
 }, ref) => {
 
@@ -96,8 +96,8 @@ const Checkbox = React.forwardRef(({
 
     return validationState ? (
         <FormValidationOverlay
+            className={validationClassName}
             control={checkbox}
-            validationOverlayProps={validationOverlayProps}
             validationState={validationState} />
     ) : checkbox;
 });
@@ -143,8 +143,8 @@ Please ensure you are either using a visible \`FormLabel\` or an \`aria-label\` 
     labelProps: PropTypes.object,
     /** Sets the `name` for the checkbox input */
     name: PropTypes.string,
-    /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
-    validationOverlayProps: PropTypes.string,
+    /** Additional classes to apply to validation popover */
+    validationClassName: PropTypes.string,
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -30,6 +30,7 @@ const Checkbox = React.forwardRef(({
     onChange,
     value,
     validationState,
+    validationOverlayProps,
     ...props
 }, ref) => {
 
@@ -96,6 +97,7 @@ const Checkbox = React.forwardRef(({
     return validationState ? (
         <FormValidationOverlay
             control={checkbox}
+            validationOverlayProps={validationOverlayProps}
             validationState={validationState} />
     ) : checkbox;
 });
@@ -141,6 +143,8 @@ Please ensure you are either using a visible \`FormLabel\` or an \`aria-label\` 
     labelProps: PropTypes.object,
     /** Sets the `name` for the checkbox input */
     name: PropTypes.string,
+    /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
+    validationOverlayProps: PropTypes.object,
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -118,6 +118,17 @@ describe('<Checkbox />', () => {
                 wrapper.find('.fd-checkbox').getDOMNode().classList
             ).toContain('wonderful-styles');
         });
+
+        test('should set validationClassName on the popover', () => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationClassName: 'wonderful-styles'
+            });
+
+            expect(
+                wrapper.find('.fd-popover').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
     });
 
     test('forwards the ref', () => {

--- a/src/Forms/_FormValidationOverlay.js
+++ b/src/Forms/_FormValidationOverlay.js
@@ -5,7 +5,7 @@ import Popper from '../utils/_Popper';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-const FormValidationOverlay = React.forwardRef(({ className, control, popperProps, validationState, validationOverlayProps, ...rest }, ref) => {
+const FormValidationOverlay = React.forwardRef(({ className, control, popperProps, validationState, ...rest }, ref) => {
     let [showValidationMessage, setShowValidationMessage] = useState(false);
 
     const _handleBlur = () => {
@@ -18,15 +18,7 @@ const FormValidationOverlay = React.forwardRef(({ className, control, popperProp
         }
     };
 
-    // const popoverClasses = classnames('fd-popover', className);
-
-    const popoverClasses = classnames(
-        'fd-popover',
-        className,
-        {
-            [validationOverlayProps]: validationOverlayProps
-        },
-    );
+    const popoverClasses = classnames('fd-popover', className);
 
     const bodyContent = (<FormMessage type={validationState?.state}>{validationState?.text}</FormMessage>);
 

--- a/src/Forms/_FormValidationOverlay.js
+++ b/src/Forms/_FormValidationOverlay.js
@@ -52,8 +52,6 @@ FormValidationOverlay.propTypes = {
     control: PropTypes.node,
     /** Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a> */
     popperProps: PropTypes.object,
-    /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
-    validationOverlayProps: PropTypes.string,
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/Forms/_FormValidationOverlay.js
+++ b/src/Forms/_FormValidationOverlay.js
@@ -18,13 +18,14 @@ const FormValidationOverlay = React.forwardRef(({ className, control, popperProp
         }
     };
 
-    const popoverClasses = classnames('fd-popover', className);
+    // const popoverClasses = classnames('fd-popover', className);
 
-    const referenceClasses = classnames(
-        'fd-popover__control',
+    const popoverClasses = classnames(
+        'fd-popover',
+        className,
         {
-            [validationOverlayProps?.className]: validationOverlayProps?.className
-        }
+            [validationOverlayProps]: validationOverlayProps
+        },
     );
 
     const bodyContent = (<FormMessage type={validationState?.state}>{validationState?.text}</FormMessage>);
@@ -42,7 +43,7 @@ const FormValidationOverlay = React.forwardRef(({ className, control, popperProp
                 noArrow
                 popperPlacement={'bottom-start'}
                 popperProps={popperProps}
-                referenceClassName={referenceClasses}
+                referenceClassName='fd-popover__control'
                 referenceComponent={referenceComponent}
                 show={showValidationMessage}
                 usePortal>
@@ -60,9 +61,7 @@ FormValidationOverlay.propTypes = {
     /** Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a> */
     popperProps: PropTypes.object,
     /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
-    validationOverlayProps: PropTypes.shape({
-        className: PropTypes.string
-    }),
+    validationOverlayProps: PropTypes.string,
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/Forms/_FormValidationOverlay.js
+++ b/src/Forms/_FormValidationOverlay.js
@@ -5,7 +5,7 @@ import Popper from '../utils/_Popper';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-const FormValidationOverlay = React.forwardRef(({ className, control, popperProps, validationState, ...rest }, ref) => {
+const FormValidationOverlay = React.forwardRef(({ className, control, popperProps, validationState, validationOverlayProps, ...rest }, ref) => {
     let [showValidationMessage, setShowValidationMessage] = useState(false);
 
     const _handleBlur = () => {
@@ -19,6 +19,13 @@ const FormValidationOverlay = React.forwardRef(({ className, control, popperProp
     };
 
     const popoverClasses = classnames('fd-popover', className);
+
+    const referenceClasses = classnames(
+        'fd-popover__control',
+        {
+            [validationOverlayProps?.className]: validationOverlayProps?.className
+        }
+    );
 
     const bodyContent = (<FormMessage type={validationState?.state}>{validationState?.text}</FormMessage>);
 
@@ -35,7 +42,7 @@ const FormValidationOverlay = React.forwardRef(({ className, control, popperProp
                 noArrow
                 popperPlacement={'bottom-start'}
                 popperProps={popperProps}
-                referenceClassName='fd-popover__control'
+                referenceClassName={referenceClasses}
                 referenceComponent={referenceComponent}
                 show={showValidationMessage}
                 usePortal>
@@ -52,12 +59,16 @@ FormValidationOverlay.propTypes = {
     control: PropTypes.node,
     /** Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a> */
     popperProps: PropTypes.object,
+    /** An object idendifying a popover class name coming from the child component in order to be used for additional styles targeting via classnames. */
+    validationOverlayProps: PropTypes.shape({
+        className: PropTypes.string
+    }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */
         state: PropTypes.oneOf(FORM_MESSAGE_TYPES),
         /** Text of the validation message */
-        text: PropTypes.stringng
+        text: PropTypes.string
     })
 };
 


### PR DESCRIPTION
### Description
This is a necessary change for correct class names to be passed to the popper wrapping element and styles be correctly applied. This is linked to PR: https://github.concur.com/coreui/nui-widgets-lab/pull/124

Edit: replaced `validationOverlayProps` with `validationClassName` thereby leveraging the existing `className` prop within `FormValidationOverlay`.

Additionally, corrected a small syntax error for `PropTypes` inside of `FormValidationOverlay`.

Features:
- added new prop: `validationOverlayProps`