### PR TITLE
feat: add additional props for customization to validationOverlayProps

### DIFF
--- a/src/ComboboxInput/ComboboxInput.js
+++ b/src/ComboboxInput/ComboboxInput.js
@@ -41,6 +41,7 @@ const ComboboxInput = React.forwardRef(({
     required,
     selectedKey,
     selectionType,
+    validationOverlayProps,
     validationState,
     ...props
 }, ref) => {
@@ -401,6 +402,7 @@ const ComboboxInput = React.forwardRef(({
                 compact={compact}
                 disabled={disabled}
                 onClick={handleInputGroupClick}
+                validationOverlayProps={validationOverlayProps}
                 validationState={validationState}>
                 <FormInput
                     autoComplete='off'
@@ -452,6 +454,7 @@ const ComboboxInput = React.forwardRef(({
                         }}>
                         {validationState &&
                             <FormMessage
+                                {...validationOverlayProps?.formMessageProps}
                                 type={validationState.state}>
                                 {validationState.text}
                             </FormMessage>
@@ -570,6 +573,19 @@ Please set 'arrowLabel' property to a non-empty localized string.
      * * `'auto-inline'`: First option from the filtered options is automatically selected and its options.text value is populated inline (type-ahead), user chooses different option by navigating through the list
     */
     selectionType: PropTypes.oneOf(COMBOBOX_SELECTION_TYPES),
+    /** Additional props to be spread to the ValidationOverlay */
+    validationOverlayProps: PropTypes.shape({
+        /** Additional classes to apply to validation popover's outermost `<div>` element  */
+        className: PropTypes.string,
+        /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
+        formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
+        /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
+    }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/ComboboxInput/ComboboxInput.test.js
+++ b/src/ComboboxInput/ComboboxInput.test.js
@@ -89,6 +89,28 @@ describe('<ComboboxInput />', () => {
         });
     });
 
+    describe('validationOverlayProps', () => {
+
+        test('pass validationOverlayProps to InputGroup', () => {
+            const element = mount(
+                <ComboboxInput
+                    ariaLabel='Dummy options'
+                    arrowLabel='Show options'
+                    id='validationOverlayTest'
+                    options={defaultOptions}
+                    validationOverlayProps={{
+                        className: 'foo'
+                    }} />
+            );
+
+            expect(
+                element.find('InputGroup').prop('validationOverlayProps')
+            ).toMatchObject({
+                className: 'foo'
+            });
+        });
+    });
+
     describe('interactions', () => {
         beforeEach(() => {
             container = document.createElement('div');

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -352,6 +352,7 @@ class DatePicker extends Component {
             disableWeekends,
             enableRangeSelection,
             inputProps,
+            inputGroupProps,
             locale,
             localizedText,
             onBlur,
@@ -362,6 +363,7 @@ class DatePicker extends Component {
             showToday,
             specialDays,
             todayAction,
+            validationOverlayProps,
             validationState,
             weekdayStart,
             modalManager,
@@ -389,11 +391,13 @@ class DatePicker extends Component {
 
         const inputGroup = (
             <InputGroup
+                {...inputGroupProps}
                 aria-expanded={this.state.isExpanded}
                 aria-haspopup='true'
                 className={inputGroupClass}
                 compact={compact}
                 disabled={disabled}
+                validationOverlayProps={validationOverlayProps}
                 validationState={validationState} >
                 <FormInput
                     {...inputProps}
@@ -424,6 +428,7 @@ class DatePicker extends Component {
                         <>
                             {validationState?.text?.length > 0 &&
                                 <FormMessage
+                                    {...validationOverlayProps?.formMessageProps}
                                     type={validationState.state}>
                                     {validationState.text}
                                 </FormMessage>
@@ -513,6 +518,8 @@ DatePicker.propTypes = {
     disabled: PropTypes.bool,
     /** Set to **true** to enable the selection of a date range (begin and end) */
     enableRangeSelection: PropTypes.bool,
+    /** Additional props to be spread to the `InputGroup` component */
+    inputGroupProps: PropTypes.object,
     /** Additional props to be spread to the `<input>` element */
     inputProps: PropTypes.object,
     /** Language code to set the locale */
@@ -547,6 +554,19 @@ DatePicker.propTypes = {
             const todayActionType = todayAction?.type?.trim();
             return todayActionType === 'select' || todayActionType === 'navigate';
         })
+    }),
+    /** Additional props to be spread to the ValidationOverlay */
+    validationOverlayProps: PropTypes.shape({
+        /** Additional classes to apply to validation popover's outermost `<div>` element  */
+        className: PropTypes.string,
+        /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
+        formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
+        /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`;
      * _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -509,6 +509,14 @@ describe('<DatePicker />', () => {
             ).toBe('Sample');
         });
 
+        test('should allow props to be spread to the DatePicker component\'s inputGroup element', () => {
+            const element = mount(<DatePicker inputGroupProps={{ 'data-sample': 'Sample' }} />);
+
+            expect(
+                element.find('InputGroup').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
+
         test('should allow props to be spread to the DatePicker component\'s button element', () => {
             const element = mount(<DatePicker buttonProps={{ 'data-sample': 'Sample' }} />);
 
@@ -587,6 +595,23 @@ describe('<DatePicker />', () => {
             expect(
                 wrapper.find('tbody').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
+        });
+    });
+
+    describe('validationOverlayProps', () => {
+        test('pass validationOverlayProps to InputGroup', () => {
+            const element = mount(
+                <DatePicker
+                    validationOverlayProps={{
+                        className: 'foo'
+                    }} />
+            );
+
+            expect(
+                element.find('InputGroup').prop('validationOverlayProps')
+            ).toMatchObject({
+                className: 'foo'
+            });
         });
     });
 });

--- a/src/Forms/Checkbox.js
+++ b/src/Forms/Checkbox.js
@@ -149,8 +149,12 @@ Please ensure you are either using a visible \`FormLabel\` or an \`aria-label\` 
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/Forms/Checkbox.test.js
+++ b/src/Forms/Checkbox.test.js
@@ -150,6 +150,30 @@ describe('<Checkbox />', () => {
                 ).toContain('wonderful-styles');
             });
 
+            test('should spread props to Validation overlay wrapper div', async() => {
+                const wrapper = setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+                });
+
+                expect(
+                    wrapper.find('.fd-popover').getDOMNode().attributes['data-sample'].value
+                ).toBe('Sample');
+            });
+
+            test('should set class on the Validation Overlay Popper', async() => {
+                await act(async() => {
+                    setup({
+                        validationState: { state: 'error', text: 'Test validation state' },
+                        validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                    });
+                });
+
+                expect(
+                    document.body.querySelector('.fd-popover__popper').classList
+                ).toContain('wonderful-styles');
+            });
+
             test('should spread formMessageProps to ValidationOverlay\'s FormMessage', async() => {
                 await act(async() => {
                     setup({

--- a/src/Forms/FormInput.js
+++ b/src/Forms/FormInput.js
@@ -74,8 +74,12 @@ FormInput.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/Forms/FormInput.test.js
+++ b/src/Forms/FormInput.test.js
@@ -1,8 +1,10 @@
+import { act } from 'react-dom/test-utils';
 import FormInput from './FormInput';
 import { mount } from 'enzyme';
 import React from 'react';
 
 describe('<FormInput />', () => {
+    const setup = (props) => mount(<FormInput {...props} />);
     describe('rendering', () => {
         test('should add compact class when compact prop added', () => {
             const element = mount(<FormInput compact />);
@@ -20,6 +22,86 @@ describe('<FormInput />', () => {
             expect(
                 element.find('.fd-input').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
+        });
+    });
+
+    describe('validationOverlayProps', () => {
+        afterEach(() => {
+            document.body.innerHTML = '';
+        });
+
+        const getFormMessage = () => document.body.querySelector('.fd-popover__popper > div > .fd-form-message');
+
+
+        test('should allow spreading className to ValidationOverlay popover', () => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationOverlayProps: { className: 'wonderful-styles' }
+            });
+
+            expect(
+                wrapper.find('.fd-popover').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
+
+        test('should allow spreading className to ValidationOverlay reference div', () => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationOverlayProps: { referenceClassName: 'wonderful-styles' }
+            });
+
+            expect(
+                wrapper.find('.fd-popover__control').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
+
+        test('should spread props to Validation overlay wrapper div', async() => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+            });
+
+            expect(
+                wrapper.find('.fd-popover').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
+
+        test('should set class on the Validation Overlay Popper', async() => {
+            await act(async() => {
+                setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                });
+            });
+
+            expect(
+                document.body.querySelector('.fd-popover__popper').classList
+            ).toContain('wonderful-styles');
+        });
+
+        test('should spread formMessageProps to ValidationOverlay\'s FormMessage', async() => {
+            await act(async() => {
+                setup({
+                    validationState: {
+                        state: 'error',
+                        text: 'Test validation state'
+                    },
+                    validationOverlayProps: {
+                        formMessageProps: { 'data-sample': 'Sample', className: 'wonderful-styles' },
+                        show: true
+                    }
+                });
+            });
+
+            const messageNode = getFormMessage();
+
+            expect(
+                messageNode.attributes['data-sample'].value
+            ).toBe('Sample');
+
+            expect(
+                messageNode.classList
+            ).toContain('wonderful-styles');
         });
     });
 

--- a/src/Forms/FormTextArea.test.js
+++ b/src/Forms/FormTextArea.test.js
@@ -70,6 +70,30 @@ describe('<FormTextArea />', () => {
                 messageNode.classList
             ).toContain('wonderful-styles');
         });
+
+        test('should spread props to Validation overlay wrapper div', async() => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+            });
+
+            expect(
+                wrapper.find('.fd-popover').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
+
+        test('should set class on the Validation Overlay Popper', async() => {
+            await act(async() => {
+                setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                });
+            });
+
+            expect(
+                document.body.querySelector('.fd-popover__popper').classList
+            ).toContain('wonderful-styles');
+        });
     });
 
     test('forwards the ref', () => {

--- a/src/Forms/FormTextarea.js
+++ b/src/Forms/FormTextarea.js
@@ -128,8 +128,12 @@ FormTextarea.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/Forms/_FormValidationOverlay.js
+++ b/src/Forms/_FormValidationOverlay.js
@@ -10,6 +10,7 @@ const FormValidationOverlay = React.forwardRef((
         className,
         control,
         formMessageProps,
+        popperClassName,
         popperProps,
         referenceClassName,
         show,
@@ -38,6 +39,7 @@ const FormValidationOverlay = React.forwardRef((
 
     const referenceComponent = React.cloneElement(control, rest);
 
+
     return (
         <div
             {...wrapperProps}
@@ -48,6 +50,7 @@ const FormValidationOverlay = React.forwardRef((
             <Popper
                 cssBlock='fd-popover'
                 noArrow
+                popperClassName={popperClassName}
                 popperPlacement={'bottom-start'}
                 popperProps={popperProps}
                 referenceClassName={referenceClasses}
@@ -67,6 +70,8 @@ FormValidationOverlay.propTypes = {
     control: PropTypes.node,
     /** Additional props to be spread to the FormMessage component */
     formMessageProps: PropTypes.object,
+    /** CSS class(es) to add to the popper div */
+    popperClassName: PropTypes.string,
     /** Additional props to be spread to the overlay element, supported by <a href="https://popper.js.org" target="_blank">popper.js</a> */
     popperProps: PropTypes.object,
     /** CSS class(es) to add to the reference div */

--- a/src/Forms/_FormValidationOverlay.test.js
+++ b/src/Forms/_FormValidationOverlay.test.js
@@ -59,6 +59,19 @@ describe('<FormValidationOverlay />', () => {
             ).toContain('wonderful-styles');
         });
 
+        test('should set className on the popper component', async() => {
+            await act(async() => {
+                setup({
+                    popperClassName: 'wonderful-styles',
+                    show: true
+                });
+            });
+            const popoverNode = getPopover();
+            expect(
+                popoverNode.className
+            ).toContain('wonderful-styles');
+        });
+
         test('should allow props to be spread to the FormMessage component', async() => {
             let element;
             await act(async() => {

--- a/src/InputGroup/InputGroup.js
+++ b/src/InputGroup/InputGroup.js
@@ -89,8 +89,12 @@ InputGroup.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/InputGroup/InputGroup.test.js
+++ b/src/InputGroup/InputGroup.test.js
@@ -111,6 +111,30 @@ describe('<InputGroup />', () => {
                     messageNode.classList
                 ).toContain('wonderful-styles');
             });
+
+            test('should spread props to Validation overlay wrapper div', async() => {
+                const wrapper = setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+                });
+
+                expect(
+                    wrapper.find('.fd-popover').getDOMNode().attributes['data-sample'].value
+                ).toBe('Sample');
+            });
+
+            test('should set class on the Validation Overlay Popper', async() => {
+                await act(async() => {
+                    setup({
+                        validationState: { state: 'error', text: 'Test validation state' },
+                        validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                    });
+                });
+
+                expect(
+                    document.body.querySelector('.fd-popover__popper').classList
+                ).toContain('wonderful-styles');
+            });
         });
     });
 });

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -152,6 +152,7 @@ class MultiInput extends Component {
             onTagsUpdate,
             placeholder,
             tagProps,
+            validationOverlayProps,
             validationState,
             ...rest
         } = this.props;
@@ -198,6 +199,7 @@ class MultiInput extends Component {
                 compact={compact}
                 disabled={disabled}
                 onClick={this.showHideTagList}
+                validationOverlayProps={validationOverlayProps}
                 validationState={validationState}>
                 <div {...tagProps} className={tokenizerClassName}>
                     <div className='fd-tokenizer__inner'>
@@ -228,6 +230,7 @@ class MultiInput extends Component {
                     (<>
                         {validationState &&
                         <FormMessage
+                            {...validationOverlayProps?.formMessageProps}
                             type={validationState.state}>
                             {validationState.text}
                         </FormMessage>
@@ -270,6 +273,19 @@ MultiInput.propTypes = {
     popoverProps: PropTypes.object,
     /** Additional props to be spread to the tags `<div>` element */
     tagProps: PropTypes.object,
+    /** Additional props to be spread to the ValidationOverlay */
+    validationOverlayProps: PropTypes.shape({
+        /** Additional classes to apply to validation popover's outermost `<div>` element  */
+        className: PropTypes.string,
+        /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
+        formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
+        /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
+    }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({
         /** State of validation: 'error', 'warning', 'information', 'success' */

--- a/src/MultiInput/MultiInput.test.js
+++ b/src/MultiInput/MultiInput.test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-
 import MultiInput from './MultiInput';
 import React from 'react';
 
@@ -221,6 +220,25 @@ describe('<MultiInput />', () => {
 
         // check that no tags exist
         expect(wrapper.state(['tags'])).toHaveLength(1);
+    });
+
+    describe('validationOverlayProps', () => {
+
+        test('pass validationOverlayProps to InputGroup', () => {
+            const element = mount(
+                <MultiInput
+                    data={data}
+                    validationOverlayProps={{
+                        className: 'foo'
+                    }} />
+            );
+
+            expect(
+                element.find('InputGroup').prop('validationOverlayProps')
+            ).toMatchObject({
+                className: 'foo'
+            });
+        });
     });
 
     describe('Prop spreading', () => {

--- a/src/SearchInput/SearchInput.js
+++ b/src/SearchInput/SearchInput.js
@@ -279,8 +279,12 @@ SearchInput.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/SearchInput/SearchInput.test.js
+++ b/src/SearchInput/SearchInput.test.js
@@ -274,6 +274,30 @@ describe('<SearchInput />', () => {
                 messageNode.classList
             ).toContain('wonderful-styles');
         });
+
+        test('should spread props to Validation overlay wrapper div', async() => {
+            const wrapper = setup({
+                validationState: { state: 'error', text: 'Test validation state' },
+                validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+            });
+
+            expect(
+                wrapper.find('.fd-popover').at(1).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
+
+        test('should set class on the Validation Overlay Popper', async() => {
+            await act(async() => {
+                setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                });
+            });
+
+            expect(
+                document.body.querySelector('.fd-popover__popper').classList
+            ).toContain('wonderful-styles');
+        });
     });
 
     describe('Prop spreading', () => {

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -253,8 +253,12 @@ Select.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/Select/Select.test.js
+++ b/src/Select/Select.test.js
@@ -62,6 +62,16 @@ describe('<Select />', () => {
                 messageNode.classList
             ).toContain('wonderful-styles');
         });
+
+        test('should spread props to Validation overlay wrapper div', async() => {
+            const element = setup({
+                validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+            });
+
+            expect(
+                element.find('.fd-popover').at(1).getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
+        });
     });
 
     describe('Prop spreading', () => {
@@ -95,13 +105,26 @@ describe('<Select />', () => {
             ).toContain('wonderful-styles');
         });
 
-        test('should set class on the Popper', async() => {
+        test('should set class on the dropdown Popper', async() => {
             const wrapper = setup({
                 popoverProps: { popperClassName: 'wonderful-styles' }
             });
 
             await act(async() => {
                 wrapper.find('.fd-select').simulate('click');
+            });
+
+            expect(
+                document.body.querySelector('.fd-popover__popper').classList
+            ).toContain('wonderful-styles');
+        });
+
+        test('should set class on the Validation Overlay Popper', async() => {
+            await act(async() => {
+                setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                });
             });
 
             expect(

--- a/src/StepInput/StepInput.js
+++ b/src/StepInput/StepInput.js
@@ -164,8 +164,12 @@ StepInput.propTypes = {
         className: PropTypes.string,
         /** Additional props to be spread to the ValdiationOverlay's FormMessage component */
         formMessageProps: PropTypes.object,
+        /** Additional classes to apply to validation popover's popper `<div>` element  */
+        popperClassName: PropTypes.string,
         /** CSS class(es) to add to the ValidationOverlay's reference `<div>` element */
-        referenceClassName: PropTypes.string
+        referenceClassName: PropTypes.string,
+        /** Additional props to be spread to the popover's outermost `<div>` element */
+        wrapperProps: PropTypes.object
     }),
     /** An object identifying a validation message.  The object will include properties for `state` and `text`; _e.g._, \`{ state: \'warning\', text: \'This is your last warning\' }\` */
     validationState: PropTypes.shape({

--- a/src/StepInput/StepInput.test.js
+++ b/src/StepInput/StepInput.test.js
@@ -88,6 +88,30 @@ describe('<StepInput />', () => {
                     messageNode.classList
                 ).toContain('wonderful-styles');
             });
+
+            test('should spread props to Validation overlay wrapper div', async() => {
+                const wrapper = setup({
+                    validationState: { state: 'error', text: 'Test validation state' },
+                    validationOverlayProps: { wrapperProps: { 'data-sample': 'Sample' }, show: true }
+                });
+
+                expect(
+                    wrapper.find('.fd-popover').getDOMNode().attributes['data-sample'].value
+                ).toBe('Sample');
+            });
+
+            test('should set class on the Validation Overlay Popper', async() => {
+                await act(async() => {
+                    setup({
+                        validationState: { state: 'error', text: 'Test validation state' },
+                        validationOverlayProps: { popperClassName: 'wonderful-styles', show: true }
+                    });
+                });
+
+                expect(
+                    document.body.querySelector('.fd-popover__popper').classList
+                ).toContain('wonderful-styles');
+            });
         });
     });
     describe('onChange handler', () => {


### PR DESCRIPTION
### Description

I want to be able to add a custom class to the Popper in FormMessage from any component consuming it.

Additionally added documentation + tests for `validationOverlayProps.wrapperProps`

Added tests

Continuation of https://github.com/SAP/fundamental-react/pull/1185


fixes #issueid