### PR TITLE
fix: select onfocus onblur callbacks called at appropriate times

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -23,6 +23,7 @@ const Select = React.forwardRef(({
     includeEmptyOption,
     listClassName,
     options,
+    onBlur,
     onClick,
     onSelect,
     placeholder,
@@ -45,6 +46,12 @@ const Select = React.forwardRef(({
     const handleClick = (e) => {
         if (!disabled && !readOnly) {
             onClick(e);
+        }
+    };
+
+    const handleBlur = (e) => {
+        if (!popoverRef?.current?.state?.isExpanded && onBlur) {
+            onBlur(e);
         }
     };
 
@@ -175,6 +182,8 @@ const Select = React.forwardRef(({
             disableTriggerOnClick={disabled || readOnly}
             firstFocusIndex={firstFocusIndex}
             noArrow
+            onBlur={handleBlur}
+            onClickOutside={handleBlur}
             ref={popoverRef}
             type='listbox'
             useArrowKeyNavigation />
@@ -227,6 +236,8 @@ Select.propTypes = {
         /** Text of the validation message */
         text: PropTypes.string
     }),
+    /** Callback function for select field onBlur. Will be called only if select field loses focus and the popover is closed. */
+    onBlur: PropTypes.func,
     /** Callback function when user clicks on the component*/
     onClick: PropTypes.func,
     /** Callback function when user clicks on an option */
@@ -235,6 +246,7 @@ Select.propTypes = {
 
 Select.defaultProps = {
     options: [],
+    onBlur: () => {},
     onClick: () => {},
     onSelect: () => {}
 };

--- a/src/Select/Select.test.js
+++ b/src/Select/Select.test.js
@@ -85,33 +85,123 @@ describe('<Select />', () => {
     });
 
     describe('interactions', () => {
-        let onSelect;
-        let element;
-        beforeEach(() => {
-            onSelect = jest.fn();
-            element = mount(
-                <Select onSelect={onSelect} options={options} />
+        describe('onSelect', () => {
+            let onSelect;
+            let element;
+            beforeEach(() => {
+                onSelect = jest.fn();
+                element = mount(
+                    <Select onSelect={onSelect} options={options} />
+                );
+                element.find('.fd-select__button').simulate('click');
+            });
+
+            afterEach(() => {
+                let event = new MouseEvent('mousedown', {});
+                document.dispatchEvent(event);
+            });
+
+            test('should call onSelect when the first checkbox option is clicked', () => {
+                element.find('.fd-list__item').at(0).simulate('click');
+
+                expect(onSelect).toHaveBeenCalledTimes(1);
+                expect(onSelect).toHaveBeenCalledWith(expect.anything(), options[0]);
+            });
+
+            test('should call onSelect when the second checkbox option is clicked', () => {
+                element.find('.fd-list__item').at(1).simulate('click');
+
+                expect(onSelect).toHaveBeenCalledTimes(1);
+                expect(onSelect).toHaveBeenCalledWith(expect.anything(), options[1]);
+            });
+        });
+
+        test('should trigger callback, with valid event object as argument, on input onFocus event', async() => {
+            const focusSpy = jest.fn();
+            const wrapper = setup({
+                onFocus: focusSpy
+            });
+
+            await act(async() => {
+                wrapper.find('.fd-select').simulate('focus');
+            });
+
+            expect(focusSpy).toHaveBeenCalledTimes(1);
+
+            expect(
+                focusSpy
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    target: wrapper.find('.fd-select').getDOMNode()
+                })
             );
-            element.find('.fd-select__button').simulate('click');
         });
 
-        afterEach(() => {
-            let event = new MouseEvent('mousedown', {});
-            document.dispatchEvent(event);
+        test('should trigger callback, with valid event object as argument, on input onBlur event', async() => {
+            const blurSpy = jest.fn();
+            const wrapper = setup({
+                onBlur: blurSpy
+            });
+
+            await act(async() => {
+                wrapper.find('.fd-select').simulate('blur');
+            });
+
+            expect(blurSpy).toHaveBeenCalledTimes(1);
+
+            expect(
+                blurSpy
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    target: wrapper.find('.fd-select').getDOMNode()
+                })
+            );
         });
 
-        test('should call onSelect when the first checkbox option is clicked', () => {
-            element.find('.fd-list__item').at(0).simulate('click');
+        test('should not trigger onBlur callback if opening dropdown', async() => {
+            const blurSpy = jest.fn();
+            const wrapper = setup({
+                onBlur: blurSpy
+            });
 
-            expect(onSelect).toHaveBeenCalledTimes(1);
-            expect(onSelect).toHaveBeenCalledWith(expect.anything(), options[0]);
+            await act(async() => {
+                wrapper.find('.fd-select').simulate('keydown',
+                    {
+                        key: 'Enter',
+                        keyCode: 13,
+                        which: 13
+                    }
+                );
+            });
+
+            expect(blurSpy).toHaveBeenCalledTimes(0);
         });
 
-        test('should call onSelect when the second checkbox option is clicked', () => {
-            element.find('.fd-list__item').at(1).simulate('click');
+        test('should not trigger onBlur callback if closing dropdown', async() => {
+            const blurSpy = jest.fn();
+            const focusSpy = jest.fn();
+            const wrapper = setup({
+                onBlur: blurSpy,
+                onFocus: focusSpy
+            });
 
-            expect(onSelect).toHaveBeenCalledTimes(1);
-            expect(onSelect).toHaveBeenCalledWith(expect.anything(), options[1]);
+            // open dropdown
+            await act(async() => {
+                wrapper.find('.fd-select').simulate('click');
+            });
+
+            // close dropdown
+            await act(async() => {
+                wrapper.find('.fd-popover').at(0).simulate('keydown',
+                    {
+                        key: 'Esc',
+                        keyCode: 27,
+                        which: 27
+                    }
+                );
+            });
+
+            expect(blurSpy).toHaveBeenCalledTimes(0);
         });
     });
 

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import Select from '../Select';
@@ -76,6 +77,8 @@ export const dev = () => (
     <Select
         compact={boolean('compact', false)}
         disabled={boolean('disabled', false)}
+        onBlur={() => console.log('on-blur-callback')}
+        onFocus={() => console.log('on-focus-callback')}
         options={options}
         placeholder={text('placeholder', 'select')}
         validationState={select('Validation State', {

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -6,6 +6,7 @@ exports[`Storyshots Component API/Select Compact 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -67,6 +68,7 @@ exports[`Storyshots Component API/Select Dev 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -96,6 +98,7 @@ exports[`Storyshots Component API/Select Dev 1`] = `
                 aria-haspopup="listbox"
                 className="fd-select"
                 onClick={[Function]}
+                onFocus={[Function]}
                 onKeyPress={[Function]}
                 role="combobox"
                 tabIndex={0}
@@ -129,6 +132,7 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -187,6 +191,7 @@ exports[`Storyshots Component API/Select Empty Option 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -246,6 +251,7 @@ exports[`Storyshots Component API/Select Primary 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -307,6 +313,7 @@ exports[`Storyshots Component API/Select Read Only 1`] = `
 >
   <div
     className="fd-popover"
+    onBlur={[Function]}
   >
     <div
       onFocus={[Function]}
@@ -365,6 +372,7 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
   >
     <div
       className="fd-popover"
+      onBlur={[Function]}
     >
       <div
         onFocus={[Function]}
@@ -419,6 +427,7 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
     </div>
     <div
       className="fd-popover"
+      onBlur={[Function]}
     >
       <div
         onFocus={[Function]}
@@ -473,6 +482,7 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
     </div>
     <div
       className="fd-popover"
+      onBlur={[Function]}
     >
       <div
         onFocus={[Function]}
@@ -527,6 +537,7 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
     </div>
     <div
       className="fd-popover"
+      onBlur={[Function]}
     >
       <div
         onFocus={[Function]}


### PR DESCRIPTION
### Description

`onBlur` is now only triggered when leaving the component - via `onClickOutside` or by leaving the select field **AND** the dropdown list. Previously, `onBlur` was being fired when leaving the select field and navigating inside of the dropdown list items.

![2020-08-26 09 03 42](https://user-images.githubusercontent.com/29607818/91331526-b57dba00-e77f-11ea-96bc-282a0d3ca902.gif)
 


fixes #1159 