### PR TITLE
fix: in SSR `null` is not a valid prop-type

### DIFF
--- a/src/utils/CustomPropTypes/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes/CustomPropTypes.js
@@ -8,7 +8,7 @@ const ANONYMOUS = '<<anonymous>>';
 const elementOrArrayOfElements = () => {
     // Element is not defined unless the Browser API is defined
     if (typeof Element === 'undefined') {
-        return null;
+        return PropTypes.any;
     }
     return PropTypes.oneOfType([
         PropTypes.arrayOf(PropTypes.instanceOf(Element)),


### PR DESCRIPTION
### Description
Consumers are seeing this warning if running code containing the DatePicker for SSR
```
Warning: Failed prop type: Popper: prop type `flipContainer` is invalid; it must be a function, usually from the `prop-types` package, but received `object`.
     in Popper
     in Popover
     in div
     in DatePicker
```


fixes #issueid