### PR TITLE
fix: multiple validationState messages + popover validation message styles

### DIFF
--- a/src/ComboboxInput/ComboboxInput.js
+++ b/src/ComboboxInput/ComboboxInput.js
@@ -403,7 +403,7 @@ const ComboboxInput = React.forwardRef(({
                 disabled={disabled}
                 onClick={handleInputGroupClick}
                 validationOverlayProps={validationOverlayProps}
-                validationState={validationState}>
+                validationState={!isExpanded && validationState}>
                 <FormInput
                     autoComplete='off'
                     {...inputProps}

--- a/src/ComboboxInput/ComboboxInput.test.js
+++ b/src/ComboboxInput/ComboboxInput.test.js
@@ -125,6 +125,18 @@ describe('<ComboboxInput />', () => {
 
         describe('When selectionType is \'manual\'', () => {
 
+            test('should not show multiple validation overlays', () => {
+                let wrapper;
+                act(() => {
+                    wrapper = setupForInteraction({
+                        validationState: { state: 'error', text: 'Test validation state' }
+                    }, container);
+                    wrapper.find('input').simulate('change', { target: { value: 'mal' } });
+                    wrapper.find('input').simulate('focus');
+                });
+                expect(document.querySelectorAll('.fd-form-message').length).toBe(1);
+            });
+
             test('should show filtered options when text is entered in the input field', () => {
                 let wrapper;
                 act(() => {

--- a/src/ComboboxInput/__stories__/ComboboxInput.stories.js
+++ b/src/ComboboxInput/__stories__/ComboboxInput.stories.js
@@ -26,6 +26,7 @@ export const primary = () => (
     <ComboboxInput
         id='primaryComboboxExample'
         label='Default'
+        maxHeight='250px'
         options={countriesData}
         placeholder={placeholder} />
 );
@@ -44,6 +45,7 @@ export const compact = () => (
         ariaLabel='Compact'
         compact
         id='compactComboboxExample'
+        maxHeight='250px'
         options={countriesData}
         placeholder={placeholder} />
 );
@@ -55,6 +57,7 @@ export const validationState = () => (
                 <ComboboxInput
                     id='errorComboboxExample'
                     label='Combobox with error'
+                    maxHeight='250px'
                     options={countriesData}
                     placeholder={placeholder}
                     required
@@ -64,6 +67,7 @@ export const validationState = () => (
                 <ComboboxInput
                     id='warningComboboxExample'
                     label='Combobox with warning'
+                    maxHeight='250px'
                     options={countriesData}
                     placeholder={placeholder}
                     validationState={{ state: 'warning', text: 'Country can be edited only once' }} />
@@ -72,6 +76,7 @@ export const validationState = () => (
                 <ComboboxInput
                     id='infoComboboxExample'
                     label='Combobox with information'
+                    maxHeight='250px'
                     options={countriesData}
                     placeholder={placeholder}
                     validationState={{ state: 'information', text: 'This data will not be shared.' }} />
@@ -80,6 +85,7 @@ export const validationState = () => (
                 <ComboboxInput
                     id='successComboboxExample'
                     label='Combobox with success'
+                    maxHeight='250px'
                     options={countriesData}
                     placeholder={placeholder}
                     validationState={{ state: 'success', text: 'Service is supported in these countries.' }} />

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -398,7 +398,7 @@ class DatePicker extends Component {
                 compact={compact}
                 disabled={disabled}
                 validationOverlayProps={validationOverlayProps}
-                validationState={validationState} >
+                validationState={!this.state.isExpanded && validationState} >
                 <FormInput
                     {...inputProps}
                     onBlur={this.handleBlur}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -419,6 +419,13 @@ class DatePicker extends Component {
             </InputGroup>
         );
 
+        const calendarClasses = classnames(
+            {
+                'fd-list--has-message': validationState?.state
+            },
+            calendarProps?.className
+        );
+
         return (
             <div
                 {...props}>
@@ -429,6 +436,7 @@ class DatePicker extends Component {
                             {validationState?.text?.length > 0 &&
                                 <FormMessage
                                     {...validationOverlayProps?.formMessageProps}
+                                    forPopoverList
                                     type={validationState.state}>
                                     {validationState.text}
                                 </FormMessage>
@@ -436,6 +444,7 @@ class DatePicker extends Component {
                             <Calendar
                                 {...calendarProps}
                                 blockedDates={blockedDates}
+                                className={calendarClasses}
                                 compact={compact}
                                 customDate={
                                     enableRangeSelection

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -625,7 +625,7 @@ describe('<DatePicker />', () => {
                 datepickerButton.simulate('click');
                 datepickerInput.simulate('focus');
             });
-            expect(wrapper.find('.fd-form-message').length).toBe(1);
+            expect(wrapper.find('.fd-list__message').length).toBe(1);
         });
     });
 });

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -615,7 +615,7 @@ describe('<DatePicker />', () => {
             });
         });
 
-        test('does not show multiple validation overlays', () => {
+        test('should not show multiple validation overlays', () => {
             wrapper = mount(
                 <DatePicker validationState={{ state: 'error', text: 'Test validation state' }} />
             );

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -1,10 +1,9 @@
 /* eslint-disable compat/compat */
+import { act } from 'react-test-renderer';
 import DatePicker from '../DatePicker/DatePicker';
 import moment from 'moment';
 import { mount } from 'enzyme';
-
 import React from 'react';
-import { act } from 'react-test-renderer';
 
 describe('<DatePicker />', () => {
     const defaultDatePicker = <DatePicker dateFormat='MM/DD/YYYY' />;

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { mount } from 'enzyme';
 
 import React from 'react';
+import { act } from 'react-test-renderer';
 
 describe('<DatePicker />', () => {
     const defaultDatePicker = <DatePicker dateFormat='MM/DD/YYYY' />;
@@ -612,6 +613,20 @@ describe('<DatePicker />', () => {
             ).toMatchObject({
                 className: 'foo'
             });
+        });
+
+        test('does not show multiple validation overlays', () => {
+            wrapper = mount(
+                <DatePicker validationState={{ state: 'error', text: 'Test validation state' }} />
+            );
+
+            const datepickerButton = wrapper.find('button.fd-button--transparent.sap-icon--appointment-2');
+            const datepickerInput = wrapper.find('input[type="text"]');
+            act(() => {
+                datepickerButton.simulate('click');
+                datepickerInput.simulate('focus');
+            });
+            expect(wrapper.find('.fd-form-message').length).toBe(1);
         });
     });
 });

--- a/src/Forms/_FormMessage.js
+++ b/src/Forms/_FormMessage.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import 'fundamental-styles/dist/form-message.css';
 
-const FormMessage = React.forwardRef(({ children, className, inPopoverList, type, ...props }, ref) => {
+const FormMessage = React.forwardRef(({ children, className, forPopoverList, type, ...props }, ref) => {
 
     const formMessageClasses = classnames(
         {
-            'fd-form-message': !inPopoverList,
-            'fd-list__message': inPopoverList,
-            [`fd-form-message--${type}`]: !inPopoverList && !!type,
-            [`fd-list__message--${type}`]: inPopoverList && !!type
+            'fd-form-message': !forPopoverList,
+            'fd-list__message': forPopoverList,
+            [`fd-form-message--${type}`]: !forPopoverList && !!type,
+            [`fd-list__message--${type}`]: forPopoverList && !!type
         },
         className
     );
@@ -34,8 +34,8 @@ FormMessage.propTypes = {
     children: PropTypes.node,
     /** CSS class(es) to add to the element */
     className: PropTypes.string,
-    /** Set to **true** if FormMessage is inside a popover*/
-    inPopoverList: PropTypes.bool,
+    /** Set to **true** if FormMessage is for a popover with list*/
+    forPopoverList: PropTypes.bool,
     /** Sets the variation of the component. Primarily used for styling */
     type: PropTypes.oneOf(FORM_MESSAGE_TYPES)
 };

--- a/src/Forms/_FormMessage.js
+++ b/src/Forms/_FormMessage.js
@@ -4,12 +4,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import 'fundamental-styles/dist/form-message.css';
 
-const FormMessage = React.forwardRef(({ type, children, className, ...props }, ref) => {
+const FormMessage = React.forwardRef(({ children, className, inPopoverList, type, ...props }, ref) => {
 
     const formMessageClasses = classnames(
-        'fd-form-message',
         {
-            [`fd-form-message--${type}`]: !!type
+            'fd-form-message': !inPopoverList,
+            'fd-list__message': inPopoverList,
+            [`fd-form-message--${type}`]: !inPopoverList && !!type,
+            [`fd-list__message--${type}`]: inPopoverList && !!type
         },
         className
     );
@@ -32,6 +34,8 @@ FormMessage.propTypes = {
     children: PropTypes.node,
     /** CSS class(es) to add to the element */
     className: PropTypes.string,
+    /** Set to **true** if FormMessage is inside a popover*/
+    inPopoverList: PropTypes.bool,
     /** Sets the variation of the component. Primarily used for styling */
     type: PropTypes.oneOf(FORM_MESSAGE_TYPES)
 };

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -200,7 +200,7 @@ class MultiInput extends Component {
                 disabled={disabled}
                 onClick={this.showHideTagList}
                 validationOverlayProps={validationOverlayProps}
-                validationState={validationState}>
+                validationState={!this.state.bShowList && validationState}>
                 <div {...tagProps} className={tokenizerClassName}>
                     <div className='fd-tokenizer__inner'>
                         {this.state.tags.length > 0 && this.createTags()}

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -231,6 +231,7 @@ class MultiInput extends Component {
                         {validationState &&
                         <FormMessage
                             {...validationOverlayProps?.formMessageProps}
+                            inPopoverList
                             type={validationState.state}>
                             {validationState.text}
                         </FormMessage>

--- a/src/MultiInput/MultiInput.js
+++ b/src/MultiInput/MultiInput.js
@@ -231,7 +231,7 @@ class MultiInput extends Component {
                         {validationState &&
                         <FormMessage
                             {...validationOverlayProps?.formMessageProps}
-                            inPopoverList
+                            forPopoverList
                             type={validationState.state}>
                             {validationState.text}
                         </FormMessage>

--- a/src/MultiInput/MultiInput.test.js
+++ b/src/MultiInput/MultiInput.test.js
@@ -100,7 +100,7 @@ describe('<MultiInput />', () => {
 
         wrapper.find('input[type="text"].fd-input').simulate('click');
         wrapper.find('input[type="text"].fd-input').simulate('focus');
-        expect(document.querySelectorAll('.fd-form-message').length).toBe(1);
+        expect(document.querySelectorAll('.fd-list__message').length).toBe(1);
 
     });
 

--- a/src/MultiInput/MultiInput.test.js
+++ b/src/MultiInput/MultiInput.test.js
@@ -19,12 +19,14 @@ describe('<MultiInput />', () => {
         'Cranberry',
         'Cupuacu'
     ];
-    const multiInput = (
+    const getMultiInput = (props) => (
         <MultiInput
+            {...props}
             data={data}
             onTagsUpdate={mockOnTagsUpdate}
             placeholder='Select a Fruit' />
     );
+    const multiInput = getMultiInput();
 
     const compactMultiInput = (
         <MultiInput
@@ -89,6 +91,17 @@ describe('<MultiInput />', () => {
         let results = getListStatus();
         expect(results.combobox).toHaveLength(1);
         expect(results.popover).toHaveLength(1);
+    });
+
+    test('check that multiple validation overlays are not displayed', () => {
+        wrapper = mount(getMultiInput({
+            validationState: { state: 'error', text: 'Test validation state' }
+        }));
+
+        wrapper.find('input[type="text"].fd-input').simulate('click');
+        wrapper.find('input[type="text"].fd-input').simulate('focus');
+        expect(document.querySelectorAll('.fd-form-message').length).toBe(1);
+
     });
 
     // check that tag list is shown on drop down click

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -155,6 +155,9 @@ const Select = React.forwardRef(({
 
     const listBoxClassName = classnames(
         'fd-list--dropdown',
+        {
+            'fd-list--has-message': validationState?.state
+        },
         listClassName
     );
 
@@ -167,6 +170,7 @@ const Select = React.forwardRef(({
                 (<>
                     {validationState &&
                     <FormMessage
+                        forPopoverList
                         {...validationOverlayProps?.formMessageProps}
                         type={validationState.state}>
                         {validationState.text}


### PR DESCRIPTION
## Description
In this change we
* Update ComboboxInput, DatePicker, and MultiInput to not show input aligned semantic messages when the popover is open. This is because the popover is expected to show this message. Hence we do not want to duplicate the semantic message.
* Use appropriate styles for validation messages that are inside popovers

## Screenshots

## Before
![image](https://user-images.githubusercontent.com/43764832/92061512-5570b000-ed4b-11ea-9585-cc865db25545.png)

![image](https://user-images.githubusercontent.com/43764832/92061535-65888f80-ed4b-11ea-9482-39178e9631c2.png)

![image](https://user-images.githubusercontent.com/43764832/92061562-776a3280-ed4b-11ea-950a-9449b8795366.png)

## After
![image](https://user-images.githubusercontent.com/43764832/92061613-98328800-ed4b-11ea-910e-757567da6399.png)
![image](https://user-images.githubusercontent.com/43764832/92142399-9ce95180-edc8-11ea-8ba0-13240e1af343.png)
![image](https://user-images.githubusercontent.com/43764832/92142463-b7232f80-edc8-11ea-98a0-6381bda6b993.png)

