### PR TITLE
chore: cleanup some test warnings

### DIFF
--- a/src/ActionBar/ActionBar.test.js
+++ b/src/ActionBar/ActionBar.test.js
@@ -3,9 +3,11 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 describe('<ActionBar />', () => {
+    const setup = (props = {}) => mount(<ActionBar title='Page Title' {...props} />);
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the ActionBar component', () => {
-            const element = mount(<ActionBar data-sample='Sample' title='Page Title' />);
+            const element = setup({ 'data-sample': 'Sample' });
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value
@@ -13,8 +15,11 @@ describe('<ActionBar />', () => {
         });
 
         test('should allow props to be spread to the back Button component', () => {
-            const element = mount(<ActionBar buttonProps={{ 'data-sample': 'Sample' }} onBackClick={() => {}}
-                title='Page Title' />);
+            const element = setup({
+                backButtonLabel: 'Placeholder label',
+                buttonProps: { 'data-sample': 'Sample' },
+                onBackClick: () => {}
+            });
 
             expect(
                 element.find('.sap-icon--navigation-left-arrow').getDOMNode().attributes['data-sample'].value
@@ -22,7 +27,7 @@ describe('<ActionBar />', () => {
         });
 
         test('should allow props to be spread to the title', () => {
-            const element = mount(<ActionBar title='Page Title' titleProps={{ 'data-sample': 'Sample' }} />);
+            const element = setup({ titleProps: { 'data-sample': 'Sample' } });
 
             expect(
                 element.find('.fd-action-bar__title').getDOMNode().attributes['data-sample'].value
@@ -30,8 +35,7 @@ describe('<ActionBar />', () => {
         });
 
         test('should allow props to be spread to the action container', () => {
-            const element = mount(<ActionBar actionProps={{ 'data-sample': 'Sample' }} actions={(<button>Button</button>)}
-                title='Page Title' />);
+            const element = setup({ actionProps: { 'data-sample': 'Sample' }, actions: (<button>Button</button>) });
 
             expect(
                 element.find('.fd-action-bar__actions').getDOMNode().attributes['data-sample'].value

--- a/src/ComboboxInput/ComboboxInput.test.js
+++ b/src/ComboboxInput/ComboboxInput.test.js
@@ -138,7 +138,11 @@ describe('<ComboboxInput />', () => {
 
                     wrapper.find('input').simulate('change', { target: { value: 'island' } });
                 });
-                wrapper.find('input').simulate('blur');
+
+                act(() => {
+                    wrapper.find('input').simulate('blur');
+                });
+
                 expect(selectionChangeHandler).toHaveBeenLastCalledWith(expect.anything(), {
                     text: 'island',
                     key: -1 // key is set to -1 for custom input in manual combobox
@@ -236,7 +240,11 @@ describe('<ComboboxInput />', () => {
 
                     wrapper.find('input').simulate('change', { target: { value: 'island' } });
                 });
-                wrapper.find('input').simulate('blur');
+
+                act(() => {
+                    wrapper.find('input').simulate('blur');
+                });
+
                 expect(selectionChangeHandler).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({
                     text: 'Ascension Island',
                     key: 'AC'
@@ -353,7 +361,11 @@ describe('<ComboboxInput />', () => {
 
                     wrapper.find('input').simulate('change', { target: { value: 'island' } });
                 });
-                wrapper.find('input').simulate('blur');
+
+                act(() => {
+                    wrapper.find('input').simulate('blur');
+                });
+
                 expect(selectionChangeHandler).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({
                     text: 'Ascension Island',
                     key: 'AC'

--- a/src/List/ListHeader.test.js
+++ b/src/List/ListHeader.test.js
@@ -3,9 +3,29 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 describe('<ListHeader />', () => {
+    const setup = (props = {}) => mount(<List.Header level={4} {...props} />);
+
+    describe('level', () => {
+        test('should render h2 when passed level 2', () => {
+            const element = setup({ level: 2 });
+
+            expect(
+                element.find('.fd-list__group-header').type()
+            ).toBe('h2');
+        });
+
+        test('should render h3 when passed level 3', () => {
+            const element = setup({ level: 3 });
+
+            expect(
+                element.find('.fd-list__group-header').type()
+            ).toBe('h3');
+        });
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the ListHeader component', () => {
-            const element = mount(<List.Header data-sample='Sample' />);
+            const element = mount(<List.Header data-sample='Sample' level={4} />);
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value

--- a/src/Menu/_MenuItem.js
+++ b/src/Menu/_MenuItem.js
@@ -59,25 +59,20 @@ const MenuItem = ({
                 children.props.className
             );
 
-            const addonChildBefore = addonBefore ? (<span
-                key='addonChildBefore'
-                {...addonProps}
-                className={addonBeforeClassnames} />) : null;
-            const addonChildAfter = addonAfter ? (<span
-                key='addonChildAfter'
-                {...addonProps}
-                className={addonAfterClassnames} />) : null;
-
             return (
                 <>
-                    {React.Children.toArray(children).map((child, key) => {
-                        return React.cloneElement(child, {
-                            'className': childrenClassnames,
-                            key: `menu-item-${key}`,
-                            ...urlProps
-                        },
-                        [addonChildBefore, (<span className='fd-menu__title' key='menuTitle'>{child.props.children}</span>), addonChildAfter]);
-                    })}
+                    {addonBefore && <span {...addonProps} {...urlProps}
+                        className={addonBeforeClassnames} />}
+                    <span className='fd-menu__title'>
+                        {React.Children.map(children, child => {
+                            return React.cloneElement(child, {
+                                className: childrenClassnames,
+                                ...urlProps
+                            });
+                        })}
+                    </span>
+                    {addonAfter && <span {...addonProps} {...urlProps}
+                        className={addonAfterClassnames} />}
                 </>
             );
         } else if (children) {

--- a/src/Menu/_MenuItem.js
+++ b/src/Menu/_MenuItem.js
@@ -59,19 +59,26 @@ const MenuItem = ({
                 children.props.className
             );
 
-            const addonChildBefore = addonBefore ? (<span {...addonProps} className={addonBeforeClassnames} />) : null;
-            const addonChildAfter = addonAfter ? (<span {...addonProps} className={addonAfterClassnames} />) : null;
+            const addonChildBefore = addonBefore ? (<span
+                key='addonChildBefore'
+                {...addonProps}
+                className={addonBeforeClassnames} />) : null;
+            const addonChildAfter = addonAfter ? (<span
+                key='addonChildAfter'
+                {...addonProps}
+                className={addonAfterClassnames} />) : null;
 
             return (
-                <React.Fragment>
-                    {React.Children.toArray(children).map(child => {
+                <>
+                    {React.Children.toArray(children).map((child, key) => {
                         return React.cloneElement(child, {
                             'className': childrenClassnames,
+                            key: `menu-item-${key}`,
                             ...urlProps
                         },
-                        [addonChildBefore, (<span className='fd-menu__title'>{child.props.children}</span>), addonChildAfter]);
+                        [addonChildBefore, (<span className='fd-menu__title' key='menuTitle'>{child.props.children}</span>), addonChildAfter]);
                     })}
-                </React.Fragment>
+                </>
             );
         } else if (children) {
             return (<a {...urlProps}
@@ -91,7 +98,7 @@ const MenuItem = ({
     );
 
     return (
-        <React.Fragment>
+        <>
             <li
                 {...props}
                 className={listClassNames}
@@ -99,7 +106,7 @@ const MenuItem = ({
                 {renderLink()}
             </li>
             {separator && <span className='fd-menu__separator' />}
-        </React.Fragment>
+        </>
     );
 };
 

--- a/src/ObjectStatus/ObjectStatus.test.js
+++ b/src/ObjectStatus/ObjectStatus.test.js
@@ -5,7 +5,7 @@ import React from 'react';
 describe('<ObjectStatus />', () => {
     describe('Prop spreading', () => {
         test('should allow props to be spread to the ObjectStatus component', () => {
-            const element = mount(<ObjectStatus data-sample='Sample' />);
+            const element = mount(<ObjectStatus ariaLabel='Placeholder label' data-sample='Sample' />);
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value
@@ -19,7 +19,7 @@ describe('<ObjectStatus />', () => {
                 super(props);
                 ref = React.createRef();
             }
-            render = () => <ObjectStatus ref={ref}>ObjectStatus</ObjectStatus>;
+            render = () => <ObjectStatus ariaLabel='Placeholder label' ref={ref}>ObjectStatus</ObjectStatus>;
         }
         mount(<Test />);
         expect(ref.current.tagName).toEqual('SPAN');

--- a/src/Pagination/Pagination.js
+++ b/src/Pagination/Pagination.js
@@ -133,7 +133,7 @@ class Pagination extends Component {
             {...this.props.linkProps}
             className={paginationLinkClasses}
             href='#'
-            key={index}
+            key={`link-${index}`}
             onClick={this.pageClicked}>
             {index + pageNumberOffset}
         </a>);

--- a/src/Tile/Tile.test.js
+++ b/src/Tile/Tile.test.js
@@ -13,7 +13,7 @@ describe('<Tile />', () => {
 
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Tile component', () => {
-            const element = mount(<Tile data-sample='Sample' />);
+            const element = mount(<Tile data-sample='Sample' onClick={handleClick} />);
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value
@@ -28,7 +28,7 @@ describe('<Tile />', () => {
                 super(props);
                 ref = React.createRef();
             }
-            render = () => <Tile ref={ref} />;
+            render = () => <Tile onClick={handleClick} ref={ref} />;
         }
         mount(<Test />);
         expect(ref.current.tagName).toEqual('DIV');

--- a/src/Time/Time.js
+++ b/src/Time/Time.js
@@ -290,7 +290,6 @@ Time.defaultProps = {
     showHour: true,
     showMinute: true,
     showSecond: true,
-    spinners: true,
     time: {
         hour: '00',
         minute: '00',

--- a/src/Time/__stories__/__snapshots__/Time.stories.storyshot
+++ b/src/Time/__stories__/__snapshots__/Time.stories.storyshot
@@ -7,7 +7,6 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
   <div
     className="fd-time"
     name="custom"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -187,7 +186,6 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -373,7 +371,6 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     
     <div
@@ -522,7 +519,6 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -671,7 +667,6 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -821,7 +816,6 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
   <div
     className="fd-time"
     name="meridiem"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -1001,7 +995,6 @@ exports[`Storyshots Component API/Time Primary 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -1181,7 +1174,6 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -1392,7 +1384,6 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
   <div
     className="fd-time"
     name="meridiem"
-    spinners={true}
   >
     <div
       className="fd-time__col"
@@ -1572,7 +1563,6 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
 >
   <div
     className="fd-time"
-    spinners={true}
   >
     <div
       className="fd-time__col"

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -112,7 +112,6 @@ class TimePicker extends Component {
             showHour,
             showMinute,
             showSecond,
-            spinners,
             time,
             value,
             timeProps,
@@ -200,7 +199,6 @@ TimePicker.defaultProps = {
     showHour: true,
     showMinute: true,
     showSecond: true,
-    spinners: true,
     time: {
         hour: '00',
         minute: '00',

--- a/src/Token/Token.test.js
+++ b/src/Token/Token.test.js
@@ -5,7 +5,7 @@ import Token from './Token';
 describe('<Token />', () => {
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Token component', () => {
-            const element = mount(<Token data-sample='Sample' />);
+            const element = mount(<Token buttonLabel='placeholder label' data-sample='Sample' />);
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value
@@ -20,7 +20,7 @@ describe('<Token />', () => {
                 super(props);
                 ref = React.createRef();
             }
-            render = () => <Token ref={ref} />;
+            render = () => <Token buttonLabel='placeholder label' ref={ref} />;
         }
         mount(<Test />);
         expect(ref.current.tagName).toEqual('SPAN');


### PR DESCRIPTION
### Description

Cleans up test warnings from a couple components (definitely not all of them!)

Breaking change: removed unused `spinners` prop from `TimePicker` and `Time` components

fixes #issueid