### PR TITLE
feat: update fundamental-styles to 0.12.0-rc.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16405,9 +16405,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.12.0-rc.39",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.39.tgz",
-      "integrity": "sha512-+TrBNMAqXOnYuA7bhJt2vsFrQ08T4pWUgj2jg5bzrF+zyVMDqEqO9EdvziFuGFT4icMWLijQirYfKWVWlwGOZA=="
+      "version": "0.12.0-rc.44",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.44.tgz",
+      "integrity": "sha512-V+aDbmSX2Twk2HauuX7MLqjkjMNzp9Nh9YG7Pg8MIA8AEvBlT1NUVAoAtDcpMBwdTgQf7JPobbfI8i+IZy71mA=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16405,9 +16405,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.12.0-rc.18",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.18.tgz",
-      "integrity": "sha512-I+1AsgKrNhtWI/LIegPtiiSI4j+zy+N+XUQOrURdtIs3oDHV5PNV93qGgMKxdem/V+eDlTLB5gb/id2d2u80cQ=="
+      "version": "0.12.0-rc.39",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.39.tgz",
+      "integrity": "sha512-+TrBNMAqXOnYuA7bhJt2vsFrQ08T4pWUgj2jg5bzrF+zyVMDqEqO9EdvziFuGFT4icMWLijQirYfKWVWlwGOZA=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@popperjs/core": "^2.4.3",
     "chain-function": "^1.0.1",
     "classnames": "^2.2.6",
-    "fundamental-styles": "0.12.0-rc.18",
+    "fundamental-styles": "0.12.0-rc.39",
     "keycode": "^2.2.0",
     "moment": "^2.26.0",
     "prop-types": "^15.7.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@popperjs/core": "^2.4.3",
     "chain-function": "^1.0.1",
     "classnames": "^2.2.6",
-    "fundamental-styles": "0.12.0-rc.39",
+    "fundamental-styles": "0.12.0-rc.44",
     "keycode": "^2.2.0",
     "moment": "^2.26.0",
     "prop-types": "^15.7.1",

--- a/src/ActionBar/ActionBar.test.js
+++ b/src/ActionBar/ActionBar.test.js
@@ -22,7 +22,7 @@ describe('<ActionBar />', () => {
             });
 
             expect(
-                element.find('.sap-icon--navigation-left-arrow').getDOMNode().attributes['data-sample'].value
+                element.find('button.fd-button--transparent').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
 

--- a/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
+++ b/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
@@ -20,6 +20,7 @@ exports[`Storyshots Component API/ActionBar Dev 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-left-arrow"
           />
         </button>
@@ -212,6 +213,7 @@ exports[`Storyshots Component API/ActionBar Primary 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-left-arrow"
           />
         </button>
@@ -305,6 +307,7 @@ exports[`Storyshots Component API/ActionBar With a ContextualMenu 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--vertical-grip"
                 />
               </button>

--- a/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
+++ b/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
@@ -15,10 +15,14 @@ exports[`Storyshots Component API/ActionBar Dev 1`] = `
       >
         <button
           aria-label="Back to home"
-          className="fd-button fd-button--transparent fd-button--compact sap-icon--navigation-left-arrow"
+          className="fd-button fd-button--transparent fd-button--compact"
           onClick={[Function]}
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-left-arrow"
+          />
+        </button>
       </div>
       <div
         className="fd-action-bar__title"
@@ -36,13 +40,21 @@ exports[`Storyshots Component API/ActionBar Dev 1`] = `
           className="fd-button"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
         <button
           className="fd-button fd-button--emphasized"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
       </div>
     </div>
@@ -105,13 +117,21 @@ exports[`Storyshots Component API/ActionBar No Back Button 1`] = `
           className="fd-button"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
         <button
           className="fd-button fd-button--emphasized"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
       </div>
     </div>
@@ -150,13 +170,21 @@ exports[`Storyshots Component API/ActionBar No Description 1`] = `
           className="fd-button"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
         <button
           className="fd-button fd-button--emphasized"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
       </div>
     </div>
@@ -179,10 +207,14 @@ exports[`Storyshots Component API/ActionBar Primary 1`] = `
       >
         <button
           aria-label="Back to home"
-          className="fd-button fd-button--transparent fd-button--compact sap-icon--navigation-left-arrow"
+          className="fd-button fd-button--transparent fd-button--compact"
           onClick={[Function]}
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-left-arrow"
+          />
+        </button>
       </div>
       <div
         className="fd-action-bar__title"
@@ -200,13 +232,21 @@ exports[`Storyshots Component API/ActionBar Primary 1`] = `
           className="fd-button"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
         <button
           className="fd-button fd-button--emphasized"
           type="button"
         >
-          Button
+          <span
+            className="fd-button__text"
+          >
+            Button
+          </span>
         </button>
       </div>
     </div>
@@ -257,13 +297,17 @@ exports[`Storyshots Component API/ActionBar With a ContextualMenu 1`] = `
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="More actions"
-                className="fd-button fd-button--transparent sap-icon--vertical-grip"
+                className="fd-button fd-button--transparent"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
                 tabIndex={0}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--vertical-grip"
+                />
+              </button>
             </div>
           </div>
         </div>

--- a/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
+++ b/src/ActionBar/__stories__/__snapshots__/ActionBar.stories.storyshot
@@ -20,8 +20,9 @@ exports[`Storyshots Component API/ActionBar Dev 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-left-arrow"
+            role="img"
           />
         </button>
       </div>
@@ -213,8 +214,9 @@ exports[`Storyshots Component API/ActionBar Primary 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-left-arrow"
+            role="img"
           />
         </button>
       </div>
@@ -307,8 +309,9 @@ exports[`Storyshots Component API/ActionBar With a ContextualMenu 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--vertical-grip"
+                  role="img"
                 />
               </button>
             </div>

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
+import Icon from '../Icon/Icon';
 import PropTypes from 'prop-types';
 import React from 'react';
 import useUniqueId from '../utils/useUniqueId';
 import { BUTTON_OPTIONS, BUTTON_TYPES } from '../utils/constants';
-import 'fundamental-styles/dist/icon.css';
 import 'fundamental-styles/dist/button.css';
 
 /** A **Button** allows users to perform an action. The priority of buttons within a page should be considered.
@@ -20,7 +20,7 @@ const Button = React.forwardRef(({
     enabledMessage,
     glyph,
     iconBeforeText,
-    iconClassName,
+    iconProps,
     selected,
     disabled,
     typeAttr,
@@ -46,13 +46,6 @@ const Button = React.forwardRef(({
     const buttonTextClasses = classnames(
         'fd-button__text',
         textClassName
-    );
-
-    const iconClasses = classnames(
-        {
-            [`sap-icon--${glyph}`]: !!glyph
-        },
-        iconClassName
     );
 
     const ariaDisabled = props['aria-disabled'];
@@ -91,6 +84,18 @@ const Button = React.forwardRef(({
         return content;
     };
 
+    const renderIcon = () => {
+        const content = glyph ? (
+            <Icon
+                {...iconProps}
+                ariaHidden
+                glyph={glyph}
+                isInButton />
+        ) : null;
+
+        return content;
+    };
+
     return (
         <>
             <button
@@ -101,9 +106,9 @@ const Button = React.forwardRef(({
                 ref={ref}
                 selected={selected}
                 type={typeAttr}>
-                {iconBeforeText && glyph && <i aria-hidden='true' className={iconClasses} />}
+                {iconBeforeText && renderIcon()}
                 {children && <span className={buttonTextClasses}>{children}</span>}
-                {!iconBeforeText && glyph && <i aria-hidden='true' className={iconClasses} />}
+                {!iconBeforeText && renderIcon()}
             </button>
             {renderButtonStateMessage()}
         </>
@@ -153,8 +158,8 @@ Button.propTypes = {
     glyph: PropTypes.string,
     /** Determines whether the icon should be placed before the text */
     iconBeforeText: PropTypes.bool,
-    /** CSS class(es) to add to the icon element */
-    iconClassName: PropTypes.string,
+    /** Additional props to be spread to the Icon component */
+    iconProps: PropTypes.object,
     /** Indicates the importance of the button: 'emphasized' or 'transparent' */
     option: PropTypes.oneOf(BUTTON_OPTIONS),
     /** Set to **true** to set state of the button to "selected" */

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -25,6 +25,7 @@ const Button = React.forwardRef(({
     onClick,
     children,
     className,
+    textClassName,
     ...props
 }, ref) => {
 
@@ -34,11 +35,15 @@ const Button = React.forwardRef(({
             [`fd-button--${option}`]: !!option,
             [`fd-button--${type}`]: !!type,
             'fd-button--compact': compact,
-            [`sap-icon--${glyph}`]: !!glyph,
             'is-selected': selected,
             'is-disabled': disabled
         },
         className
+    );
+
+    const buttonTextClasses = classnames(
+        'fd-button__text',
+        textClassName
     );
 
     const ariaDisabled = props['aria-disabled'];
@@ -86,7 +91,8 @@ const Button = React.forwardRef(({
                 ref={ref}
                 selected={selected}
                 type={typeAttr}>
-                {children}
+                {children && <span className={buttonTextClasses}>{children}</span>}
+                {glyph && <i className={`sap-icon--${glyph}`} />}
             </button>
             {renderButtonStateMessage()}
         </>
@@ -138,6 +144,8 @@ Button.propTypes = {
     option: PropTypes.oneOf(BUTTON_OPTIONS),
     /** Set to **true** to set state of the button to "selected" */
     selected: PropTypes.bool,
+    /** CSS class(es) to add to the text element */
+    textClassName: PropTypes.string,
     /** Sets the variation of the component. Primarily used for styling: 'standard',
     'positive',
     'negative',

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -19,6 +19,8 @@ const Button = React.forwardRef(({
     disabledMessage,
     enabledMessage,
     glyph,
+    iconBeforeText,
+    iconClassName,
     selected,
     disabled,
     typeAttr,
@@ -44,6 +46,13 @@ const Button = React.forwardRef(({
     const buttonTextClasses = classnames(
         'fd-button__text',
         textClassName
+    );
+
+    const iconClasses = classnames(
+        {
+            [`sap-icon--${glyph}`]: !!glyph
+        },
+        iconClassName
     );
 
     const ariaDisabled = props['aria-disabled'];
@@ -91,8 +100,9 @@ const Button = React.forwardRef(({
                 ref={ref}
                 selected={selected}
                 type={typeAttr}>
+                {iconBeforeText && glyph && <i className={iconClasses} />}
                 {children && <span className={buttonTextClasses}>{children}</span>}
-                {glyph && <i className={`sap-icon--${glyph}`} />}
+                {!iconBeforeText && glyph && <i className={iconClasses} />}
             </button>
             {renderButtonStateMessage()}
         </>
@@ -140,6 +150,10 @@ Button.propTypes = {
     enabledMessage: validateStateTransitionMessage,
     /** The icon to include. See the icon page for the list of icons */
     glyph: PropTypes.string,
+    /** Determines whether the icon should be placed before the text */
+    iconBeforeText: PropTypes.bool,
+    /** CSS class(es) to add to the icon element */
+    iconClassName: PropTypes.string,
     /** Indicates the importance of the button: 'empahsized' or 'transparent' */
     option: PropTypes.oneOf(BUTTON_OPTIONS),
     /** Set to **true** to set state of the button to "selected" */

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -90,6 +90,7 @@ const Button = React.forwardRef(({
         }
         return content;
     };
+
     return (
         <>
             <button
@@ -100,9 +101,9 @@ const Button = React.forwardRef(({
                 ref={ref}
                 selected={selected}
                 type={typeAttr}>
-                {iconBeforeText && glyph && <i className={iconClasses} />}
+                {iconBeforeText && glyph && <i aria-hidden='true' className={iconClasses} />}
                 {children && <span className={buttonTextClasses}>{children}</span>}
-                {!iconBeforeText && glyph && <i className={iconClasses} />}
+                {!iconBeforeText && glyph && <i aria-hidden='true' className={iconClasses} />}
             </button>
             {renderButtonStateMessage()}
         </>
@@ -154,7 +155,7 @@ Button.propTypes = {
     iconBeforeText: PropTypes.bool,
     /** CSS class(es) to add to the icon element */
     iconClassName: PropTypes.string,
-    /** Indicates the importance of the button: 'empahsized' or 'transparent' */
+    /** Indicates the importance of the button: 'emphasized' or 'transparent' */
     option: PropTypes.oneOf(BUTTON_OPTIONS),
     /** Set to **true** to set state of the button to "selected" */
     selected: PropTypes.bool,

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -89,8 +89,7 @@ const Button = React.forwardRef(({
             <Icon
                 {...iconProps}
                 ariaHidden
-                glyph={glyph}
-                isInButton />
+                glyph={glyph} />
         ) : null;
 
         return content;

--- a/src/Button/Button.test.js
+++ b/src/Button/Button.test.js
@@ -11,6 +11,14 @@ describe('<Button />', () => {
                 element.find('.fd-button').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
+
+        test('should allow spreading className to inner text', () => {
+            const element = mount(<Button textClassName='wonderful-styles'>Button</Button>);
+
+            expect(
+                element.find('.fd-button__text').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
     });
     test('forwards the ref', () => {
         let ref;

--- a/src/Button/Button.test.js
+++ b/src/Button/Button.test.js
@@ -19,6 +19,14 @@ describe('<Button />', () => {
                 element.find('.fd-button__text').getDOMNode().classList
             ).toContain('wonderful-styles');
         });
+
+        test('should allow spreading className to icon', () => {
+            const element = mount(<Button glyph='bell' iconClassName='wonderful-styles'>Button</Button>);
+
+            expect(
+                element.find('.sap-icon--bell').getDOMNode().classList
+            ).toContain('wonderful-styles');
+        });
     });
     test('forwards the ref', () => {
         let ref;
@@ -32,6 +40,22 @@ describe('<Button />', () => {
         mount(<Test />);
         expect(ref.current.tagName).toEqual('BUTTON');
         expect(ref.current.className).toEqual('fd-button');
+    });
+
+    test('should render the icon before the text when `iconBeforeText` is true', () => {
+        const element = mount(<Button glyph='bell' iconBeforeText>Button</Button>);
+
+        expect(
+            element.find('.fd-button').childAt(0).getDOMNode().classList
+        ).toContain('sap-icon--bell');
+    });
+
+    test('should render the icon after the text when `iconBeforeText` is not defined', () => {
+        const element = mount(<Button glyph='bell'>Button</Button>);
+
+        expect(
+            element.find('.fd-button').childAt(1).getDOMNode().classList
+        ).toContain('sap-icon--bell');
     });
 
     describe('a11y', () => {

--- a/src/Button/Button.test.js
+++ b/src/Button/Button.test.js
@@ -20,12 +20,12 @@ describe('<Button />', () => {
             ).toContain('wonderful-styles');
         });
 
-        test('should allow spreading className to icon', () => {
-            const element = mount(<Button glyph='bell' iconClassName='wonderful-styles'>Button</Button>);
+        test('should allow spreading props to icon', () => {
+            const element = mount(<Button glyph='bell'iconProps={{ 'data-sample': 'Sample' }}>Button</Button>);
 
             expect(
-                element.find('.sap-icon--bell').getDOMNode().classList
-            ).toContain('wonderful-styles');
+                element.find('i.sap-icon--bell').getDOMNode().attributes['data-sample'].value
+            ).toBe('Sample');
         });
     });
     test('forwards the ref', () => {

--- a/src/Button/__stories__/Button.stories.js
+++ b/src/Button/__stories__/Button.stories.js
@@ -65,7 +65,8 @@ export const icons = () => (
         <Button glyph='edit' type='ghost'>Edit</Button>
         <Button glyph='warning' type='attention'>Ignore</Button>
         <div className='fddocs-container--break' />
-        <Button glyph='alert' option='emphasized' />
+        <Button aria-label='See warning' glyph='alert'
+            option='emphasized' />
         <Button aria-label='Add to cart' glyph='cart' />
         <Button aria-label='Filter' glyph='cart'
             option='transparent' />

--- a/src/Button/__stories__/Button.stories.js
+++ b/src/Button/__stories__/Button.stories.js
@@ -53,7 +53,7 @@ export const types = () => (
 
 types.storyName = 'Types';
 
-/** Button can have an icon with text or just and icon. */
+/** Button can have an icon with text or just an icon. Be sure to use an `aria-label` if there is no text. */
 
 export const icons = () => (
     <div className='fddocs-container'>

--- a/src/Button/__stories__/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/Button.stories.storyshot
@@ -133,6 +133,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       className="fddocs-container--break"
     />
     <button
+      aria-label="See warning"
       className="fd-button fd-button--emphasized"
       type="button"
     >

--- a/src/Button/__stories__/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/Button.stories.storyshot
@@ -34,6 +34,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Add to Cart
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--cart"
       />
     </button>
@@ -47,6 +48,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Add to Cart
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--cart"
       />
     </button>
@@ -60,6 +62,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Filter
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--filter"
       />
     </button>
@@ -73,6 +76,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Approve
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--accept"
       />
     </button>
@@ -86,6 +90,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Reject
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -99,6 +104,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Edit
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--edit"
       />
     </button>
@@ -112,6 +118,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Ignore
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--warning"
       />
     </button>
@@ -123,6 +130,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--alert"
       />
     </button>
@@ -132,6 +140,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--cart"
       />
     </button>
@@ -141,6 +150,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--cart"
       />
     </button>
@@ -150,6 +160,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--accept"
       />
     </button>
@@ -159,6 +170,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -168,6 +180,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--edit"
       />
     </button>
@@ -177,6 +190,7 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--warning"
       />
     </button>

--- a/src/Button/__stories__/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/Button.stories.storyshot
@@ -8,7 +8,11 @@ exports[`Storyshots Component API/Button/Button Dev 1`] = `
     className="fd-button"
     type="button"
   >
-    Dev
+    <span
+      className="fd-button__text"
+    >
+      Dev
+    </span>
   </button>
 </div>
 `;
@@ -21,84 +25,161 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
     className="fddocs-container"
   >
     <button
-      className="fd-button fd-button--emphasized sap-icon--cart"
+      className="fd-button fd-button--emphasized"
       type="button"
     >
-      Add to Cart
+      <span
+        className="fd-button__text"
+      >
+        Add to Cart
+      </span>
+      <i
+        className="sap-icon--cart"
+      />
     </button>
     <button
-      className="fd-button sap-icon--cart"
+      className="fd-button"
       type="button"
     >
-      Add to Cart
+      <span
+        className="fd-button__text"
+      >
+        Add to Cart
+      </span>
+      <i
+        className="sap-icon--cart"
+      />
     </button>
     <button
-      className="fd-button fd-button--transparent sap-icon--filter"
+      className="fd-button fd-button--transparent"
       type="button"
     >
-      Filter
+      <span
+        className="fd-button__text"
+      >
+        Filter
+      </span>
+      <i
+        className="sap-icon--filter"
+      />
     </button>
     <button
-      className="fd-button fd-button--positive sap-icon--accept"
+      className="fd-button fd-button--positive"
       type="button"
     >
-      Approve
+      <span
+        className="fd-button__text"
+      >
+        Approve
+      </span>
+      <i
+        className="sap-icon--accept"
+      />
     </button>
     <button
-      className="fd-button fd-button--negative sap-icon--decline"
+      className="fd-button fd-button--negative"
       type="button"
     >
-      Reject
+      <span
+        className="fd-button__text"
+      >
+        Reject
+      </span>
+      <i
+        className="sap-icon--decline"
+      />
     </button>
     <button
-      className="fd-button fd-button--ghost sap-icon--edit"
+      className="fd-button fd-button--ghost"
       type="button"
     >
-      Edit
+      <span
+        className="fd-button__text"
+      >
+        Edit
+      </span>
+      <i
+        className="sap-icon--edit"
+      />
     </button>
     <button
-      className="fd-button fd-button--attention sap-icon--warning"
+      className="fd-button fd-button--attention"
       type="button"
     >
-      Ignore
+      <span
+        className="fd-button__text"
+      >
+        Ignore
+      </span>
+      <i
+        className="sap-icon--warning"
+      />
     </button>
     <div
       className="fddocs-container--break"
     />
     <button
-      className="fd-button fd-button--emphasized sap-icon--alert"
+      className="fd-button fd-button--emphasized"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--alert"
+      />
+    </button>
     <button
       aria-label="Add to cart"
-      className="fd-button sap-icon--cart"
+      className="fd-button"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--cart"
+      />
+    </button>
     <button
       aria-label="Filter"
-      className="fd-button fd-button--transparent sap-icon--cart"
+      className="fd-button fd-button--transparent"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--cart"
+      />
+    </button>
     <button
       aria-label="Accept"
-      className="fd-button fd-button--positive sap-icon--accept"
+      className="fd-button fd-button--positive"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--accept"
+      />
+    </button>
     <button
       aria-label="Decline"
-      className="fd-button fd-button--negative sap-icon--decline"
+      className="fd-button fd-button--negative"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <button
       aria-label="Edit"
-      className="fd-button fd-button--ghost sap-icon--edit"
+      className="fd-button fd-button--ghost"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--edit"
+      />
+    </button>
     <button
       aria-label="Ignore"
-      className="fd-button fd-button--attention sap-icon--warning"
+      className="fd-button fd-button--attention"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--warning"
+      />
+    </button>
   </div>
 </div>
 `;
@@ -114,19 +195,31 @@ exports[`Storyshots Component API/Button/Button Options 1`] = `
       className="fd-button fd-button--emphasized"
       type="button"
     >
-      Emphasized Button
+      <span
+        className="fd-button__text"
+      >
+        Emphasized Button
+      </span>
     </button>
     <button
       className="fd-button"
       type="button"
     >
-      Default Button
+      <span
+        className="fd-button__text"
+      >
+        Default Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--transparent"
       type="button"
     >
-      Transparent Button
+      <span
+        className="fd-button__text"
+      >
+        Transparent Button
+      </span>
     </button>
   </div>
 </div>
@@ -140,7 +233,11 @@ exports[`Storyshots Component API/Button/Button Primary 1`] = `
     className="fd-button"
     type="button"
   >
-    Button
+    <span
+      className="fd-button__text"
+    >
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -156,13 +253,21 @@ exports[`Storyshots Component API/Button/Button Sizes 1`] = `
       className="fd-button"
       type="button"
     >
-      Default
+      <span
+        className="fd-button__text"
+      >
+        Default
+      </span>
     </button>
     <button
       className="fd-button fd-button--compact"
       type="button"
     >
-      Compact
+      <span
+        className="fd-button__text"
+      >
+        Compact
+      </span>
     </button>
   </div>
 </div>
@@ -179,21 +284,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button"
       type="button"
     >
-      Default
+      <span
+        className="fd-button__text"
+      >
+        Default
+      </span>
     </button>
     <button
       className="fd-button is-selected"
       selected={true}
       type="button"
     >
-      Selected
+      <span
+        className="fd-button__text"
+      >
+        Selected
+      </span>
     </button>
     <button
       className="fd-button is-disabled"
       disabled={true}
       type="button"
     >
-      Disabled
+      <span
+        className="fd-button__text"
+      >
+        Disabled
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -202,7 +319,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Disabled Focusable
+      <span
+        className="fd-button__text"
+      >
+        Disabled Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -218,21 +339,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--emphasized"
       type="button"
     >
-      Emphasized
+      <span
+        className="fd-button__text"
+      >
+        Emphasized
+      </span>
     </button>
     <button
       className="fd-button fd-button--emphasized is-selected"
       selected={true}
       type="button"
     >
-      Emphasized
+      <span
+        className="fd-button__text"
+      >
+        Emphasized
+      </span>
     </button>
     <button
       className="fd-button fd-button--emphasized is-disabled"
       disabled={true}
       type="button"
     >
-      Emphasized
+      <span
+        className="fd-button__text"
+      >
+        Emphasized
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -241,7 +374,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Emphasized Focusable
+      <span
+        className="fd-button__text"
+      >
+        Emphasized Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -257,21 +394,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--transparent"
       type="button"
     >
-      Transparent
+      <span
+        className="fd-button__text"
+      >
+        Transparent
+      </span>
     </button>
     <button
       className="fd-button fd-button--transparent is-selected"
       selected={true}
       type="button"
     >
-      Transparent
+      <span
+        className="fd-button__text"
+      >
+        Transparent
+      </span>
     </button>
     <button
       className="fd-button fd-button--transparent is-disabled"
       disabled={true}
       type="button"
     >
-      Transparent
+      <span
+        className="fd-button__text"
+      >
+        Transparent
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -280,7 +429,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Transparent Focusable
+      <span
+        className="fd-button__text"
+      >
+        Transparent Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -296,21 +449,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--positive"
       type="button"
     >
-      Positive Button
+      <span
+        className="fd-button__text"
+      >
+        Positive Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--positive is-selected"
       selected={true}
       type="button"
     >
-      Positive Button
+      <span
+        className="fd-button__text"
+      >
+        Positive Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--positive is-disabled"
       disabled={true}
       type="button"
     >
-      Positive Button
+      <span
+        className="fd-button__text"
+      >
+        Positive Button
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -319,7 +484,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Positive Focusable
+      <span
+        className="fd-button__text"
+      >
+        Positive Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -335,21 +504,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--negative"
       type="button"
     >
-      Negative Button
+      <span
+        className="fd-button__text"
+      >
+        Negative Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--negative is-selected"
       selected={true}
       type="button"
     >
-      Negative Button
+      <span
+        className="fd-button__text"
+      >
+        Negative Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--negative is-disabled"
       disabled={true}
       type="button"
     >
-      Negative Button
+      <span
+        className="fd-button__text"
+      >
+        Negative Button
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -358,7 +539,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Negative Focusable
+      <span
+        className="fd-button__text"
+      >
+        Negative Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -374,21 +559,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--ghost"
       type="button"
     >
-      Ghost Button
+      <span
+        className="fd-button__text"
+      >
+        Ghost Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--ghost is-selected"
       selected={true}
       type="button"
     >
-      Ghost Button
+      <span
+        className="fd-button__text"
+      >
+        Ghost Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--ghost is-disabled"
       disabled={true}
       type="button"
     >
-      Ghost Button
+      <span
+        className="fd-button__text"
+      >
+        Ghost Button
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -397,7 +594,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Ghost Focusable
+      <span
+        className="fd-button__text"
+      >
+        Ghost Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -413,21 +614,33 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       className="fd-button fd-button--attention"
       type="button"
     >
-      Attention Button
+      <span
+        className="fd-button__text"
+      >
+        Attention Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--attention is-selected"
       selected={true}
       type="button"
     >
-      Attention Button
+      <span
+        className="fd-button__text"
+      >
+        Attention Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--attention is-disabled"
       disabled={true}
       type="button"
     >
-      Attention Button
+      <span
+        className="fd-button__text"
+      >
+        Attention Button
+      </span>
     </button>
     <button
       aria-describedby="fd-mocked-short-id"
@@ -436,7 +649,11 @@ exports[`Storyshots Component API/Button/Button States 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Attention Focusable
+      <span
+        className="fd-button__text"
+      >
+        Attention Focusable
+      </span>
     </button>
     <p
       aria-live="assertive"
@@ -460,37 +677,61 @@ exports[`Storyshots Component API/Button/Button Types 1`] = `
       className="fd-button"
       type="button"
     >
-      Default Button
+      <span
+        className="fd-button__text"
+      >
+        Default Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--standard"
       type="button"
     >
-      Standard Button
+      <span
+        className="fd-button__text"
+      >
+        Standard Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--positive"
       type="button"
     >
-      Positive Button
+      <span
+        className="fd-button__text"
+      >
+        Positive Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--negative"
       type="button"
     >
-      Negative Button
+      <span
+        className="fd-button__text"
+      >
+        Negative Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--ghost"
       type="button"
     >
-      Ghost Button
+      <span
+        className="fd-button__text"
+      >
+        Ghost Button
+      </span>
     </button>
     <button
       className="fd-button fd-button--attention"
       type="button"
     >
-      Attention Button
+      <span
+        className="fd-button__text"
+      >
+        Attention Button
+      </span>
     </button>
   </div>
 </div>

--- a/src/Button/__stories__/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/Button.stories.storyshot
@@ -34,8 +34,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Add to Cart
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--cart"
+        role="img"
       />
     </button>
     <button
@@ -48,8 +49,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Add to Cart
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--cart"
+        role="img"
       />
     </button>
     <button
@@ -62,8 +64,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Filter
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--filter"
+        role="img"
       />
     </button>
     <button
@@ -76,8 +79,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Approve
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--accept"
+        role="img"
       />
     </button>
     <button
@@ -90,8 +94,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Reject
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <button
@@ -104,8 +109,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Edit
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--edit"
+        role="img"
       />
     </button>
     <button
@@ -118,8 +124,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
         Ignore
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--warning"
+        role="img"
       />
     </button>
     <div
@@ -130,8 +137,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--alert"
+        role="img"
       />
     </button>
     <button
@@ -140,8 +148,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--cart"
+        role="img"
       />
     </button>
     <button
@@ -150,8 +159,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--cart"
+        role="img"
       />
     </button>
     <button
@@ -160,8 +170,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--accept"
+        role="img"
       />
     </button>
     <button
@@ -170,8 +181,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <button
@@ -180,8 +192,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--edit"
+        role="img"
       />
     </button>
     <button
@@ -190,8 +203,9 @@ exports[`Storyshots Component API/Button/Button Icons 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--warning"
+        role="img"
       />
     </button>
   </div>

--- a/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
@@ -58,8 +58,9 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--survey"
+        role="img"
       />
     </button>
     <button
@@ -68,8 +69,9 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--pie-chart"
+        role="img"
       />
     </button>
     <button
@@ -77,8 +79,9 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--pool"
+        role="img"
       />
     </button>
   </div>

--- a/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
@@ -58,6 +58,7 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--survey"
       />
     </button>
@@ -67,6 +68,7 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--pie-chart"
       />
     </button>
@@ -75,6 +77,7 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--pool"
       />
     </button>

--- a/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
+++ b/src/Button/__stories__/__snapshots__/ButtonSegmented.stories.storyshot
@@ -13,20 +13,32 @@ exports[`Storyshots Component API/Button/ButtonSegmented Compact 1`] = `
       className="fd-button fd-button--compact"
       type="button"
     >
-      Left
+      <span
+        className="fd-button__text"
+      >
+        Left
+      </span>
     </button>
     <button
       className="fd-button fd-button--compact is-selected"
       selected={true}
       type="button"
     >
-      Middle
+      <span
+        className="fd-button__text"
+      >
+        Middle
+      </span>
     </button>
     <button
       className="fd-button fd-button--compact"
       type="button"
     >
-      Right
+      <span
+        className="fd-button__text"
+      >
+        Right
+      </span>
     </button>
   </div>
 </div>
@@ -42,18 +54,30 @@ exports[`Storyshots Component API/Button/ButtonSegmented Primary 1`] = `
     role="group"
   >
     <button
-      className="fd-button sap-icon--survey"
+      className="fd-button"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--survey"
+      />
+    </button>
     <button
-      className="fd-button sap-icon--pie-chart is-selected"
+      className="fd-button is-selected"
       selected={true}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--pie-chart"
+      />
+    </button>
     <button
-      className="fd-button sap-icon--pool"
+      className="fd-button"
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--pool"
+      />
+    </button>
   </div>
 </div>
 `;

--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -479,9 +479,7 @@ class Calendar extends Component {
                             compact={this.props.compact}
                             onClick={this.showMonths}
                             option='transparent'>
-                            <span>
-                                {months[this.state.currentDateDisplayed.month()]}
-                            </span>
+                            {months[this.state.currentDateDisplayed.month()]}
                         </Button>
                     </div>
                     <div className='fd-calendar__action'>
@@ -489,9 +487,7 @@ class Calendar extends Component {
                             compact={this.props.compact}
                             onClick={this.showYears}
                             option='transparent'>
-                            <span>
-                                {this.state.currentDateDisplayed.year()}
-                            </span>
+                            {this.state.currentDateDisplayed.year()}
                         </Button>
                     </div>
 

--- a/src/ComboboxInput/ComboboxInput.test.js
+++ b/src/ComboboxInput/ComboboxInput.test.js
@@ -84,7 +84,7 @@ describe('<ComboboxInput />', () => {
                     selectionType='auto-inline' />
             );
             expect(
-                element.find('button.sap-icon--navigation-down-arrow').getDOMNode().attributes['data-sample'].value
+                element.find('button').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
     });

--- a/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
+++ b/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
@@ -494,6 +494,7 @@ exports[`Storyshots Component API/ComboboxInput Selection Type 1`] = `
                           type="button"
                         >
                           <i
+                            aria-hidden="true"
                             className="sap-icon--navigation-down-arrow"
                           />
                         </button>

--- a/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
+++ b/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
@@ -494,8 +494,9 @@ exports[`Storyshots Component API/ComboboxInput Selection Type 1`] = `
                           type="button"
                         >
                           <i
-                            aria-hidden="true"
+                            aria-hidden={true}
                             className="sap-icon--navigation-down-arrow"
+                            role="img"
                           />
                         </button>
                       </span>

--- a/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
+++ b/src/ComboboxInput/__stories__/__snapshots__/ComboboxInput.stories.storyshot
@@ -69,7 +69,11 @@ exports[`Storyshots Component API/ComboboxInput Dev 1`] = `
             className="fd-button"
             type="button"
           >
-            Dummy
+            <span
+              className="fd-button__text"
+            >
+              Dummy
+            </span>
           </button>
         </div>
       </div>
@@ -177,7 +181,11 @@ exports[`Storyshots Component API/ComboboxInput Dev 1`] = `
             className="fd-button"
             type="button"
           >
-            Dummy
+            <span
+              className="fd-button__text"
+            >
+              Dummy
+            </span>
           </button>
         </div>
       </div>
@@ -479,12 +487,16 @@ exports[`Storyshots Component API/ComboboxInput Selection Type 1`] = `
                       >
                         <button
                           aria-label="Show country options"
-                          className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+                          className="fd-button fd-button--transparent fd-input-group__button"
                           id="comboboxAutoInlineSelectExample-combobox-arrow"
                           onClick={[Function]}
                           tabIndex="-1"
                           type="button"
-                        />
+                        >
+                          <i
+                            className="sap-icon--navigation-down-arrow"
+                          />
+                        </button>
                       </span>
                     </div>
                   </div>

--- a/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
+++ b/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
@@ -77,8 +77,9 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--bell"
+        role="img"
       />
     </button>
     <button
@@ -96,8 +97,9 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--bell"
+        role="img"
       />
     </button>
     <button
@@ -115,8 +117,9 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--bell"
+        role="img"
       />
     </button>
     <button
@@ -134,8 +137,9 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--bell"
+        role="img"
       />
     </button>
   </div>

--- a/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
+++ b/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
@@ -77,6 +77,7 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--bell"
       />
     </button>
@@ -95,6 +96,7 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--bell"
       />
     </button>
@@ -113,6 +115,7 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--bell"
       />
     </button>
@@ -131,6 +134,7 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
         </span>
       </span>
       <i
+        aria-hidden="true"
         className="sap-icon--bell"
       />
     </button>

--- a/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
+++ b/src/Counter/__stories__/__snapshots__/Counter.stories.storyshot
@@ -63,48 +63,76 @@ exports[`Storyshots Component API/Counter Default Counter 2`] = `
     className="fddocs-container"
   >
     <button
-      className="fd-button fd-button--transparent sap-icon--bell"
+      className="fd-button fd-button--transparent"
       type="button"
     >
       <span
-        aria-label="Unread count"
-        className="fd-counter fd-counter--notification"
+        className="fd-button__text"
       >
-        5
+        <span
+          aria-label="Unread count"
+          className="fd-counter fd-counter--notification"
+        >
+          5
+        </span>
       </span>
+      <i
+        className="sap-icon--bell"
+      />
     </button>
     <button
-      className="fd-button fd-button--transparent sap-icon--bell"
+      className="fd-button fd-button--transparent"
       type="button"
     >
       <span
-        aria-label="Unread count"
-        className="fd-counter fd-counter--notification"
+        className="fd-button__text"
       >
-        25
+        <span
+          aria-label="Unread count"
+          className="fd-counter fd-counter--notification"
+        >
+          25
+        </span>
       </span>
+      <i
+        className="sap-icon--bell"
+      />
     </button>
     <button
-      className="fd-button fd-button--transparent sap-icon--bell"
+      className="fd-button fd-button--transparent"
       type="button"
     >
       <span
-        aria-label="Unread count"
-        className="fd-counter fd-counter--notification"
+        className="fd-button__text"
       >
-        101
+        <span
+          aria-label="Unread count"
+          className="fd-counter fd-counter--notification"
+        >
+          101
+        </span>
       </span>
+      <i
+        className="sap-icon--bell"
+      />
     </button>
     <button
-      className="fd-button fd-button--transparent sap-icon--bell"
+      className="fd-button fd-button--transparent"
       type="button"
     >
       <span
-        aria-label="Unread count"
-        className="fd-counter fd-counter--notification"
+        className="fd-button__text"
       >
-        999+
+        <span
+          aria-label="Unread count"
+          className="fd-counter fd-counter--notification"
+        >
+          999+
+        </span>
       </span>
+      <i
+        className="sap-icon--bell"
+      />
     </button>
   </div>
 </div>

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -315,10 +315,10 @@ describe('<DatePicker />', () => {
                         type: 'select',
                         label: 'Today'
                     }} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(true);
-            expect(todayButtonWrapper.getDOMNode().innerHTML).toBe('Today');
+            expect(todayButtonWrapper.text()).toBe('Today');
         });
 
         test('doesn\'t render today button when todayAction.type=\'select\' AND valid todayAction.label is specified but date range selection is enabled', () => {
@@ -329,7 +329,7 @@ describe('<DatePicker />', () => {
                         type: 'select',
                         label: 'Today'
                     }} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(false);
         });
@@ -341,7 +341,7 @@ describe('<DatePicker />', () => {
                         type: 'select',
                         label: 'Today'
                     }} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(true);
             todayButtonWrapper.simulate('click');
@@ -358,7 +358,7 @@ describe('<DatePicker />', () => {
                         type: 'select',
                         label: 'Today'
                     }} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             todayButtonWrapper.simulate('click');
             expect(change).toHaveBeenCalledWith(expect.objectContaining({ formattedDate: moment().format('YYYY/MM/DD') }));
@@ -409,7 +409,7 @@ describe('<DatePicker />', () => {
             const datePickerClose = jest.fn();
             const element = mount(<DatePicker dateFormat='YYYY-MM-DD' defaultValue='2020-03-13'
                 onDatePickerClose={datePickerClose} />);
-            element.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            element.find('button.fd-button--transparent').simulate('click');
             element.find('.fd-calendar__text').at(8).simulate('click');
             expect(datePickerClose).toHaveBeenCalledWith(expect.objectContaining({ formattedDate: '2020-03-02' }));
             expect(datePickerClose).toHaveBeenCalledTimes(1);
@@ -468,7 +468,7 @@ describe('<DatePicker />', () => {
             element = element.setProps({
                 dateFormat: 'MM/DD/YYYY'
             });
-            element.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            element.find('button.fd-button--transparent').simulate('click');
             element.find('.fd-calendar__text').at(8).simulate('click');
 
             expect(change).toHaveBeenCalledWith(expect.objectContaining({ formattedDate: '03/02/2020' }));
@@ -521,7 +521,7 @@ describe('<DatePicker />', () => {
             const element = mount(<DatePicker buttonProps={{ 'data-sample': 'Sample' }} />);
 
             expect(
-                element.find('button.fd-button--transparent.sap-icon--appointment-2').getDOMNode().attributes['data-sample'].value
+                element.find('button.fd-button--transparent').getDOMNode().attributes['data-sample'].value
             ).toBe('Sample');
         });
 
@@ -532,7 +532,7 @@ describe('<DatePicker />', () => {
                 }
             };
             wrapper = mount(<DatePicker calendarProps={calendarProps} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             wrapper.find('.fd-calendar__action').at(1).childAt(0).simulate('click');
 
             expect(
@@ -547,7 +547,7 @@ describe('<DatePicker />', () => {
                 }
             };
             wrapper = mount(<DatePicker calendarProps={calendarProps} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
             wrapper.find('.fd-calendar__action').at(2).childAt(0).simulate('click');
 
             expect(
@@ -562,7 +562,7 @@ describe('<DatePicker />', () => {
                 }
             };
             wrapper = mount(<DatePicker calendarProps={calendarProps} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
 
             expect(
                 wrapper.find('.fd-calendar__dates').childAt(0).getDOMNode().attributes['data-sample'].value
@@ -576,7 +576,7 @@ describe('<DatePicker />', () => {
                 }
             };
             wrapper = mount(<DatePicker calendarProps={calendarProps} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
 
             expect(
                 wrapper.find('.fd-calendar__group').at(0).getDOMNode().attributes['data-sample'].value
@@ -590,7 +590,7 @@ describe('<DatePicker />', () => {
                 }
             };
             wrapper = mount(<DatePicker calendarProps={calendarProps} />);
-            wrapper.find('button.fd-button--transparent.sap-icon--appointment-2').simulate('click');
+            wrapper.find('button.fd-button--transparent').simulate('click');
 
             expect(
                 wrapper.find('tbody').getDOMNode().attributes['data-sample'].value

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -619,7 +619,7 @@ describe('<DatePicker />', () => {
                 <DatePicker validationState={{ state: 'error', text: 'Test validation state' }} />
             );
 
-            const datepickerButton = wrapper.find('button.fd-button--transparent.sap-icon--appointment-2');
+            const datepickerButton = wrapper.find('button.fd-button--transparent');
             const datepickerInput = wrapper.find('input[type="text"]');
             act(() => {
                 datepickerButton.simulate('click');

--- a/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
+++ b/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
@@ -40,10 +40,14 @@ exports[`Storyshots Component API/DatePicker Compact 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent fd-button--compact sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -110,10 +114,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -169,10 +177,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -232,10 +244,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -291,10 +307,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -354,10 +374,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="debugz"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -413,10 +437,14 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                     >
                       <button
                         aria-label="debugz"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -470,10 +498,14 @@ exports[`Storyshots Component API/DatePicker Dev 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -525,11 +557,15 @@ exports[`Storyshots Component API/DatePicker Disabled 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 is-disabled fd-input-group__button"
+                className="fd-button fd-button--transparent is-disabled fd-input-group__button"
                 disabled={true}
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -579,10 +615,14 @@ exports[`Storyshots Component API/DatePicker Enabled Range Selection 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -641,10 +681,14 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                   >
                     <button
                       aria-label="Choose date"
-                      className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                      className="fd-button fd-button--transparent fd-input-group__button"
                       onClick={[Function]}
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--appointment-2"
+                      />
+                    </button>
                   </span>
                 </div>
               </div>
@@ -691,10 +735,14 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                   >
                     <button
                       aria-label="Choose date"
-                      className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                      className="fd-button fd-button--transparent fd-input-group__button"
                       onClick={[Function]}
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--appointment-2"
+                      />
+                    </button>
                   </span>
                 </div>
               </div>
@@ -764,10 +812,14 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent fd-button--compact sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -823,10 +875,14 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -897,10 +953,14 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent fd-button--compact sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -956,10 +1016,14 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                     >
                       <button
                         aria-label="Choose date"
-                        className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                        className="fd-button fd-button--transparent fd-input-group__button"
                         onClick={[Function]}
                         type="button"
-                      />
+                      >
+                        <i
+                          className="sap-icon--appointment-2"
+                        />
+                      </button>
                     </span>
                   </div>
                 </div>
@@ -1013,10 +1077,14 @@ exports[`Storyshots Component API/DatePicker Open To Date 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -1066,10 +1134,14 @@ exports[`Storyshots Component API/DatePicker Primary 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -1120,11 +1192,15 @@ exports[`Storyshots Component API/DatePicker ReadOnly 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 is-disabled fd-input-group__button"
+                className="fd-button fd-button--transparent is-disabled fd-input-group__button"
                 disabled={true}
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -1174,10 +1250,14 @@ exports[`Storyshots Component API/DatePicker Special Days 1`] = `
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -1249,10 +1329,14 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                         >
                           <button
                             aria-label="Choose date"
-                            className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--appointment-2"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -1315,10 +1399,14 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                         >
                           <button
                             aria-label="Choose date"
-                            className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--appointment-2"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -1381,10 +1469,14 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                         >
                           <button
                             aria-label="Choose date"
-                            className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--appointment-2"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -1447,10 +1539,14 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                         >
                           <button
                             aria-label="Choose date"
-                            className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--appointment-2"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -1506,10 +1602,14 @@ exports[`Storyshots Component API/DatePicker Weekday Start (Monday Start) 1`] = 
             >
               <button
                 aria-label="Choose date"
-                className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 onClick={[Function]}
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--appointment-2"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -1575,10 +1675,14 @@ exports[`Storyshots Component API/DatePicker With Custom Flip Container 1`] = `
                 >
                   <button
                     aria-label="Choose date"
-                    className="fd-button fd-button--transparent sap-icon--appointment-2 fd-input-group__button"
+                    className="fd-button fd-button--transparent fd-input-group__button"
                     onClick={[Function]}
                     type="button"
-                  />
+                  >
+                    <i
+                      className="sap-icon--appointment-2"
+                    />
+                  </button>
                 </span>
               </div>
             </div>

--- a/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
+++ b/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
@@ -45,6 +45,7 @@ exports[`Storyshots Component API/DatePicker Compact 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -119,6 +120,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -182,6 +184,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -249,6 +252,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -312,6 +316,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -379,6 +384,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -442,6 +448,7 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -503,6 +510,7 @@ exports[`Storyshots Component API/DatePicker Dev 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -563,6 +571,7 @@ exports[`Storyshots Component API/DatePicker Disabled 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -620,6 +629,7 @@ exports[`Storyshots Component API/DatePicker Enabled Range Selection 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -686,6 +696,7 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--appointment-2"
                       />
                     </button>
@@ -740,6 +751,7 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--appointment-2"
                       />
                     </button>
@@ -817,6 +829,7 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -880,6 +893,7 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -958,6 +972,7 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -1021,6 +1036,7 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                         type="button"
                       >
                         <i
+                          aria-hidden="true"
                           className="sap-icon--appointment-2"
                         />
                       </button>
@@ -1082,6 +1098,7 @@ exports[`Storyshots Component API/DatePicker Open To Date 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -1139,6 +1156,7 @@ exports[`Storyshots Component API/DatePicker Primary 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -1198,6 +1216,7 @@ exports[`Storyshots Component API/DatePicker ReadOnly 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -1255,6 +1274,7 @@ exports[`Storyshots Component API/DatePicker Special Days 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -1334,6 +1354,7 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--appointment-2"
                             />
                           </button>
@@ -1404,6 +1425,7 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--appointment-2"
                             />
                           </button>
@@ -1474,6 +1496,7 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--appointment-2"
                             />
                           </button>
@@ -1544,6 +1567,7 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--appointment-2"
                             />
                           </button>
@@ -1607,6 +1631,7 @@ exports[`Storyshots Component API/DatePicker Weekday Start (Monday Start) 1`] = 
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--appointment-2"
                 />
               </button>
@@ -1680,6 +1705,7 @@ exports[`Storyshots Component API/DatePicker With Custom Flip Container 1`] = `
                     type="button"
                   >
                     <i
+                      aria-hidden="true"
                       className="sap-icon--appointment-2"
                     />
                   </button>

--- a/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
+++ b/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
@@ -45,8 +45,9 @@ exports[`Storyshots Component API/DatePicker Compact 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -120,8 +121,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -184,8 +186,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -252,8 +255,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -316,8 +320,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -384,8 +389,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -448,8 +454,9 @@ exports[`Storyshots Component API/DatePicker Date Formats 1`] = `
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -510,8 +517,9 @@ exports[`Storyshots Component API/DatePicker Dev 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -571,8 +579,9 @@ exports[`Storyshots Component API/DatePicker Disabled 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -629,8 +638,9 @@ exports[`Storyshots Component API/DatePicker Enabled Range Selection 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -696,8 +706,9 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--appointment-2"
+                        role="img"
                       />
                     </button>
                   </span>
@@ -751,8 +762,9 @@ exports[`Storyshots Component API/DatePicker Localized DatePicker 1`] = `
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--appointment-2"
+                        role="img"
                       />
                     </button>
                   </span>
@@ -829,8 +841,9 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -893,8 +906,9 @@ exports[`Storyshots Component API/DatePicker Localized Today Footer Button 1`] =
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -972,8 +986,9 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -1036,8 +1051,9 @@ exports[`Storyshots Component API/DatePicker Localized Today Header Button 1`] =
                         type="button"
                       >
                         <i
-                          aria-hidden="true"
+                          aria-hidden={true}
                           className="sap-icon--appointment-2"
+                          role="img"
                         />
                       </button>
                     </span>
@@ -1098,8 +1114,9 @@ exports[`Storyshots Component API/DatePicker Open To Date 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -1156,8 +1173,9 @@ exports[`Storyshots Component API/DatePicker Primary 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -1216,8 +1234,9 @@ exports[`Storyshots Component API/DatePicker ReadOnly 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -1274,8 +1293,9 @@ exports[`Storyshots Component API/DatePicker Special Days 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -1354,8 +1374,9 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--appointment-2"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -1425,8 +1446,9 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--appointment-2"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -1496,8 +1518,9 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--appointment-2"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -1567,8 +1590,9 @@ exports[`Storyshots Component API/DatePicker Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--appointment-2"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -1631,8 +1655,9 @@ exports[`Storyshots Component API/DatePicker Weekday Start (Monday Start) 1`] = 
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--appointment-2"
+                  role="img"
                 />
               </button>
             </span>
@@ -1705,8 +1730,9 @@ exports[`Storyshots Component API/DatePicker With Custom Flip Container 1`] = `
                     type="button"
                   >
                     <i
-                      aria-hidden="true"
+                      aria-hidden={true}
                       className="sap-icon--appointment-2"
+                      role="img"
                     />
                   </button>
                 </span>

--- a/src/Dialog/__stories__/__snapshots__/Dialog.stories.storyshot
+++ b/src/Dialog/__stories__/__snapshots__/Dialog.stories.storyshot
@@ -9,7 +9,11 @@ exports[`Storyshots Component API/Dialog Header 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Show Dialog
+    <span
+      className="fd-button__text"
+    >
+      Show Dialog
+    </span>
   </button>
 </div>
 `;
@@ -23,7 +27,11 @@ exports[`Storyshots Component API/Dialog Primary 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Show Dialog
+    <span
+      className="fd-button__text"
+    >
+      Show Dialog
+    </span>
   </button>
 </div>
 `;
@@ -40,28 +48,44 @@ exports[`Storyshots Component API/Dialog Sizes 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Show Small Dialog
+      <span
+        className="fd-button__text"
+      >
+        Show Small Dialog
+      </span>
     </button>
     <button
       className="fd-button"
       onClick={[Function]}
       type="button"
     >
-      Show Medium Dialog
+      <span
+        className="fd-button__text"
+      >
+        Show Medium Dialog
+      </span>
     </button>
     <button
       className="fd-button"
       onClick={[Function]}
       type="button"
     >
-      Show Large Dialog
+      <span
+        className="fd-button__text"
+      >
+        Show Large Dialog
+      </span>
     </button>
     <button
       className="fd-button"
       onClick={[Function]}
       type="button"
     >
-      Show XL Dialog
+      <span
+        className="fd-button__text"
+      >
+        Show XL Dialog
+      </span>
     </button>
   </div>
 </div>
@@ -76,7 +100,11 @@ exports[`Storyshots Component API/Dialog Subheader 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Show Dialog
+    <span
+      className="fd-button__text"
+    >
+      Show Dialog
+    </span>
   </button>
 </div>
 `;

--- a/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
+++ b/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
@@ -26,8 +26,9 @@ exports[`Storyshots Component API/Forms/FormGroup Primary 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--accept"
+              role="img"
             />
           </button>
         </span>

--- a/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
+++ b/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
@@ -22,9 +22,13 @@ exports[`Storyshots Component API/Forms/FormGroup Primary 1`] = `
           className="fd-input-group__addon fd-input-group__addon--button"
         >
           <button
-            className="fd-button fd-button--transparent sap-icon--accept fd-input-group__button"
+            className="fd-button fd-button--transparent fd-input-group__button"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--accept"
+            />
+          </button>
         </span>
         <input
           className="fd-input fd-input-group__input"

--- a/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
+++ b/src/Forms/__stories__/__snapshots__/FormGroup.stories.storyshot
@@ -26,6 +26,7 @@ exports[`Storyshots Component API/Forms/FormGroup Primary 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--accept"
             />
           </button>

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -8,7 +8,7 @@ import 'fundamental-styles/dist/icon.css';
 and focus, and for fun. Icons can be used adaptively if desired, but at
 this point they are used more as visual elements within other
 components. */
-const Icon = React.forwardRef(({ ariaHidden, ariaLabel, glyph, size, className, isInButton, ...props }, ref) => {
+const Icon = React.forwardRef(({ ariaHidden, ariaLabel, glyph, size, className, ...props }, ref) => {
 
     const iconClasses = classnames(
         {
@@ -22,10 +22,8 @@ const Icon = React.forwardRef(({ ariaHidden, ariaLabel, glyph, size, className, 
         style = { fontSize: ICON_SIZES[size] };
     }
 
-    const Tag = isInButton ? 'i' : 'span';
-
     return (
-        <Tag
+        <i
             {...props}
             aria-hidden={ariaHidden}
             aria-label={ariaLabel}
@@ -55,8 +53,6 @@ Icon.propTypes = {
     },
     /** CSS class(es) to add to the element */
     className: PropTypes.string,
-    /** If the icon is in a button */
-    isInButton: PropTypes.bool,
     /** Size of the component: 's', 'm', 'l', 'xl' */
     size: PropTypes.oneOf(Object.keys(ICON_SIZES))
 };

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -8,7 +8,7 @@ import 'fundamental-styles/dist/icon.css';
 and focus, and for fun. Icons can be used adaptively if desired, but at
 this point they are used more as visual elements within other
 components. */
-const Icon = React.forwardRef(({ glyph, size, className, ...props }, ref) => {
+const Icon = React.forwardRef(({ ariaHidden, ariaLabel, glyph, size, className, isInButton, ...props }, ref) => {
 
     const iconClasses = classnames(
         {
@@ -22,9 +22,13 @@ const Icon = React.forwardRef(({ glyph, size, className, ...props }, ref) => {
         style = { fontSize: ICON_SIZES[size] };
     }
 
+    const Tag = isInButton ? 'i' : 'span';
+
     return (
-        <span
+        <Tag
             {...props}
+            aria-hidden={ariaHidden}
+            aria-label={ariaLabel}
             className={iconClasses}
             ref={ref}
             style={style} />
@@ -36,8 +40,22 @@ Icon.displayName = 'Icon';
 Icon.propTypes = {
     /** The icon to include. See the icon page for the list of icons */
     glyph: PropTypes.string.isRequired,
+    /** The value for the `aria-hidden` attribute. Set to `true` when there is already visible text explaining the icon, or the icon is purely for decoration. */
+    ariaHidden: PropTypes.bool,
+    /** Text to describe the icon. The value is placed in the `aria-label` attribute. */
+
+    ariaLabel: (props) => {
+        if (
+            (!props.ariaHidden && !props.ariaLabel) ||
+            (!props.ariaHidden && typeof props.ariaLabel !== 'string')
+        ) {
+            return new Error('ariaLabel is required if ariaHidden is false and must be a string');
+        }
+    },
     /** CSS class(es) to add to the element */
     className: PropTypes.string,
+    /** If the icon is in a button */
+    isInButton: PropTypes.bool,
     /** Size of the component: 's', 'm', 'l', 'xl' */
     size: PropTypes.oneOf(Object.keys(ICON_SIZES))
 };

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -31,6 +31,7 @@ const Icon = React.forwardRef(({ ariaHidden, ariaLabel, glyph, size, className, 
             aria-label={ariaLabel}
             className={iconClasses}
             ref={ref}
+            role='img'
             style={style} />
     );
 });

--- a/src/Icon/Icon.test.js
+++ b/src/Icon/Icon.test.js
@@ -4,16 +4,16 @@ import React from 'react';
 
 describe('<Icon />', () => {
     const mockOnClick = jest.fn();
-    const defaultIcon = (
-        <Icon
-            className='blue'
-            glyph='cart'
-            onClick={mockOnClick} />
-    );
-    const iconWithSize = <Icon glyph='cart' size='s' />;
+
+    const defaultProps = { ariaHidden: true, glyph: 'cart' };
+    const defaultIcon = <Icon {...defaultProps} />;
+    const clickIcon = <Icon {...defaultProps} onClick={mockOnClick} />;
+    const iconWithSize = <Icon {...defaultProps} size='s' />;
+    const ariaLabelIcon = <Icon ariaLabel='Add to cart' glyph='cart' />;
+    const propSpreadIcon = <Icon {...defaultProps} data-sample='Sample' />;
 
     test('click on icon', () => {
-        let wrapper = mount(defaultIcon);
+        let wrapper = mount(clickIcon);
         wrapper.find('.sap-icon--cart').simulate('click');
         expect(wrapper.prop('onClick')).toBeCalledTimes(1);
 
@@ -22,9 +22,19 @@ describe('<Icon />', () => {
         expect(wrapper.prop('onClick')).toBeUndefined;
     });
 
+    test('passes aria-label prop', () => {
+        const element = mount(ariaLabelIcon);
+        expect(element.getDOMNode().getAttribute('aria-label')).toBe('Add to cart');
+    });
+
+    test('passes the aria-hidden prop', () => {
+        const element = mount(defaultIcon);
+        expect(element.getDOMNode().getAttribute('aria-hidden')).toBe('true');
+    });
+
     describe('Prop spreading', () => {
         test('should allow props to be spread to the Icon component', () => {
-            const element = mount(<Icon data-sample='Sample' glyph='cart' />);
+            const element = mount(propSpreadIcon);
 
             expect(
                 element.getDOMNode().attributes['data-sample'].value
@@ -39,7 +49,7 @@ describe('<Icon />', () => {
                 super(props);
                 ref = React.createRef();
             }
-            render = () => <Icon glyph='cart' ref={ref} />;
+            render = () => <Icon {...defaultProps} ref={ref} />;
         }
         mount(<Test />);
         expect(ref.current.tagName).toEqual('SPAN');

--- a/src/Icon/Icon.test.js
+++ b/src/Icon/Icon.test.js
@@ -18,7 +18,7 @@ describe('<Icon />', () => {
         expect(wrapper.prop('onClick')).toBeCalledTimes(1);
 
         wrapper = mount(iconWithSize);
-        wrapper.find('span.sap-icon--cart').simulate('click');
+        wrapper.find('.sap-icon--cart').simulate('click');
         expect(wrapper.prop('onClick')).toBeUndefined;
     });
 
@@ -52,7 +52,7 @@ describe('<Icon />', () => {
             render = () => <Icon {...defaultProps} ref={ref} />;
         }
         mount(<Test />);
-        expect(ref.current.tagName).toEqual('SPAN');
+        expect(ref.current.tagName).toEqual('I');
         expect(ref.current.className).toEqual('sap-icon--cart');
     });
 });

--- a/src/Icon/__stories__/__snapshots__/Icon.stories.storyshot
+++ b/src/Icon/__stories__/__snapshots__/Icon.stories.storyshot
@@ -12,6 +12,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--accelerated"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -28,6 +29,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--accept"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -44,6 +46,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--accidental-leave"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -60,6 +63,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--account"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -76,6 +80,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--accounting-document-verification"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -92,6 +97,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--action"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -108,6 +114,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--action-settings"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -124,6 +131,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activate"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -140,6 +148,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activities"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -156,6 +165,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activity-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -172,6 +182,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activity-assigned-to-goal"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -188,6 +199,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activity-individual"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -204,6 +216,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--activity-items"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -220,6 +233,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -236,6 +250,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-activity"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -252,6 +267,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-activity-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -268,6 +284,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-contact"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -284,6 +301,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-coursebook"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -300,6 +318,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-document"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -316,6 +335,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-equipment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -332,6 +352,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-favorite"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -348,6 +369,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-filter"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -364,6 +386,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-photo"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -380,6 +403,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-process"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -396,6 +420,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--add-product"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -412,6 +437,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--address-book"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -428,6 +454,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--addresses"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -444,6 +471,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--alert"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -460,6 +488,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--along-stacked-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -476,6 +505,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--alphabetical-order"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -492,6 +522,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--appointment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -508,6 +539,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--appointment-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -524,6 +556,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--approvals"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -540,6 +573,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--area-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -556,6 +590,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arobase"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -572,6 +607,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arrow-bottom"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -588,6 +624,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arrow-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -604,6 +641,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arrow-left"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -620,6 +658,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arrow-right"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -636,6 +675,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--arrow-top"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -652,6 +692,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -668,6 +709,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-audio"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -684,6 +726,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-e-pub"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -700,6 +743,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-html"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -716,6 +760,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-photo"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -732,6 +777,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-text-file"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -748,6 +794,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-video"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -764,6 +811,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--attachment-zip-file"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -780,6 +828,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--back-to-top"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -796,6 +845,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--background"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -812,6 +862,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--badge"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -828,6 +879,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -844,6 +896,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bar-code"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -860,6 +913,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--basket"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -876,6 +930,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--batch-payments"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -892,6 +947,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bbyd-active-sales"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -908,6 +964,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bbyd-dashboard"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -924,6 +981,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bed"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -940,6 +998,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--begin"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -956,6 +1015,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bell"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -972,6 +1032,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--blank-tag"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -988,6 +1049,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--blank-tag-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1004,6 +1066,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bo-strategy-management"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1020,6 +1083,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bold-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1036,6 +1100,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bookmark"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1052,6 +1117,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--border"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1068,6 +1134,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--broken-link"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1084,6 +1151,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bubble-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1100,6 +1168,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--building"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1116,6 +1185,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bullet-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1132,6 +1202,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--burglary"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1148,6 +1219,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--bus-public-transport"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1164,6 +1236,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-by-design"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1180,6 +1253,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-card"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1196,6 +1270,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-objects-experience"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1212,6 +1287,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-objects-explorer"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1228,6 +1304,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-objects-mobile"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1244,6 +1321,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--business-one"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1260,6 +1338,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--calendar"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1276,6 +1355,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--call"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1292,6 +1372,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--camera"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1308,6 +1389,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cancel"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1324,6 +1406,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cancel-maintenance"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1340,6 +1423,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cancel-share"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1356,6 +1440,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--capital-projects"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1372,6 +1457,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--car-rental"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1388,6 +1474,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--card"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1404,6 +1491,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cargo-train"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1420,6 +1508,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1436,6 +1525,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1452,6 +1542,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-3"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1468,6 +1559,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-4"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1484,6 +1576,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-5"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1500,6 +1593,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-approval"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1516,6 +1610,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cart-full"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1532,6 +1627,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cause"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1548,6 +1644,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chain-link"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1564,6 +1661,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chalkboard"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1580,6 +1678,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chart-axis"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1596,6 +1695,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chart-table-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1612,6 +1712,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--Chart-Tree-Map"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1628,6 +1729,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--check-availability"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1644,6 +1746,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--checklist"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1660,6 +1763,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--checklist-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1676,6 +1780,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--checklist-item"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1692,6 +1797,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--checklist-item-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1708,6 +1814,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chevron-phase"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1724,6 +1831,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--chevron-phase-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1740,6 +1848,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--choropleth-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1756,6 +1865,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--circle-task"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1772,6 +1882,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--circle-task-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1788,6 +1899,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--citizen-connect"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1804,6 +1916,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--clear-filter"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1820,6 +1933,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--clinical-order"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1836,6 +1950,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--clinical-tast-tracker"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1852,6 +1967,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--close-command-field"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1868,6 +1984,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cloud"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1884,6 +2001,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--co"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1900,6 +2018,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collaborate"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1916,6 +2035,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collapse"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1932,6 +2052,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collapse-group"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1948,6 +2069,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collections-insight"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1964,6 +2086,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collections-management"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1980,6 +2103,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--collision"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -1996,6 +2120,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--color-fill"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2012,6 +2137,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--column-chart-dual-axis"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2028,6 +2154,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--comment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2044,6 +2171,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--commission-check"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2060,6 +2188,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--company-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2076,6 +2205,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--compare"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2092,6 +2222,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--compare-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2108,6 +2239,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--competitor"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2124,6 +2256,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--complete"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2140,6 +2273,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--connected"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2156,6 +2290,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--contacts"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2172,6 +2307,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--copy"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2188,6 +2324,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--course-book"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2204,6 +2341,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--course-program"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2220,6 +2358,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--create"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2236,6 +2375,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--create-entry-time"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2252,6 +2392,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--create-form"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2268,6 +2409,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--create-leave-request"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2284,6 +2426,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--create-session"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2300,6 +2443,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--credit-card"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2316,6 +2460,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--crm-sales"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2332,6 +2477,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--crm-service-manager"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2348,6 +2494,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--crop"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2364,6 +2511,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--crossed-line-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2380,6 +2528,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--curriculum"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2396,6 +2545,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--cursor"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2412,6 +2562,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2428,6 +2579,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-and-contacts"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2444,6 +2596,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-and-supplier"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2460,6 +2613,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-briefing"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2476,6 +2630,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-financial-fact-sheet"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2492,6 +2647,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-history"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2508,6 +2664,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-order-entry"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2524,6 +2681,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customer-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2540,6 +2698,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--customize"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2556,6 +2715,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--database"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2572,6 +2732,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--date-time"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2588,6 +2749,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--decision"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2604,6 +2766,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--decline"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2620,6 +2783,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--decrease-line-height"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2636,6 +2800,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--delete"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2652,6 +2817,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--detail-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2668,6 +2834,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--developer-settings"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2684,6 +2851,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--dimension"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2700,6 +2868,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--disconnected"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2716,6 +2885,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--discussion"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2732,6 +2902,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--discussion-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2748,6 +2919,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--dishwasher"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2764,6 +2936,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--display"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2780,6 +2953,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--display-more"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2796,6 +2970,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--doc-attachment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2812,6 +2987,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--doctor"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2828,6 +3004,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--document"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2844,6 +3021,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--document-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2860,6 +3038,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--documents"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2876,6 +3055,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--donut-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2892,6 +3072,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2908,6 +3089,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--download"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2924,6 +3106,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--download-from-cloud"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2940,6 +3123,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--draw-rectangle"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2956,6 +3140,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--drill-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2972,6 +3157,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--drill-up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -2988,6 +3174,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--drop-down-list"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3004,6 +3191,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--dropdown"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3020,6 +3208,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--duplicate"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3036,6 +3225,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--e-care"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3052,6 +3242,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--e-learning"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3068,6 +3259,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--eam-work-order"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3084,6 +3276,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--edit"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3100,6 +3293,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--edit-outside"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3116,6 +3310,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--education"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3132,6 +3327,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--electrocardiogram"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3148,6 +3344,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--electronic-medical-record"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3164,6 +3361,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--email"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3180,6 +3378,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--email-read"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3196,6 +3395,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--employee"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3212,6 +3412,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--employee-approvals"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3228,6 +3429,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--employee-lookup"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3244,6 +3446,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--employee-pane"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3260,6 +3463,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--employee-rejections"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3276,6 +3480,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--end-user-experience-monitoring"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3292,6 +3497,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--endoscopy"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3308,6 +3514,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--energy-saving-lightbulb"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3324,6 +3531,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--enter-more"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3340,6 +3548,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--eraser"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3356,6 +3565,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--error"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3372,6 +3582,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--example"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3388,6 +3599,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--excel-attachment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3404,6 +3616,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--exitfullscreen"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3420,6 +3633,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--expand"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3436,6 +3650,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--expand-group"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3452,6 +3667,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--expense-report"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3468,6 +3684,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--explorer"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3484,6 +3701,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--factory"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3500,6 +3718,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--fallback"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3516,6 +3735,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--family-care"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3532,6 +3752,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--family-protection"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3548,6 +3769,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--favorite"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3564,6 +3786,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--favorite-list"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3580,6 +3803,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--fax-machine"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3596,6 +3820,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--feed"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3612,6 +3837,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--feeder-arrow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3628,6 +3854,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--filter"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3644,6 +3871,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--filter-analytics"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3660,6 +3888,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--filter-facets"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3676,6 +3905,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--filter-fields"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3692,6 +3922,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--flag"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3708,6 +3939,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--flight"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3724,6 +3956,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--fob-watch"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3740,6 +3973,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--folder"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3756,6 +3990,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--folder-blank"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3772,6 +4007,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--folder-full"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3788,6 +4024,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--form"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3804,6 +4041,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--forward"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3820,6 +4058,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--fridge"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3836,6 +4075,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--full-screen"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3852,6 +4092,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--full-stacked-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3868,6 +4109,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--full-stacked-column-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3884,6 +4126,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--functional-location"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3900,6 +4143,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--future"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3916,6 +4160,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--gantt-bars"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3932,6 +4177,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--general-leave-request"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3948,6 +4194,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--generate-shortcut"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3964,6 +4211,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--geographic-bubble-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3980,6 +4228,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--globe"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -3996,6 +4245,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--goal"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4012,6 +4262,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--goalseek"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4028,6 +4279,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--grid"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4044,6 +4296,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--group"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4060,6 +4313,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--group-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4076,6 +4330,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--header"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4092,6 +4347,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--heading-1"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4108,6 +4364,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--heading-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4124,6 +4381,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--heading-3"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4140,6 +4398,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--headset"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4156,6 +4415,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--heating-cooling"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4172,6 +4432,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--heatmap-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4188,6 +4449,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--hello-world"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4204,6 +4466,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--hide"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4220,6 +4483,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--hint"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4236,6 +4500,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--history"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4252,6 +4517,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--home"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4268,6 +4534,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--home-share"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4284,6 +4551,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-bar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4300,6 +4568,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-bar-chart-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4316,6 +4585,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-bullet-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4332,6 +4602,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-grip"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4348,6 +4619,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-stacked-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4364,6 +4636,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--horizontal-waterfall-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4380,6 +4653,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--hr-approval"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4396,6 +4670,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--idea-wall"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4412,6 +4687,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--image-viewer"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4428,6 +4704,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--inbox"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4444,6 +4721,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--incident"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4460,6 +4738,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--incoming-call"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4476,6 +4755,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--increase-line-height"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4492,6 +4772,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--indent"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4508,6 +4789,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--initiative"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4524,6 +4806,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--inspect"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4540,6 +4823,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--inspect-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4556,6 +4840,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--inspection"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4572,6 +4857,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--instance"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4588,6 +4874,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--insurance-car"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4604,6 +4891,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--insurance-house"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4620,6 +4908,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--insurance-life"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4636,6 +4925,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--internet-browser"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4652,6 +4942,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--inventory"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4668,6 +4959,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--ipad"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4684,6 +4976,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--ipad-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4700,6 +4993,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--iphone"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4716,6 +5010,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--iphone-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4732,6 +5027,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--it-host"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4748,6 +5044,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--it-instance"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4764,6 +5061,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--it-system"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4780,6 +5078,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--italic-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4796,6 +5095,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--jam"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4812,6 +5112,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--journey-arrive"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4828,6 +5129,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--journey-change"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4844,6 +5146,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--journey-depart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4860,6 +5163,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--key"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4876,6 +5180,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--key-user-settings"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4892,6 +5197,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--kpi-corporate-performance"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4908,6 +5214,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--kpi-managing-my-area"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4924,6 +5231,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--lab"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4940,6 +5248,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--laptop"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4956,6 +5265,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--lateness"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4972,6 +5282,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--lead"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -4988,6 +5299,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--lead-outdated"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5004,6 +5316,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--leads"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5020,6 +5333,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--learning-assistant"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5036,6 +5350,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--legend"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5052,6 +5367,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--less"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5068,6 +5384,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--letter"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5084,6 +5401,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--lightbulb"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5100,6 +5418,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--line-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5116,6 +5435,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--line-chart-dual-axis"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5132,6 +5452,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--line-chart-time-axis"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5148,6 +5469,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--line-charts"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5164,6 +5486,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--list"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5180,6 +5503,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--loan"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5196,6 +5520,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--locate-me"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5212,6 +5537,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--locked"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5228,6 +5554,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--log"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5244,6 +5571,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--machine"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5260,6 +5588,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--manager"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5276,6 +5605,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--manager-insight"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5292,6 +5622,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--map"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5308,6 +5639,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--map-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5324,6 +5656,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--map-3"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5340,6 +5673,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--marketing-campaign"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5356,6 +5690,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--master-task-triangle"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5372,6 +5707,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--master-task-triangle-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5388,6 +5724,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--meal"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5404,6 +5741,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--measure"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5420,6 +5758,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--measurement-document"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5436,6 +5775,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--measuring-point"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5452,6 +5792,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--media-forward"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5468,6 +5809,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--media-pause"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5484,6 +5826,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--media-play"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5500,6 +5843,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--media-reverse"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5516,6 +5860,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--media-rewind"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5532,6 +5877,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--meeting-room"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5548,6 +5894,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--menu"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5564,6 +5911,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--menu2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5580,6 +5928,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--message-error"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5596,6 +5945,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--message-information"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5612,6 +5962,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--message-popup"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5628,6 +5979,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--message-success"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5644,6 +5996,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--message-warning"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5660,6 +6013,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--microphone"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5676,6 +6030,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--mileage"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5692,6 +6047,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--minimize"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5708,6 +6064,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--mirrored-task-circle"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5724,6 +6081,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--mirrored-task-circle-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5740,6 +6098,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--money-bills"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5756,6 +6115,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--monitor-payments"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5772,6 +6132,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--move"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5788,6 +6149,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--mri-scan"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5804,6 +6166,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiple-bar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5820,6 +6183,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiple-line-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5836,6 +6200,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiple-pie-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5852,6 +6217,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiple-radar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5868,6 +6234,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiselect"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5884,6 +6251,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiselect-all"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5900,6 +6268,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--multiselect-none"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5916,6 +6285,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--my-sales-order"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5932,6 +6302,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--my-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5948,6 +6319,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--nav-back"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5964,6 +6336,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--navigation-down-arrow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5980,6 +6353,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--navigation-left-arrow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -5996,6 +6370,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--navigation-right-arrow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6012,6 +6387,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--navigation-up-arrow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6028,6 +6404,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--negative"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6044,6 +6421,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--Netweaver-business-client"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6060,6 +6438,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--newspaper"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6076,6 +6455,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--notes"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6092,6 +6472,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--notification-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6108,6 +6489,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--number-sign"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6124,6 +6506,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--numbered-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6140,6 +6523,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--nurse"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6156,6 +6540,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--nutrition-activity"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6172,6 +6557,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--official-service"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6188,6 +6574,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--offsite-work"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6204,6 +6591,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--open-command-field"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6220,6 +6608,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--open-folder"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6236,6 +6625,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--opportunities"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6252,6 +6642,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--opportunity"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6268,6 +6659,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--order-status"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6284,6 +6676,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--org-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6300,6 +6693,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--outbox"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6316,6 +6710,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--outdent"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6332,6 +6727,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--outgoing-call"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6348,6 +6744,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--overflow"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6364,6 +6761,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--overlay"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6380,6 +6778,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--overview-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6396,6 +6795,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--paging"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6412,6 +6812,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--paid-leave"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6428,6 +6829,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--palette"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6444,6 +6846,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--paper-plane"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6460,6 +6863,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--passenger-train"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6476,6 +6880,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--past"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6492,6 +6897,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--paste"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6508,6 +6914,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pause"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6524,6 +6931,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--payment-approval"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6540,6 +6948,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pdf-attachment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6556,6 +6965,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pdf-reader"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6572,6 +6982,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pending"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6588,6 +6999,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--per-diem"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6604,6 +7016,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--performance"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6620,6 +7033,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--permission"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6636,6 +7050,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--person-placeholder"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6652,6 +7067,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--personnel-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6668,6 +7084,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pharmacy"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6684,6 +7101,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--phone"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6700,6 +7118,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--photo-voltaic"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6716,6 +7135,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--physical-activity"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6732,6 +7152,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--picture"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6748,6 +7169,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pie-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6764,6 +7186,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pipeline-analysis"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6780,6 +7203,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--play"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6796,6 +7220,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pool"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6812,6 +7237,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--popup-window"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6828,6 +7254,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--positive"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6844,6 +7271,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--post"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6860,6 +7288,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--ppt-attachment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6876,6 +7305,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--present"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6892,6 +7322,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--print"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6908,6 +7339,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--private"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6924,6 +7356,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--process"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6940,6 +7373,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--product"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6956,6 +7390,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--program-triangles"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6972,6 +7407,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--program-triangles-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -6988,6 +7424,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--project-definition-triangle"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7004,6 +7441,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--project-definition-triangle-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7020,6 +7458,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--projector"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7036,6 +7475,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--provision"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7052,6 +7492,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pull-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7068,6 +7509,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pushpin-off"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7084,6 +7526,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--pushpin-on"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7100,6 +7543,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--puzzle"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7116,6 +7560,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--quality-issue"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7132,6 +7577,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--question-mark"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7148,6 +7594,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--radar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7164,6 +7611,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--receipt"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7180,6 +7628,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--record"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7196,6 +7645,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--redo"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7212,6 +7662,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--refresh"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7228,6 +7679,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--repost"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7244,6 +7696,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--request"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7260,6 +7713,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--reset"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7276,6 +7730,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--resize"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7292,6 +7747,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--resize-corner"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7308,6 +7764,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--resize-horizontal"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7324,6 +7781,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--resize-vertical"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7340,6 +7798,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--response"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7356,6 +7815,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--restart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7372,6 +7832,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--retail-store"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7388,6 +7849,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--retail-store-manager"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7404,6 +7866,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--rhombus-milestone"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7420,6 +7883,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--rhombus-milestone-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7436,6 +7900,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--role"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7452,6 +7917,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sales-document"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7468,6 +7934,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sales-notification"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7484,6 +7951,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sales-order"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7500,6 +7968,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sales-order-item"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7516,6 +7985,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sales-quote"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7532,6 +8002,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sap-box"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7548,6 +8019,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sap-logo-shape"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7564,6 +8036,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sap-ui5"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7580,6 +8053,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--save"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7596,6 +8070,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--scatter-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7612,6 +8087,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--scissors"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7628,6 +8104,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--screen-split-one"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7644,6 +8121,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--screen-split-three"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7660,6 +8138,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--screen-split-two"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7676,6 +8155,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--search"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7692,6 +8172,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--settings"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7708,6 +8189,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--share"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7724,6 +8206,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--share-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7740,6 +8223,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--shelf"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7756,6 +8240,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--shield"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7772,6 +8257,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--shipping-status"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7788,6 +8274,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--shortcut"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7804,6 +8291,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--show"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7820,6 +8308,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--signature"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7836,6 +8325,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--simple-payment"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7852,6 +8342,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--simulate"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7868,6 +8359,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--slim-arrow-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7884,6 +8376,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--slim-arrow-left"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7900,6 +8393,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--slim-arrow-right"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7916,6 +8410,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--slim-arrow-up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7932,6 +8427,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--soccor"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7948,6 +8444,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sonography"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7964,6 +8461,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sort"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7980,6 +8478,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sort-ascending"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -7996,6 +8495,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sort-descending"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8012,6 +8512,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sorting-ranking"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8028,6 +8529,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sound"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8044,6 +8546,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sound-loud"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8060,6 +8563,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sound-off"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8076,6 +8580,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--source-code"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8092,6 +8597,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--status-critical"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8108,6 +8614,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--status-inactive"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8124,6 +8631,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--status-negative"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8140,6 +8648,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--status-positive"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8156,6 +8665,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--step"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8172,6 +8682,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--stethoscope"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8188,6 +8699,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--stop"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8204,6 +8716,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--study-leave"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8220,6 +8733,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--subway-train"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8236,6 +8750,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--suitcase"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8252,6 +8767,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--supplier"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8268,6 +8784,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--survey"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8284,6 +8801,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--switch-classes"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8300,6 +8818,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--switch-views"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8316,6 +8835,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--synchronize"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8332,6 +8852,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--syntax"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8348,6 +8869,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--syringe"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8364,6 +8886,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-add"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8380,6 +8903,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-back"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8396,6 +8920,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-back-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8412,6 +8937,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-cancel"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8428,6 +8954,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-cancel-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8444,6 +8971,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-enter"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8460,6 +8988,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-enter-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8476,6 +9005,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-find"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8492,6 +9022,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-find-next"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8508,6 +9039,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-first-page"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8524,6 +9056,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-help"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8540,6 +9073,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-help-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8556,6 +9090,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-last-page"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8572,6 +9107,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-minus"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8588,6 +9124,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-monitor"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8604,6 +9141,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-next-page"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8620,6 +9158,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--sys-prev-page"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8636,6 +9175,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--system-exit"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8652,6 +9192,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--system-exit-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8668,6 +9209,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--table-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8684,6 +9226,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--table-view"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8700,6 +9243,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--tag"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8716,6 +9260,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--tag-cloud-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8732,6 +9277,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--tags"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8748,6 +9294,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--target-group"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8764,6 +9311,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--task"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8780,6 +9328,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--taxi"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8796,6 +9345,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--technical-object"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8812,6 +9362,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--temperature"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8828,6 +9379,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--text-align-center"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8844,6 +9396,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--text-align-justified"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8860,6 +9413,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--text-align-left"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8876,6 +9430,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--text-align-right"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8892,6 +9447,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--text-formatting"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8908,6 +9464,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--theater"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8924,6 +9481,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--thing-type"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8940,6 +9498,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--thumb-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8956,6 +9515,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--thumb-up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8972,6 +9532,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--time-account"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -8988,6 +9549,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--time-entry-request"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9004,6 +9566,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--time-overtime"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9020,6 +9583,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--timesheet"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9036,6 +9600,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--to-be-reviewed"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9052,6 +9617,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--toaster-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9068,6 +9634,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--toaster-top"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9084,6 +9651,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--toaster-up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9100,6 +9668,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--tools-opportunity"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9116,6 +9685,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--travel-expense"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9132,6 +9702,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--travel-expense-report"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9148,6 +9719,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--travel-itinerary"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9164,6 +9736,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--travel-request"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9180,6 +9753,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--tree"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9196,6 +9770,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--trend-down"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9212,6 +9787,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--trend-up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9228,6 +9804,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--trip-report"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9244,6 +9821,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--ui-notifications"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9260,6 +9838,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--umbrella"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9276,6 +9855,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--underline-text"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9292,6 +9872,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--undo"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9308,6 +9889,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--unfavorite"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9324,6 +9906,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--unlocked"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9340,6 +9923,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--unpaid-leave"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9356,6 +9940,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--unwired"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9372,6 +9957,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--up"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9388,6 +9974,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--upload"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9404,6 +9991,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--upload-to-cloud"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9420,6 +10008,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--upstacked-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9436,6 +10025,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--user-edit"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9452,6 +10042,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--user-settings"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9468,6 +10059,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--value-help"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9484,6 +10076,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vds-file"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9500,6 +10093,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vehicle-repair"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9516,6 +10110,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-bar-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9532,6 +10127,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-bar-chart-2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9548,6 +10144,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-bullet-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9564,6 +10161,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-grip"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9580,6 +10178,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-stacked-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9596,6 +10195,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--vertical-waterfall-chart"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9612,6 +10212,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--video"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9628,6 +10229,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--visits"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9644,6 +10246,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--waiver"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9660,6 +10263,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--wallet"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9676,6 +10280,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--warning"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9692,6 +10297,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--warning2"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9708,6 +10314,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--washing-machine"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9724,6 +10331,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--weather-proofing"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9740,6 +10348,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--web-cam"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9756,6 +10365,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--widgets"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9772,6 +10382,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--windows-doors"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9788,6 +10399,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--work-history"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9804,6 +10416,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--workflow-tasks"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9820,6 +10433,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--world"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9836,6 +10450,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--wounds-doc"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9852,6 +10467,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--wrench"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9868,6 +10484,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--write-new"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9884,6 +10501,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--write-new-document"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9900,6 +10518,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--x-ray"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9916,6 +10535,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--zoom-in"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9932,6 +10552,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     >
       <span
         className="sap-icon--zoom-out"
+        role="img"
         style={
           Object {
             "fontSize": "1.5rem",
@@ -9953,6 +10574,7 @@ exports[`Storyshots Component API/Icon Primary 1`] = `
 >
   <span
     className="sap-icon--cart"
+    role="img"
   />
 </div>
 `;
@@ -9966,6 +10588,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
   >
     <span
       className="sap-icon--cart"
+      role="img"
       style={
         Object {
           "fontSize": "0.75rem",
@@ -9974,9 +10597,11 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
     />
     <span
       className="sap-icon--cart"
+      role="img"
     />
     <span
       className="sap-icon--cart"
+      role="img"
       style={
         Object {
           "fontSize": "1rem",
@@ -9985,6 +10610,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
     />
     <span
       className="sap-icon--cart"
+      role="img"
       style={
         Object {
           "fontSize": "1.25rem",
@@ -9993,6 +10619,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
     />
     <span
       className="sap-icon--cart"
+      role="img"
       style={
         Object {
           "fontSize": "1.5rem",

--- a/src/Icon/__stories__/__snapshots__/Icon.stories.storyshot
+++ b/src/Icon/__stories__/__snapshots__/Icon.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--accelerated"
         role="img"
         style={
@@ -27,7 +27,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--accept"
         role="img"
         style={
@@ -44,7 +44,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--accidental-leave"
         role="img"
         style={
@@ -61,7 +61,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--account"
         role="img"
         style={
@@ -78,7 +78,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--accounting-document-verification"
         role="img"
         style={
@@ -95,7 +95,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--action"
         role="img"
         style={
@@ -112,7 +112,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--action-settings"
         role="img"
         style={
@@ -129,7 +129,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activate"
         role="img"
         style={
@@ -146,7 +146,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activities"
         role="img"
         style={
@@ -163,7 +163,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activity-2"
         role="img"
         style={
@@ -180,7 +180,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activity-assigned-to-goal"
         role="img"
         style={
@@ -197,7 +197,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activity-individual"
         role="img"
         style={
@@ -214,7 +214,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--activity-items"
         role="img"
         style={
@@ -231,7 +231,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add"
         role="img"
         style={
@@ -248,7 +248,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-activity"
         role="img"
         style={
@@ -265,7 +265,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-activity-2"
         role="img"
         style={
@@ -282,7 +282,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-contact"
         role="img"
         style={
@@ -299,7 +299,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-coursebook"
         role="img"
         style={
@@ -316,7 +316,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-document"
         role="img"
         style={
@@ -333,7 +333,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-equipment"
         role="img"
         style={
@@ -350,7 +350,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-favorite"
         role="img"
         style={
@@ -367,7 +367,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-filter"
         role="img"
         style={
@@ -384,7 +384,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-photo"
         role="img"
         style={
@@ -401,7 +401,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-process"
         role="img"
         style={
@@ -418,7 +418,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--add-product"
         role="img"
         style={
@@ -435,7 +435,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--address-book"
         role="img"
         style={
@@ -452,7 +452,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--addresses"
         role="img"
         style={
@@ -469,7 +469,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--alert"
         role="img"
         style={
@@ -486,7 +486,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--along-stacked-chart"
         role="img"
         style={
@@ -503,7 +503,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--alphabetical-order"
         role="img"
         style={
@@ -520,7 +520,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--appointment"
         role="img"
         style={
@@ -537,7 +537,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--appointment-2"
         role="img"
         style={
@@ -554,7 +554,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--approvals"
         role="img"
         style={
@@ -571,7 +571,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--area-chart"
         role="img"
         style={
@@ -588,7 +588,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arobase"
         role="img"
         style={
@@ -605,7 +605,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arrow-bottom"
         role="img"
         style={
@@ -622,7 +622,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arrow-down"
         role="img"
         style={
@@ -639,7 +639,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arrow-left"
         role="img"
         style={
@@ -656,7 +656,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arrow-right"
         role="img"
         style={
@@ -673,7 +673,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--arrow-top"
         role="img"
         style={
@@ -690,7 +690,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment"
         role="img"
         style={
@@ -707,7 +707,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-audio"
         role="img"
         style={
@@ -724,7 +724,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-e-pub"
         role="img"
         style={
@@ -741,7 +741,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-html"
         role="img"
         style={
@@ -758,7 +758,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-photo"
         role="img"
         style={
@@ -775,7 +775,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-text-file"
         role="img"
         style={
@@ -792,7 +792,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-video"
         role="img"
         style={
@@ -809,7 +809,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--attachment-zip-file"
         role="img"
         style={
@@ -826,7 +826,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--back-to-top"
         role="img"
         style={
@@ -843,7 +843,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--background"
         role="img"
         style={
@@ -860,7 +860,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--badge"
         role="img"
         style={
@@ -877,7 +877,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bar-chart"
         role="img"
         style={
@@ -894,7 +894,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bar-code"
         role="img"
         style={
@@ -911,7 +911,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--basket"
         role="img"
         style={
@@ -928,7 +928,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--batch-payments"
         role="img"
         style={
@@ -945,7 +945,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bbyd-active-sales"
         role="img"
         style={
@@ -962,7 +962,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bbyd-dashboard"
         role="img"
         style={
@@ -979,7 +979,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bed"
         role="img"
         style={
@@ -996,7 +996,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--begin"
         role="img"
         style={
@@ -1013,7 +1013,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bell"
         role="img"
         style={
@@ -1030,7 +1030,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--blank-tag"
         role="img"
         style={
@@ -1047,7 +1047,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--blank-tag-2"
         role="img"
         style={
@@ -1064,7 +1064,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bo-strategy-management"
         role="img"
         style={
@@ -1081,7 +1081,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bold-text"
         role="img"
         style={
@@ -1098,7 +1098,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bookmark"
         role="img"
         style={
@@ -1115,7 +1115,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--border"
         role="img"
         style={
@@ -1132,7 +1132,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--broken-link"
         role="img"
         style={
@@ -1149,7 +1149,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bubble-chart"
         role="img"
         style={
@@ -1166,7 +1166,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--building"
         role="img"
         style={
@@ -1183,7 +1183,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bullet-text"
         role="img"
         style={
@@ -1200,7 +1200,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--burglary"
         role="img"
         style={
@@ -1217,7 +1217,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--bus-public-transport"
         role="img"
         style={
@@ -1234,7 +1234,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-by-design"
         role="img"
         style={
@@ -1251,7 +1251,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-card"
         role="img"
         style={
@@ -1268,7 +1268,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-objects-experience"
         role="img"
         style={
@@ -1285,7 +1285,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-objects-explorer"
         role="img"
         style={
@@ -1302,7 +1302,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-objects-mobile"
         role="img"
         style={
@@ -1319,7 +1319,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--business-one"
         role="img"
         style={
@@ -1336,7 +1336,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--calendar"
         role="img"
         style={
@@ -1353,7 +1353,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--call"
         role="img"
         style={
@@ -1370,7 +1370,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--camera"
         role="img"
         style={
@@ -1387,7 +1387,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cancel"
         role="img"
         style={
@@ -1404,7 +1404,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cancel-maintenance"
         role="img"
         style={
@@ -1421,7 +1421,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cancel-share"
         role="img"
         style={
@@ -1438,7 +1438,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--capital-projects"
         role="img"
         style={
@@ -1455,7 +1455,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--car-rental"
         role="img"
         style={
@@ -1472,7 +1472,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--card"
         role="img"
         style={
@@ -1489,7 +1489,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cargo-train"
         role="img"
         style={
@@ -1506,7 +1506,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart"
         role="img"
         style={
@@ -1523,7 +1523,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-2"
         role="img"
         style={
@@ -1540,7 +1540,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-3"
         role="img"
         style={
@@ -1557,7 +1557,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-4"
         role="img"
         style={
@@ -1574,7 +1574,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-5"
         role="img"
         style={
@@ -1591,7 +1591,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-approval"
         role="img"
         style={
@@ -1608,7 +1608,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cart-full"
         role="img"
         style={
@@ -1625,7 +1625,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cause"
         role="img"
         style={
@@ -1642,7 +1642,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chain-link"
         role="img"
         style={
@@ -1659,7 +1659,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chalkboard"
         role="img"
         style={
@@ -1676,7 +1676,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chart-axis"
         role="img"
         style={
@@ -1693,7 +1693,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chart-table-view"
         role="img"
         style={
@@ -1710,7 +1710,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--Chart-Tree-Map"
         role="img"
         style={
@@ -1727,7 +1727,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--check-availability"
         role="img"
         style={
@@ -1744,7 +1744,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--checklist"
         role="img"
         style={
@@ -1761,7 +1761,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--checklist-2"
         role="img"
         style={
@@ -1778,7 +1778,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--checklist-item"
         role="img"
         style={
@@ -1795,7 +1795,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--checklist-item-2"
         role="img"
         style={
@@ -1812,7 +1812,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chevron-phase"
         role="img"
         style={
@@ -1829,7 +1829,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--chevron-phase-2"
         role="img"
         style={
@@ -1846,7 +1846,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--choropleth-chart"
         role="img"
         style={
@@ -1863,7 +1863,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--circle-task"
         role="img"
         style={
@@ -1880,7 +1880,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--circle-task-2"
         role="img"
         style={
@@ -1897,7 +1897,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--citizen-connect"
         role="img"
         style={
@@ -1914,7 +1914,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--clear-filter"
         role="img"
         style={
@@ -1931,7 +1931,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--clinical-order"
         role="img"
         style={
@@ -1948,7 +1948,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--clinical-tast-tracker"
         role="img"
         style={
@@ -1965,7 +1965,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--close-command-field"
         role="img"
         style={
@@ -1982,7 +1982,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cloud"
         role="img"
         style={
@@ -1999,7 +1999,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--co"
         role="img"
         style={
@@ -2016,7 +2016,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collaborate"
         role="img"
         style={
@@ -2033,7 +2033,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collapse"
         role="img"
         style={
@@ -2050,7 +2050,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collapse-group"
         role="img"
         style={
@@ -2067,7 +2067,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collections-insight"
         role="img"
         style={
@@ -2084,7 +2084,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collections-management"
         role="img"
         style={
@@ -2101,7 +2101,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--collision"
         role="img"
         style={
@@ -2118,7 +2118,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--color-fill"
         role="img"
         style={
@@ -2135,7 +2135,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--column-chart-dual-axis"
         role="img"
         style={
@@ -2152,7 +2152,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--comment"
         role="img"
         style={
@@ -2169,7 +2169,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--commission-check"
         role="img"
         style={
@@ -2186,7 +2186,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--company-view"
         role="img"
         style={
@@ -2203,7 +2203,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--compare"
         role="img"
         style={
@@ -2220,7 +2220,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--compare-2"
         role="img"
         style={
@@ -2237,7 +2237,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--competitor"
         role="img"
         style={
@@ -2254,7 +2254,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--complete"
         role="img"
         style={
@@ -2271,7 +2271,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--connected"
         role="img"
         style={
@@ -2288,7 +2288,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--contacts"
         role="img"
         style={
@@ -2305,7 +2305,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--copy"
         role="img"
         style={
@@ -2322,7 +2322,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--course-book"
         role="img"
         style={
@@ -2339,7 +2339,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--course-program"
         role="img"
         style={
@@ -2356,7 +2356,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--create"
         role="img"
         style={
@@ -2373,7 +2373,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--create-entry-time"
         role="img"
         style={
@@ -2390,7 +2390,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--create-form"
         role="img"
         style={
@@ -2407,7 +2407,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--create-leave-request"
         role="img"
         style={
@@ -2424,7 +2424,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--create-session"
         role="img"
         style={
@@ -2441,7 +2441,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--credit-card"
         role="img"
         style={
@@ -2458,7 +2458,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--crm-sales"
         role="img"
         style={
@@ -2475,7 +2475,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--crm-service-manager"
         role="img"
         style={
@@ -2492,7 +2492,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--crop"
         role="img"
         style={
@@ -2509,7 +2509,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--crossed-line-chart"
         role="img"
         style={
@@ -2526,7 +2526,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--curriculum"
         role="img"
         style={
@@ -2543,7 +2543,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--cursor"
         role="img"
         style={
@@ -2560,7 +2560,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer"
         role="img"
         style={
@@ -2577,7 +2577,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-and-contacts"
         role="img"
         style={
@@ -2594,7 +2594,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-and-supplier"
         role="img"
         style={
@@ -2611,7 +2611,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-briefing"
         role="img"
         style={
@@ -2628,7 +2628,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-financial-fact-sheet"
         role="img"
         style={
@@ -2645,7 +2645,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-history"
         role="img"
         style={
@@ -2662,7 +2662,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-order-entry"
         role="img"
         style={
@@ -2679,7 +2679,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customer-view"
         role="img"
         style={
@@ -2696,7 +2696,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--customize"
         role="img"
         style={
@@ -2713,7 +2713,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--database"
         role="img"
         style={
@@ -2730,7 +2730,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--date-time"
         role="img"
         style={
@@ -2747,7 +2747,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--decision"
         role="img"
         style={
@@ -2764,7 +2764,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--decline"
         role="img"
         style={
@@ -2781,7 +2781,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--decrease-line-height"
         role="img"
         style={
@@ -2798,7 +2798,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--delete"
         role="img"
         style={
@@ -2815,7 +2815,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--detail-view"
         role="img"
         style={
@@ -2832,7 +2832,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--developer-settings"
         role="img"
         style={
@@ -2849,7 +2849,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--dimension"
         role="img"
         style={
@@ -2866,7 +2866,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--disconnected"
         role="img"
         style={
@@ -2883,7 +2883,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--discussion"
         role="img"
         style={
@@ -2900,7 +2900,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--discussion-2"
         role="img"
         style={
@@ -2917,7 +2917,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--dishwasher"
         role="img"
         style={
@@ -2934,7 +2934,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--display"
         role="img"
         style={
@@ -2951,7 +2951,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--display-more"
         role="img"
         style={
@@ -2968,7 +2968,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--doc-attachment"
         role="img"
         style={
@@ -2985,7 +2985,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--doctor"
         role="img"
         style={
@@ -3002,7 +3002,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--document"
         role="img"
         style={
@@ -3019,7 +3019,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--document-text"
         role="img"
         style={
@@ -3036,7 +3036,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--documents"
         role="img"
         style={
@@ -3053,7 +3053,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--donut-chart"
         role="img"
         style={
@@ -3070,7 +3070,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--down"
         role="img"
         style={
@@ -3087,7 +3087,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--download"
         role="img"
         style={
@@ -3104,7 +3104,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--download-from-cloud"
         role="img"
         style={
@@ -3121,7 +3121,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--draw-rectangle"
         role="img"
         style={
@@ -3138,7 +3138,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--drill-down"
         role="img"
         style={
@@ -3155,7 +3155,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--drill-up"
         role="img"
         style={
@@ -3172,7 +3172,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--drop-down-list"
         role="img"
         style={
@@ -3189,7 +3189,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--dropdown"
         role="img"
         style={
@@ -3206,7 +3206,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--duplicate"
         role="img"
         style={
@@ -3223,7 +3223,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--e-care"
         role="img"
         style={
@@ -3240,7 +3240,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--e-learning"
         role="img"
         style={
@@ -3257,7 +3257,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--eam-work-order"
         role="img"
         style={
@@ -3274,7 +3274,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--edit"
         role="img"
         style={
@@ -3291,7 +3291,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--edit-outside"
         role="img"
         style={
@@ -3308,7 +3308,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--education"
         role="img"
         style={
@@ -3325,7 +3325,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--electrocardiogram"
         role="img"
         style={
@@ -3342,7 +3342,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--electronic-medical-record"
         role="img"
         style={
@@ -3359,7 +3359,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--email"
         role="img"
         style={
@@ -3376,7 +3376,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--email-read"
         role="img"
         style={
@@ -3393,7 +3393,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--employee"
         role="img"
         style={
@@ -3410,7 +3410,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--employee-approvals"
         role="img"
         style={
@@ -3427,7 +3427,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--employee-lookup"
         role="img"
         style={
@@ -3444,7 +3444,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--employee-pane"
         role="img"
         style={
@@ -3461,7 +3461,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--employee-rejections"
         role="img"
         style={
@@ -3478,7 +3478,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--end-user-experience-monitoring"
         role="img"
         style={
@@ -3495,7 +3495,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--endoscopy"
         role="img"
         style={
@@ -3512,7 +3512,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--energy-saving-lightbulb"
         role="img"
         style={
@@ -3529,7 +3529,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--enter-more"
         role="img"
         style={
@@ -3546,7 +3546,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--eraser"
         role="img"
         style={
@@ -3563,7 +3563,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--error"
         role="img"
         style={
@@ -3580,7 +3580,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--example"
         role="img"
         style={
@@ -3597,7 +3597,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--excel-attachment"
         role="img"
         style={
@@ -3614,7 +3614,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--exitfullscreen"
         role="img"
         style={
@@ -3631,7 +3631,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--expand"
         role="img"
         style={
@@ -3648,7 +3648,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--expand-group"
         role="img"
         style={
@@ -3665,7 +3665,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--expense-report"
         role="img"
         style={
@@ -3682,7 +3682,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--explorer"
         role="img"
         style={
@@ -3699,7 +3699,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--factory"
         role="img"
         style={
@@ -3716,7 +3716,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--fallback"
         role="img"
         style={
@@ -3733,7 +3733,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--family-care"
         role="img"
         style={
@@ -3750,7 +3750,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--family-protection"
         role="img"
         style={
@@ -3767,7 +3767,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--favorite"
         role="img"
         style={
@@ -3784,7 +3784,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--favorite-list"
         role="img"
         style={
@@ -3801,7 +3801,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--fax-machine"
         role="img"
         style={
@@ -3818,7 +3818,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--feed"
         role="img"
         style={
@@ -3835,7 +3835,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--feeder-arrow"
         role="img"
         style={
@@ -3852,7 +3852,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--filter"
         role="img"
         style={
@@ -3869,7 +3869,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--filter-analytics"
         role="img"
         style={
@@ -3886,7 +3886,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--filter-facets"
         role="img"
         style={
@@ -3903,7 +3903,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--filter-fields"
         role="img"
         style={
@@ -3920,7 +3920,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--flag"
         role="img"
         style={
@@ -3937,7 +3937,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--flight"
         role="img"
         style={
@@ -3954,7 +3954,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--fob-watch"
         role="img"
         style={
@@ -3971,7 +3971,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--folder"
         role="img"
         style={
@@ -3988,7 +3988,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--folder-blank"
         role="img"
         style={
@@ -4005,7 +4005,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--folder-full"
         role="img"
         style={
@@ -4022,7 +4022,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--form"
         role="img"
         style={
@@ -4039,7 +4039,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--forward"
         role="img"
         style={
@@ -4056,7 +4056,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--fridge"
         role="img"
         style={
@@ -4073,7 +4073,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--full-screen"
         role="img"
         style={
@@ -4090,7 +4090,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--full-stacked-chart"
         role="img"
         style={
@@ -4107,7 +4107,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--full-stacked-column-chart"
         role="img"
         style={
@@ -4124,7 +4124,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--functional-location"
         role="img"
         style={
@@ -4141,7 +4141,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--future"
         role="img"
         style={
@@ -4158,7 +4158,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--gantt-bars"
         role="img"
         style={
@@ -4175,7 +4175,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--general-leave-request"
         role="img"
         style={
@@ -4192,7 +4192,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--generate-shortcut"
         role="img"
         style={
@@ -4209,7 +4209,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--geographic-bubble-chart"
         role="img"
         style={
@@ -4226,7 +4226,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--globe"
         role="img"
         style={
@@ -4243,7 +4243,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--goal"
         role="img"
         style={
@@ -4260,7 +4260,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--goalseek"
         role="img"
         style={
@@ -4277,7 +4277,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--grid"
         role="img"
         style={
@@ -4294,7 +4294,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--group"
         role="img"
         style={
@@ -4311,7 +4311,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--group-2"
         role="img"
         style={
@@ -4328,7 +4328,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--header"
         role="img"
         style={
@@ -4345,7 +4345,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--heading-1"
         role="img"
         style={
@@ -4362,7 +4362,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--heading-2"
         role="img"
         style={
@@ -4379,7 +4379,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--heading-3"
         role="img"
         style={
@@ -4396,7 +4396,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--headset"
         role="img"
         style={
@@ -4413,7 +4413,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--heating-cooling"
         role="img"
         style={
@@ -4430,7 +4430,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--heatmap-chart"
         role="img"
         style={
@@ -4447,7 +4447,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--hello-world"
         role="img"
         style={
@@ -4464,7 +4464,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--hide"
         role="img"
         style={
@@ -4481,7 +4481,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--hint"
         role="img"
         style={
@@ -4498,7 +4498,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--history"
         role="img"
         style={
@@ -4515,7 +4515,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--home"
         role="img"
         style={
@@ -4532,7 +4532,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--home-share"
         role="img"
         style={
@@ -4549,7 +4549,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-bar-chart"
         role="img"
         style={
@@ -4566,7 +4566,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-bar-chart-2"
         role="img"
         style={
@@ -4583,7 +4583,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-bullet-chart"
         role="img"
         style={
@@ -4600,7 +4600,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-grip"
         role="img"
         style={
@@ -4617,7 +4617,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-stacked-chart"
         role="img"
         style={
@@ -4634,7 +4634,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--horizontal-waterfall-chart"
         role="img"
         style={
@@ -4651,7 +4651,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--hr-approval"
         role="img"
         style={
@@ -4668,7 +4668,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--idea-wall"
         role="img"
         style={
@@ -4685,7 +4685,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--image-viewer"
         role="img"
         style={
@@ -4702,7 +4702,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--inbox"
         role="img"
         style={
@@ -4719,7 +4719,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--incident"
         role="img"
         style={
@@ -4736,7 +4736,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--incoming-call"
         role="img"
         style={
@@ -4753,7 +4753,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--increase-line-height"
         role="img"
         style={
@@ -4770,7 +4770,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--indent"
         role="img"
         style={
@@ -4787,7 +4787,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--initiative"
         role="img"
         style={
@@ -4804,7 +4804,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--inspect"
         role="img"
         style={
@@ -4821,7 +4821,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--inspect-down"
         role="img"
         style={
@@ -4838,7 +4838,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--inspection"
         role="img"
         style={
@@ -4855,7 +4855,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--instance"
         role="img"
         style={
@@ -4872,7 +4872,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--insurance-car"
         role="img"
         style={
@@ -4889,7 +4889,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--insurance-house"
         role="img"
         style={
@@ -4906,7 +4906,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--insurance-life"
         role="img"
         style={
@@ -4923,7 +4923,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--internet-browser"
         role="img"
         style={
@@ -4940,7 +4940,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--inventory"
         role="img"
         style={
@@ -4957,7 +4957,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--ipad"
         role="img"
         style={
@@ -4974,7 +4974,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--ipad-2"
         role="img"
         style={
@@ -4991,7 +4991,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--iphone"
         role="img"
         style={
@@ -5008,7 +5008,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--iphone-2"
         role="img"
         style={
@@ -5025,7 +5025,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--it-host"
         role="img"
         style={
@@ -5042,7 +5042,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--it-instance"
         role="img"
         style={
@@ -5059,7 +5059,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--it-system"
         role="img"
         style={
@@ -5076,7 +5076,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--italic-text"
         role="img"
         style={
@@ -5093,7 +5093,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--jam"
         role="img"
         style={
@@ -5110,7 +5110,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--journey-arrive"
         role="img"
         style={
@@ -5127,7 +5127,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--journey-change"
         role="img"
         style={
@@ -5144,7 +5144,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--journey-depart"
         role="img"
         style={
@@ -5161,7 +5161,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--key"
         role="img"
         style={
@@ -5178,7 +5178,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--key-user-settings"
         role="img"
         style={
@@ -5195,7 +5195,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--kpi-corporate-performance"
         role="img"
         style={
@@ -5212,7 +5212,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--kpi-managing-my-area"
         role="img"
         style={
@@ -5229,7 +5229,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--lab"
         role="img"
         style={
@@ -5246,7 +5246,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--laptop"
         role="img"
         style={
@@ -5263,7 +5263,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--lateness"
         role="img"
         style={
@@ -5280,7 +5280,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--lead"
         role="img"
         style={
@@ -5297,7 +5297,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--lead-outdated"
         role="img"
         style={
@@ -5314,7 +5314,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--leads"
         role="img"
         style={
@@ -5331,7 +5331,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--learning-assistant"
         role="img"
         style={
@@ -5348,7 +5348,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--legend"
         role="img"
         style={
@@ -5365,7 +5365,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--less"
         role="img"
         style={
@@ -5382,7 +5382,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--letter"
         role="img"
         style={
@@ -5399,7 +5399,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--lightbulb"
         role="img"
         style={
@@ -5416,7 +5416,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--line-chart"
         role="img"
         style={
@@ -5433,7 +5433,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--line-chart-dual-axis"
         role="img"
         style={
@@ -5450,7 +5450,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--line-chart-time-axis"
         role="img"
         style={
@@ -5467,7 +5467,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--line-charts"
         role="img"
         style={
@@ -5484,7 +5484,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--list"
         role="img"
         style={
@@ -5501,7 +5501,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--loan"
         role="img"
         style={
@@ -5518,7 +5518,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--locate-me"
         role="img"
         style={
@@ -5535,7 +5535,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--locked"
         role="img"
         style={
@@ -5552,7 +5552,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--log"
         role="img"
         style={
@@ -5569,7 +5569,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--machine"
         role="img"
         style={
@@ -5586,7 +5586,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--manager"
         role="img"
         style={
@@ -5603,7 +5603,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--manager-insight"
         role="img"
         style={
@@ -5620,7 +5620,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--map"
         role="img"
         style={
@@ -5637,7 +5637,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--map-2"
         role="img"
         style={
@@ -5654,7 +5654,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--map-3"
         role="img"
         style={
@@ -5671,7 +5671,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--marketing-campaign"
         role="img"
         style={
@@ -5688,7 +5688,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--master-task-triangle"
         role="img"
         style={
@@ -5705,7 +5705,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--master-task-triangle-2"
         role="img"
         style={
@@ -5722,7 +5722,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--meal"
         role="img"
         style={
@@ -5739,7 +5739,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--measure"
         role="img"
         style={
@@ -5756,7 +5756,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--measurement-document"
         role="img"
         style={
@@ -5773,7 +5773,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--measuring-point"
         role="img"
         style={
@@ -5790,7 +5790,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--media-forward"
         role="img"
         style={
@@ -5807,7 +5807,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--media-pause"
         role="img"
         style={
@@ -5824,7 +5824,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--media-play"
         role="img"
         style={
@@ -5841,7 +5841,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--media-reverse"
         role="img"
         style={
@@ -5858,7 +5858,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--media-rewind"
         role="img"
         style={
@@ -5875,7 +5875,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--meeting-room"
         role="img"
         style={
@@ -5892,7 +5892,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--menu"
         role="img"
         style={
@@ -5909,7 +5909,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--menu2"
         role="img"
         style={
@@ -5926,7 +5926,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--message-error"
         role="img"
         style={
@@ -5943,7 +5943,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--message-information"
         role="img"
         style={
@@ -5960,7 +5960,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--message-popup"
         role="img"
         style={
@@ -5977,7 +5977,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--message-success"
         role="img"
         style={
@@ -5994,7 +5994,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--message-warning"
         role="img"
         style={
@@ -6011,7 +6011,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--microphone"
         role="img"
         style={
@@ -6028,7 +6028,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--mileage"
         role="img"
         style={
@@ -6045,7 +6045,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--minimize"
         role="img"
         style={
@@ -6062,7 +6062,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--mirrored-task-circle"
         role="img"
         style={
@@ -6079,7 +6079,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--mirrored-task-circle-2"
         role="img"
         style={
@@ -6096,7 +6096,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--money-bills"
         role="img"
         style={
@@ -6113,7 +6113,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--monitor-payments"
         role="img"
         style={
@@ -6130,7 +6130,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--move"
         role="img"
         style={
@@ -6147,7 +6147,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--mri-scan"
         role="img"
         style={
@@ -6164,7 +6164,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiple-bar-chart"
         role="img"
         style={
@@ -6181,7 +6181,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiple-line-chart"
         role="img"
         style={
@@ -6198,7 +6198,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiple-pie-chart"
         role="img"
         style={
@@ -6215,7 +6215,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiple-radar-chart"
         role="img"
         style={
@@ -6232,7 +6232,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiselect"
         role="img"
         style={
@@ -6249,7 +6249,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiselect-all"
         role="img"
         style={
@@ -6266,7 +6266,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--multiselect-none"
         role="img"
         style={
@@ -6283,7 +6283,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--my-sales-order"
         role="img"
         style={
@@ -6300,7 +6300,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--my-view"
         role="img"
         style={
@@ -6317,7 +6317,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--nav-back"
         role="img"
         style={
@@ -6334,7 +6334,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--navigation-down-arrow"
         role="img"
         style={
@@ -6351,7 +6351,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--navigation-left-arrow"
         role="img"
         style={
@@ -6368,7 +6368,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--navigation-right-arrow"
         role="img"
         style={
@@ -6385,7 +6385,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--navigation-up-arrow"
         role="img"
         style={
@@ -6402,7 +6402,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--negative"
         role="img"
         style={
@@ -6419,7 +6419,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--Netweaver-business-client"
         role="img"
         style={
@@ -6436,7 +6436,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--newspaper"
         role="img"
         style={
@@ -6453,7 +6453,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--notes"
         role="img"
         style={
@@ -6470,7 +6470,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--notification-2"
         role="img"
         style={
@@ -6487,7 +6487,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--number-sign"
         role="img"
         style={
@@ -6504,7 +6504,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--numbered-text"
         role="img"
         style={
@@ -6521,7 +6521,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--nurse"
         role="img"
         style={
@@ -6538,7 +6538,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--nutrition-activity"
         role="img"
         style={
@@ -6555,7 +6555,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--official-service"
         role="img"
         style={
@@ -6572,7 +6572,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--offsite-work"
         role="img"
         style={
@@ -6589,7 +6589,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--open-command-field"
         role="img"
         style={
@@ -6606,7 +6606,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--open-folder"
         role="img"
         style={
@@ -6623,7 +6623,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--opportunities"
         role="img"
         style={
@@ -6640,7 +6640,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--opportunity"
         role="img"
         style={
@@ -6657,7 +6657,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--order-status"
         role="img"
         style={
@@ -6674,7 +6674,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--org-chart"
         role="img"
         style={
@@ -6691,7 +6691,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--outbox"
         role="img"
         style={
@@ -6708,7 +6708,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--outdent"
         role="img"
         style={
@@ -6725,7 +6725,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--outgoing-call"
         role="img"
         style={
@@ -6742,7 +6742,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--overflow"
         role="img"
         style={
@@ -6759,7 +6759,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--overlay"
         role="img"
         style={
@@ -6776,7 +6776,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--overview-chart"
         role="img"
         style={
@@ -6793,7 +6793,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--paging"
         role="img"
         style={
@@ -6810,7 +6810,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--paid-leave"
         role="img"
         style={
@@ -6827,7 +6827,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--palette"
         role="img"
         style={
@@ -6844,7 +6844,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--paper-plane"
         role="img"
         style={
@@ -6861,7 +6861,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--passenger-train"
         role="img"
         style={
@@ -6878,7 +6878,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--past"
         role="img"
         style={
@@ -6895,7 +6895,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--paste"
         role="img"
         style={
@@ -6912,7 +6912,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pause"
         role="img"
         style={
@@ -6929,7 +6929,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--payment-approval"
         role="img"
         style={
@@ -6946,7 +6946,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pdf-attachment"
         role="img"
         style={
@@ -6963,7 +6963,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pdf-reader"
         role="img"
         style={
@@ -6980,7 +6980,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pending"
         role="img"
         style={
@@ -6997,7 +6997,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--per-diem"
         role="img"
         style={
@@ -7014,7 +7014,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--performance"
         role="img"
         style={
@@ -7031,7 +7031,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--permission"
         role="img"
         style={
@@ -7048,7 +7048,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--person-placeholder"
         role="img"
         style={
@@ -7065,7 +7065,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--personnel-view"
         role="img"
         style={
@@ -7082,7 +7082,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pharmacy"
         role="img"
         style={
@@ -7099,7 +7099,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--phone"
         role="img"
         style={
@@ -7116,7 +7116,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--photo-voltaic"
         role="img"
         style={
@@ -7133,7 +7133,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--physical-activity"
         role="img"
         style={
@@ -7150,7 +7150,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--picture"
         role="img"
         style={
@@ -7167,7 +7167,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pie-chart"
         role="img"
         style={
@@ -7184,7 +7184,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pipeline-analysis"
         role="img"
         style={
@@ -7201,7 +7201,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--play"
         role="img"
         style={
@@ -7218,7 +7218,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pool"
         role="img"
         style={
@@ -7235,7 +7235,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--popup-window"
         role="img"
         style={
@@ -7252,7 +7252,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--positive"
         role="img"
         style={
@@ -7269,7 +7269,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--post"
         role="img"
         style={
@@ -7286,7 +7286,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--ppt-attachment"
         role="img"
         style={
@@ -7303,7 +7303,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--present"
         role="img"
         style={
@@ -7320,7 +7320,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--print"
         role="img"
         style={
@@ -7337,7 +7337,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--private"
         role="img"
         style={
@@ -7354,7 +7354,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--process"
         role="img"
         style={
@@ -7371,7 +7371,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--product"
         role="img"
         style={
@@ -7388,7 +7388,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--program-triangles"
         role="img"
         style={
@@ -7405,7 +7405,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--program-triangles-2"
         role="img"
         style={
@@ -7422,7 +7422,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--project-definition-triangle"
         role="img"
         style={
@@ -7439,7 +7439,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--project-definition-triangle-2"
         role="img"
         style={
@@ -7456,7 +7456,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--projector"
         role="img"
         style={
@@ -7473,7 +7473,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--provision"
         role="img"
         style={
@@ -7490,7 +7490,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pull-down"
         role="img"
         style={
@@ -7507,7 +7507,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pushpin-off"
         role="img"
         style={
@@ -7524,7 +7524,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--pushpin-on"
         role="img"
         style={
@@ -7541,7 +7541,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--puzzle"
         role="img"
         style={
@@ -7558,7 +7558,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--quality-issue"
         role="img"
         style={
@@ -7575,7 +7575,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--question-mark"
         role="img"
         style={
@@ -7592,7 +7592,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--radar-chart"
         role="img"
         style={
@@ -7609,7 +7609,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--receipt"
         role="img"
         style={
@@ -7626,7 +7626,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--record"
         role="img"
         style={
@@ -7643,7 +7643,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--redo"
         role="img"
         style={
@@ -7660,7 +7660,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--refresh"
         role="img"
         style={
@@ -7677,7 +7677,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--repost"
         role="img"
         style={
@@ -7694,7 +7694,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--request"
         role="img"
         style={
@@ -7711,7 +7711,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--reset"
         role="img"
         style={
@@ -7728,7 +7728,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--resize"
         role="img"
         style={
@@ -7745,7 +7745,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--resize-corner"
         role="img"
         style={
@@ -7762,7 +7762,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--resize-horizontal"
         role="img"
         style={
@@ -7779,7 +7779,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--resize-vertical"
         role="img"
         style={
@@ -7796,7 +7796,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--response"
         role="img"
         style={
@@ -7813,7 +7813,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--restart"
         role="img"
         style={
@@ -7830,7 +7830,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--retail-store"
         role="img"
         style={
@@ -7847,7 +7847,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--retail-store-manager"
         role="img"
         style={
@@ -7864,7 +7864,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--rhombus-milestone"
         role="img"
         style={
@@ -7881,7 +7881,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--rhombus-milestone-2"
         role="img"
         style={
@@ -7898,7 +7898,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--role"
         role="img"
         style={
@@ -7915,7 +7915,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sales-document"
         role="img"
         style={
@@ -7932,7 +7932,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sales-notification"
         role="img"
         style={
@@ -7949,7 +7949,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sales-order"
         role="img"
         style={
@@ -7966,7 +7966,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sales-order-item"
         role="img"
         style={
@@ -7983,7 +7983,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sales-quote"
         role="img"
         style={
@@ -8000,7 +8000,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sap-box"
         role="img"
         style={
@@ -8017,7 +8017,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sap-logo-shape"
         role="img"
         style={
@@ -8034,7 +8034,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sap-ui5"
         role="img"
         style={
@@ -8051,7 +8051,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--save"
         role="img"
         style={
@@ -8068,7 +8068,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--scatter-chart"
         role="img"
         style={
@@ -8085,7 +8085,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--scissors"
         role="img"
         style={
@@ -8102,7 +8102,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--screen-split-one"
         role="img"
         style={
@@ -8119,7 +8119,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--screen-split-three"
         role="img"
         style={
@@ -8136,7 +8136,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--screen-split-two"
         role="img"
         style={
@@ -8153,7 +8153,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--search"
         role="img"
         style={
@@ -8170,7 +8170,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--settings"
         role="img"
         style={
@@ -8187,7 +8187,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--share"
         role="img"
         style={
@@ -8204,7 +8204,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--share-2"
         role="img"
         style={
@@ -8221,7 +8221,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--shelf"
         role="img"
         style={
@@ -8238,7 +8238,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--shield"
         role="img"
         style={
@@ -8255,7 +8255,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--shipping-status"
         role="img"
         style={
@@ -8272,7 +8272,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--shortcut"
         role="img"
         style={
@@ -8289,7 +8289,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--show"
         role="img"
         style={
@@ -8306,7 +8306,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--signature"
         role="img"
         style={
@@ -8323,7 +8323,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--simple-payment"
         role="img"
         style={
@@ -8340,7 +8340,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--simulate"
         role="img"
         style={
@@ -8357,7 +8357,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--slim-arrow-down"
         role="img"
         style={
@@ -8374,7 +8374,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--slim-arrow-left"
         role="img"
         style={
@@ -8391,7 +8391,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--slim-arrow-right"
         role="img"
         style={
@@ -8408,7 +8408,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--slim-arrow-up"
         role="img"
         style={
@@ -8425,7 +8425,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--soccor"
         role="img"
         style={
@@ -8442,7 +8442,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sonography"
         role="img"
         style={
@@ -8459,7 +8459,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sort"
         role="img"
         style={
@@ -8476,7 +8476,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sort-ascending"
         role="img"
         style={
@@ -8493,7 +8493,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sort-descending"
         role="img"
         style={
@@ -8510,7 +8510,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sorting-ranking"
         role="img"
         style={
@@ -8527,7 +8527,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sound"
         role="img"
         style={
@@ -8544,7 +8544,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sound-loud"
         role="img"
         style={
@@ -8561,7 +8561,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sound-off"
         role="img"
         style={
@@ -8578,7 +8578,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--source-code"
         role="img"
         style={
@@ -8595,7 +8595,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--status-critical"
         role="img"
         style={
@@ -8612,7 +8612,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--status-inactive"
         role="img"
         style={
@@ -8629,7 +8629,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--status-negative"
         role="img"
         style={
@@ -8646,7 +8646,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--status-positive"
         role="img"
         style={
@@ -8663,7 +8663,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--step"
         role="img"
         style={
@@ -8680,7 +8680,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--stethoscope"
         role="img"
         style={
@@ -8697,7 +8697,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--stop"
         role="img"
         style={
@@ -8714,7 +8714,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--study-leave"
         role="img"
         style={
@@ -8731,7 +8731,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--subway-train"
         role="img"
         style={
@@ -8748,7 +8748,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--suitcase"
         role="img"
         style={
@@ -8765,7 +8765,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--supplier"
         role="img"
         style={
@@ -8782,7 +8782,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--survey"
         role="img"
         style={
@@ -8799,7 +8799,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--switch-classes"
         role="img"
         style={
@@ -8816,7 +8816,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--switch-views"
         role="img"
         style={
@@ -8833,7 +8833,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--synchronize"
         role="img"
         style={
@@ -8850,7 +8850,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--syntax"
         role="img"
         style={
@@ -8867,7 +8867,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--syringe"
         role="img"
         style={
@@ -8884,7 +8884,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-add"
         role="img"
         style={
@@ -8901,7 +8901,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-back"
         role="img"
         style={
@@ -8918,7 +8918,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-back-2"
         role="img"
         style={
@@ -8935,7 +8935,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-cancel"
         role="img"
         style={
@@ -8952,7 +8952,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-cancel-2"
         role="img"
         style={
@@ -8969,7 +8969,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-enter"
         role="img"
         style={
@@ -8986,7 +8986,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-enter-2"
         role="img"
         style={
@@ -9003,7 +9003,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-find"
         role="img"
         style={
@@ -9020,7 +9020,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-find-next"
         role="img"
         style={
@@ -9037,7 +9037,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-first-page"
         role="img"
         style={
@@ -9054,7 +9054,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-help"
         role="img"
         style={
@@ -9071,7 +9071,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-help-2"
         role="img"
         style={
@@ -9088,7 +9088,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-last-page"
         role="img"
         style={
@@ -9105,7 +9105,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-minus"
         role="img"
         style={
@@ -9122,7 +9122,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-monitor"
         role="img"
         style={
@@ -9139,7 +9139,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-next-page"
         role="img"
         style={
@@ -9156,7 +9156,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--sys-prev-page"
         role="img"
         style={
@@ -9173,7 +9173,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--system-exit"
         role="img"
         style={
@@ -9190,7 +9190,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--system-exit-2"
         role="img"
         style={
@@ -9207,7 +9207,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--table-chart"
         role="img"
         style={
@@ -9224,7 +9224,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--table-view"
         role="img"
         style={
@@ -9241,7 +9241,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--tag"
         role="img"
         style={
@@ -9258,7 +9258,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--tag-cloud-chart"
         role="img"
         style={
@@ -9275,7 +9275,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--tags"
         role="img"
         style={
@@ -9292,7 +9292,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--target-group"
         role="img"
         style={
@@ -9309,7 +9309,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--task"
         role="img"
         style={
@@ -9326,7 +9326,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--taxi"
         role="img"
         style={
@@ -9343,7 +9343,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--technical-object"
         role="img"
         style={
@@ -9360,7 +9360,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--temperature"
         role="img"
         style={
@@ -9377,7 +9377,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--text-align-center"
         role="img"
         style={
@@ -9394,7 +9394,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--text-align-justified"
         role="img"
         style={
@@ -9411,7 +9411,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--text-align-left"
         role="img"
         style={
@@ -9428,7 +9428,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--text-align-right"
         role="img"
         style={
@@ -9445,7 +9445,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--text-formatting"
         role="img"
         style={
@@ -9462,7 +9462,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--theater"
         role="img"
         style={
@@ -9479,7 +9479,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--thing-type"
         role="img"
         style={
@@ -9496,7 +9496,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--thumb-down"
         role="img"
         style={
@@ -9513,7 +9513,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--thumb-up"
         role="img"
         style={
@@ -9530,7 +9530,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--time-account"
         role="img"
         style={
@@ -9547,7 +9547,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--time-entry-request"
         role="img"
         style={
@@ -9564,7 +9564,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--time-overtime"
         role="img"
         style={
@@ -9581,7 +9581,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--timesheet"
         role="img"
         style={
@@ -9598,7 +9598,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--to-be-reviewed"
         role="img"
         style={
@@ -9615,7 +9615,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--toaster-down"
         role="img"
         style={
@@ -9632,7 +9632,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--toaster-top"
         role="img"
         style={
@@ -9649,7 +9649,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--toaster-up"
         role="img"
         style={
@@ -9666,7 +9666,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--tools-opportunity"
         role="img"
         style={
@@ -9683,7 +9683,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--travel-expense"
         role="img"
         style={
@@ -9700,7 +9700,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--travel-expense-report"
         role="img"
         style={
@@ -9717,7 +9717,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--travel-itinerary"
         role="img"
         style={
@@ -9734,7 +9734,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--travel-request"
         role="img"
         style={
@@ -9751,7 +9751,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--tree"
         role="img"
         style={
@@ -9768,7 +9768,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--trend-down"
         role="img"
         style={
@@ -9785,7 +9785,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--trend-up"
         role="img"
         style={
@@ -9802,7 +9802,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--trip-report"
         role="img"
         style={
@@ -9819,7 +9819,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--ui-notifications"
         role="img"
         style={
@@ -9836,7 +9836,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--umbrella"
         role="img"
         style={
@@ -9853,7 +9853,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--underline-text"
         role="img"
         style={
@@ -9870,7 +9870,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--undo"
         role="img"
         style={
@@ -9887,7 +9887,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--unfavorite"
         role="img"
         style={
@@ -9904,7 +9904,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--unlocked"
         role="img"
         style={
@@ -9921,7 +9921,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--unpaid-leave"
         role="img"
         style={
@@ -9938,7 +9938,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--unwired"
         role="img"
         style={
@@ -9955,7 +9955,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--up"
         role="img"
         style={
@@ -9972,7 +9972,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--upload"
         role="img"
         style={
@@ -9989,7 +9989,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--upload-to-cloud"
         role="img"
         style={
@@ -10006,7 +10006,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--upstacked-chart"
         role="img"
         style={
@@ -10023,7 +10023,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--user-edit"
         role="img"
         style={
@@ -10040,7 +10040,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--user-settings"
         role="img"
         style={
@@ -10057,7 +10057,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--value-help"
         role="img"
         style={
@@ -10074,7 +10074,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vds-file"
         role="img"
         style={
@@ -10091,7 +10091,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vehicle-repair"
         role="img"
         style={
@@ -10108,7 +10108,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-bar-chart"
         role="img"
         style={
@@ -10125,7 +10125,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-bar-chart-2"
         role="img"
         style={
@@ -10142,7 +10142,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-bullet-chart"
         role="img"
         style={
@@ -10159,7 +10159,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-grip"
         role="img"
         style={
@@ -10176,7 +10176,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-stacked-chart"
         role="img"
         style={
@@ -10193,7 +10193,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--vertical-waterfall-chart"
         role="img"
         style={
@@ -10210,7 +10210,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--video"
         role="img"
         style={
@@ -10227,7 +10227,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--visits"
         role="img"
         style={
@@ -10244,7 +10244,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--waiver"
         role="img"
         style={
@@ -10261,7 +10261,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--wallet"
         role="img"
         style={
@@ -10278,7 +10278,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--warning"
         role="img"
         style={
@@ -10295,7 +10295,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--warning2"
         role="img"
         style={
@@ -10312,7 +10312,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--washing-machine"
         role="img"
         style={
@@ -10329,7 +10329,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--weather-proofing"
         role="img"
         style={
@@ -10346,7 +10346,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--web-cam"
         role="img"
         style={
@@ -10363,7 +10363,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--widgets"
         role="img"
         style={
@@ -10380,7 +10380,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--windows-doors"
         role="img"
         style={
@@ -10397,7 +10397,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--work-history"
         role="img"
         style={
@@ -10414,7 +10414,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--workflow-tasks"
         role="img"
         style={
@@ -10431,7 +10431,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--world"
         role="img"
         style={
@@ -10448,7 +10448,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--wounds-doc"
         role="img"
         style={
@@ -10465,7 +10465,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--wrench"
         role="img"
         style={
@@ -10482,7 +10482,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--write-new"
         role="img"
         style={
@@ -10499,7 +10499,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--write-new-document"
         role="img"
         style={
@@ -10516,7 +10516,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--x-ray"
         role="img"
         style={
@@ -10533,7 +10533,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--zoom-in"
         role="img"
         style={
@@ -10550,7 +10550,7 @@ exports[`Storyshots Component API/Icon Icon List 1`] = `
     <div
       className="fddocs-container--icon"
     >
-      <span
+      <i
         className="sap-icon--zoom-out"
         role="img"
         style={
@@ -10572,7 +10572,7 @@ exports[`Storyshots Component API/Icon Primary 1`] = `
 <div
   dir="ltr"
 >
-  <span
+  <i
     className="sap-icon--cart"
     role="img"
   />
@@ -10586,7 +10586,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
   <div
     className="fddocs-container"
   >
-    <span
+    <i
       className="sap-icon--cart"
       role="img"
       style={
@@ -10595,11 +10595,11 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
         }
       }
     />
-    <span
+    <i
       className="sap-icon--cart"
       role="img"
     />
-    <span
+    <i
       className="sap-icon--cart"
       role="img"
       style={
@@ -10608,7 +10608,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
         }
       }
     />
-    <span
+    <i
       className="sap-icon--cart"
       role="img"
       style={
@@ -10617,7 +10617,7 @@ exports[`Storyshots Component API/Icon Sizes 1`] = `
         }
       }
     />
-    <span
+    <i
       className="sap-icon--cart"
       role="img"
       style={

--- a/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
@@ -22,8 +22,9 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-down-arrow"
+            role="img"
           />
         </button>
       </span>
@@ -39,8 +40,9 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-down-arrow"
+            role="img"
           />
         </button>
       </span>
@@ -68,8 +70,9 @@ exports[`Storyshots Component API/InputGroup Compact 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </span>
@@ -102,8 +105,9 @@ exports[`Storyshots Component API/InputGroup Dev 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </span>
@@ -127,8 +131,9 @@ exports[`Storyshots Component API/InputGroup Disabled 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </span>
@@ -156,6 +161,7 @@ exports[`Storyshots Component API/InputGroup Icon add-on 1`] = `
       >
         <span
           className="sap-icon--globe"
+          role="img"
         />
       </span>
       <input
@@ -177,6 +183,7 @@ exports[`Storyshots Component API/InputGroup Icon add-on 1`] = `
       >
         <span
           className="sap-icon--hide"
+          role="img"
         />
       </span>
     </div>
@@ -199,8 +206,9 @@ exports[`Storyshots Component API/InputGroup Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </span>
@@ -229,6 +237,7 @@ exports[`Storyshots Component API/InputGroup Text Area 1`] = `
     >
       <span
         className="sap-icon--hide"
+        role="img"
       />
     </span>
   </div>

--- a/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
@@ -159,7 +159,7 @@ exports[`Storyshots Component API/InputGroup Icon add-on 1`] = `
       <span
         className="fd-input-group__addon"
       >
-        <span
+        <i
           className="sap-icon--globe"
           role="img"
         />
@@ -181,7 +181,7 @@ exports[`Storyshots Component API/InputGroup Icon add-on 1`] = `
       <span
         className="fd-input-group__addon"
       >
-        <span
+        <i
           className="sap-icon--hide"
           role="img"
         />
@@ -235,7 +235,7 @@ exports[`Storyshots Component API/InputGroup Text Area 1`] = `
     <span
       className="fd-input-group__addon"
     >
-      <span
+      <i
         className="sap-icon--hide"
         role="img"
       />

--- a/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
@@ -22,6 +22,7 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-down-arrow"
           />
         </button>
@@ -38,6 +39,7 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-down-arrow"
           />
         </button>
@@ -66,6 +68,7 @@ exports[`Storyshots Component API/InputGroup Compact 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -99,6 +102,7 @@ exports[`Storyshots Component API/InputGroup Dev 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -123,6 +127,7 @@ exports[`Storyshots Component API/InputGroup Disabled 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -194,6 +199,7 @@ exports[`Storyshots Component API/InputGroup Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>

--- a/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__stories__/__snapshots__/InputGroup.stories.storyshot
@@ -18,9 +18,13 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
         className="fd-input-group__addon fd-input-group__addon--button"
       >
         <button
-          className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+          className="fd-button fd-button--transparent fd-input-group__button"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-down-arrow"
+          />
+        </button>
       </span>
     </div>
     <div
@@ -30,9 +34,13 @@ exports[`Storyshots Component API/InputGroup Button add-on 1`] = `
         className="fd-input-group__addon fd-input-group__addon--button"
       >
         <button
-          className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+          className="fd-button fd-button--transparent fd-input-group__button"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-down-arrow"
+          />
+        </button>
       </span>
       <input
         className="fd-input fd-input-group__input"
@@ -54,9 +62,13 @@ exports[`Storyshots Component API/InputGroup Compact 1`] = `
       className="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact"
     >
       <button
-        className="fd-button fd-button--transparent fd-button--compact sap-icon--navigation-down-arrow fd-input-group__button"
+        className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </span>
     <input
       className="fd-input fd-input--compact fd-input-group__input"
@@ -83,9 +95,13 @@ exports[`Storyshots Component API/InputGroup Dev 1`] = `
       disabled={false}
     >
       <button
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+        className="fd-button fd-button--transparent fd-input-group__button"
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </span>
   </div>
 </div>
@@ -103,9 +119,13 @@ exports[`Storyshots Component API/InputGroup Disabled 1`] = `
       disabled={true}
     >
       <button
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+        className="fd-button fd-button--transparent fd-input-group__button"
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </span>
     <input
       className="fd-input fd-input-group__input"
@@ -170,9 +190,13 @@ exports[`Storyshots Component API/InputGroup Primary 1`] = `
       className="fd-input-group__addon fd-input-group__addon--button"
     >
       <button
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow fd-input-group__button"
+        className="fd-button fd-button--transparent fd-input-group__button"
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </span>
     <input
       className="fd-input fd-input-group__input"

--- a/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
+++ b/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
@@ -50,6 +50,7 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
+                  aria-hidden="true"
                   className="sap-icon--add"
                 />
               </button>
@@ -211,6 +212,7 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
+                  aria-hidden="true"
                   className="sap-icon--add"
                 />
               </button>
@@ -376,6 +378,7 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
+                  aria-hidden="true"
                   className="sap-icon--add"
                 />
               </button>
@@ -537,6 +540,7 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
+                  aria-hidden="true"
                   className="sap-icon--add"
                 />
               </button>
@@ -763,6 +767,7 @@ exports[`Storyshots Component API/LayoutPanel Single Layout Panel 1`] = `
             Add New Button
           </span>
           <i
+            aria-hidden="true"
             className="sap-icon--add"
           />
         </button>

--- a/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
+++ b/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
@@ -50,8 +50,9 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--add"
+                  role="img"
                 />
               </button>
             </div>
@@ -212,8 +213,9 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--add"
+                  role="img"
                 />
               </button>
             </div>
@@ -378,8 +380,9 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--add"
+                  role="img"
                 />
               </button>
             </div>
@@ -540,8 +543,9 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                   Add New Button
                 </span>
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--add"
+                  role="img"
                 />
               </button>
             </div>
@@ -767,8 +771,9 @@ exports[`Storyshots Component API/LayoutPanel Single Layout Panel 1`] = `
             Add New Button
           </span>
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--add"
+            role="img"
           />
         </button>
       </div>

--- a/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
+++ b/src/LayoutPanel/__stories__/__snapshots__/LayoutPanel.stories.storyshot
@@ -41,10 +41,17 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
               className="fd-layout-panel__actions"
             >
               <button
-                className="fd-button fd-button--compact sap-icon--add"
+                className="fd-button fd-button--compact"
                 type="button"
               >
-                Add New Button
+                <span
+                  className="fd-button__text"
+                >
+                  Add New Button
+                </span>
+                <i
+                  className="sap-icon--add"
+                />
               </button>
             </div>
           </div>
@@ -77,7 +84,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Color
+                    <span
+                      className="fd-button__text"
+                    >
+                      Color
+                    </span>
                   </button>
                 </div>
               </div>
@@ -104,7 +115,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Size
+                    <span
+                      className="fd-button__text"
+                    >
+                      Size
+                    </span>
                   </button>
                 </div>
               </div>
@@ -187,10 +202,17 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
               className="fd-layout-panel__actions"
             >
               <button
-                className="fd-button fd-button--compact sap-icon--add"
+                className="fd-button fd-button--compact"
                 type="button"
               >
-                Add New Button
+                <span
+                  className="fd-button__text"
+                >
+                  Add New Button
+                </span>
+                <i
+                  className="sap-icon--add"
+                />
               </button>
             </div>
           </div>
@@ -223,7 +245,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Color
+                    <span
+                      className="fd-button__text"
+                    >
+                      Color
+                    </span>
                   </button>
                 </div>
               </div>
@@ -250,7 +276,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Size
+                    <span
+                      className="fd-button__text"
+                    >
+                      Size
+                    </span>
                   </button>
                 </div>
               </div>
@@ -337,10 +367,17 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
               className="fd-layout-panel__actions"
             >
               <button
-                className="fd-button fd-button--compact sap-icon--add"
+                className="fd-button fd-button--compact"
                 type="button"
               >
-                Add New Button
+                <span
+                  className="fd-button__text"
+                >
+                  Add New Button
+                </span>
+                <i
+                  className="sap-icon--add"
+                />
               </button>
             </div>
           </div>
@@ -373,7 +410,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Color
+                    <span
+                      className="fd-button__text"
+                    >
+                      Color
+                    </span>
                   </button>
                 </div>
               </div>
@@ -400,7 +441,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Size
+                    <span
+                      className="fd-button__text"
+                    >
+                      Size
+                    </span>
                   </button>
                 </div>
               </div>
@@ -483,10 +528,17 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
               className="fd-layout-panel__actions"
             >
               <button
-                className="fd-button fd-button--compact sap-icon--add"
+                className="fd-button fd-button--compact"
                 type="button"
               >
-                Add New Button
+                <span
+                  className="fd-button__text"
+                >
+                  Add New Button
+                </span>
+                <i
+                  className="sap-icon--add"
+                />
               </button>
             </div>
           </div>
@@ -519,7 +571,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Color
+                    <span
+                      className="fd-button__text"
+                    >
+                      Color
+                    </span>
                   </button>
                 </div>
               </div>
@@ -546,7 +602,11 @@ exports[`Storyshots Component API/LayoutPanel In A Responsive Layout Grid 1`] = 
                     tabIndex={0}
                     type="button"
                   >
-                    Size
+                    <span
+                      className="fd-button__text"
+                    >
+                      Size
+                    </span>
                   </button>
                 </div>
               </div>
@@ -694,10 +754,17 @@ exports[`Storyshots Component API/LayoutPanel Single Layout Panel 1`] = `
         className="fd-layout-panel__actions"
       >
         <button
-          className="fd-button fd-button--compact sap-icon--add"
+          className="fd-button fd-button--compact"
           type="button"
         >
-          Add New Button
+          <span
+            className="fd-button__text"
+          >
+            Add New Button
+          </span>
+          <i
+            className="sap-icon--add"
+          />
         </button>
       </div>
     </div>
@@ -730,7 +797,11 @@ exports[`Storyshots Component API/LayoutPanel Single Layout Panel 1`] = `
               tabIndex={0}
               type="button"
             >
-              Color
+              <span
+                className="fd-button__text"
+              >
+                Color
+              </span>
             </button>
           </div>
         </div>
@@ -757,7 +828,11 @@ exports[`Storyshots Component API/LayoutPanel Single Layout Panel 1`] = `
               tabIndex={0}
               type="button"
             >
-              Size
+              <span
+                className="fd-button__text"
+              >
+                Size
+              </span>
             </button>
           </div>
         </div>

--- a/src/LocalizationEditor/__stories__/__snapshots__/LocalizationEditor.stories.storyshot
+++ b/src/LocalizationEditor/__stories__/__snapshots__/LocalizationEditor.stories.storyshot
@@ -39,7 +39,11 @@ exports[`Storyshots Component API/LocalizationEditor Compact 1`] = `
                 className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
                 type="button"
               >
-                EN*
+                <span
+                  className="fd-button__text"
+                >
+                  EN*
+                </span>
               </button>
             </span>
           </div>
@@ -89,7 +93,11 @@ exports[`Storyshots Component API/LocalizationEditor Primary 1`] = `
                 className="fd-button fd-button--transparent fd-input-group__button"
                 type="button"
               >
-                EN*
+                <span
+                  className="fd-button__text"
+                >
+                  EN*
+                </span>
               </button>
             </span>
           </div>
@@ -138,7 +146,11 @@ exports[`Storyshots Component API/LocalizationEditor Text Area 1`] = `
                 className="fd-button fd-button--transparent fd-input-group__button"
                 type="button"
               >
-                EN*
+                <span
+                  className="fd-button__text"
+                >
+                  EN*
+                </span>
               </button>
             </span>
           </div>

--- a/src/MessageStrip/MessageStrip.js
+++ b/src/MessageStrip/MessageStrip.js
@@ -66,6 +66,7 @@ const MessageStrip = (props) => {
                             aria-label={localizedText.close}
                             className='fd-message-strip__close'
                             compact
+                            glyph='decline'
                             onClick={closeMessageStripHandler}
                             option='transparent' />
                     )}

--- a/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
+++ b/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
@@ -36,8 +36,9 @@ exports[`Storyshots Component API/MessageStrip Dismissible 1`] = `
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <p
@@ -153,8 +154,9 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <p
@@ -187,8 +189,9 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <p
@@ -225,8 +228,9 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <p
@@ -266,8 +270,9 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
-        aria-hidden="true"
+        aria-hidden={true}
         className="sap-icon--decline"
+        role="img"
       />
     </button>
     <p

--- a/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
+++ b/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
@@ -34,7 +34,11 @@ exports[`Storyshots Component API/MessageStrip Dismissible 1`] = `
       className="fd-button fd-button--transparent fd-button--compact fd-message-strip__close"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <p
       className="fd-message-strip__text"
     >
@@ -146,7 +150,11 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       className="fd-button fd-button--transparent fd-button--compact fd-message-strip__close"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <p
       className="fd-message-strip__text"
     >
@@ -175,7 +183,11 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       className="fd-button fd-button--transparent fd-button--compact fd-message-strip__close"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <p
       className="fd-message-strip__text"
     >
@@ -208,7 +220,11 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       className="fd-button fd-button--transparent fd-button--compact fd-message-strip__close"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <p
       className="fd-message-strip__text"
     >
@@ -244,7 +260,11 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       className="fd-button fd-button--transparent fd-button--compact fd-message-strip__close"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <i
+        className="sap-icon--decline"
+      />
+    </button>
     <p
       className="fd-message-strip__text"
     >

--- a/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
+++ b/src/MessageStrip/__stories__/__snapshots__/MessageStrip.stories.storyshot
@@ -36,6 +36,7 @@ exports[`Storyshots Component API/MessageStrip Dismissible 1`] = `
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -152,6 +153,7 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -185,6 +187,7 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -222,6 +225,7 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>
@@ -262,6 +266,7 @@ exports[`Storyshots Component API/MessageStrip States With Custom Content And Li
       type="button"
     >
       <i
+        aria-hidden="true"
         className="sap-icon--decline"
       />
     </button>

--- a/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
+++ b/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
@@ -51,6 +51,7 @@ exports[`Storyshots Component API/MultiInput Compact 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--value-help"
               />
             </button>
@@ -116,6 +117,7 @@ exports[`Storyshots Component API/MultiInput Dev 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--value-help"
               />
             </button>
@@ -181,6 +183,7 @@ exports[`Storyshots Component API/MultiInput Disabled 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--value-help"
               />
             </button>
@@ -242,6 +245,7 @@ exports[`Storyshots Component API/MultiInput Primary 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--value-help"
               />
             </button>
@@ -325,6 +329,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
+                            aria-hidden="true"
                             className="sap-icon--value-help"
                           />
                         </button>
@@ -403,6 +408,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
+                            aria-hidden="true"
                             className="sap-icon--value-help"
                           />
                         </button>
@@ -481,6 +487,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
+                            aria-hidden="true"
                             className="sap-icon--value-help"
                           />
                         </button>
@@ -559,6 +566,7 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
+                            aria-hidden="true"
                             className="sap-icon--value-help"
                           />
                         </button>

--- a/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
+++ b/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
@@ -51,8 +51,9 @@ exports[`Storyshots Component API/MultiInput Compact 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--value-help"
+                role="img"
               />
             </button>
           </span>
@@ -117,8 +118,9 @@ exports[`Storyshots Component API/MultiInput Dev 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--value-help"
+                role="img"
               />
             </button>
           </span>
@@ -183,8 +185,9 @@ exports[`Storyshots Component API/MultiInput Disabled 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--value-help"
+                role="img"
               />
             </button>
           </span>
@@ -245,8 +248,9 @@ exports[`Storyshots Component API/MultiInput Primary 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--value-help"
+                role="img"
               />
             </button>
           </span>
@@ -329,8 +333,9 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
-                            aria-hidden="true"
+                            aria-hidden={true}
                             className="sap-icon--value-help"
+                            role="img"
                           />
                         </button>
                       </span>
@@ -408,8 +413,9 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
-                            aria-hidden="true"
+                            aria-hidden={true}
                             className="sap-icon--value-help"
+                            role="img"
                           />
                         </button>
                       </span>
@@ -487,8 +493,9 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
-                            aria-hidden="true"
+                            aria-hidden={true}
                             className="sap-icon--value-help"
+                            role="img"
                           />
                         </button>
                       </span>
@@ -566,8 +573,9 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                           type="button"
                         >
                           <i
-                            aria-hidden="true"
+                            aria-hidden={true}
                             className="sap-icon--value-help"
+                            role="img"
                           />
                         </button>
                       </span>

--- a/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
+++ b/src/MultiInput/__stories__/__snapshots__/MultiInput.stories.storyshot
@@ -47,9 +47,13 @@ exports[`Storyshots Component API/MultiInput Compact 1`] = `
           >
             <button
               aria-label="Show options"
-              className="fd-button fd-button--transparent fd-button--compact sap-icon--value-help fd-input-group__button"
+              className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--value-help"
+              />
+            </button>
           </span>
         </div>
       </div>
@@ -108,9 +112,13 @@ exports[`Storyshots Component API/MultiInput Dev 1`] = `
           >
             <button
               aria-label="Show options"
-              className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+              className="fd-button fd-button--transparent fd-input-group__button"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--value-help"
+              />
+            </button>
           </span>
         </div>
       </div>
@@ -168,10 +176,14 @@ exports[`Storyshots Component API/MultiInput Disabled 1`] = `
           >
             <button
               aria-label="Show options"
-              className="fd-button fd-button--transparent sap-icon--value-help is-disabled fd-input-group__button"
+              className="fd-button fd-button--transparent is-disabled fd-input-group__button"
               disabled={true}
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--value-help"
+              />
+            </button>
           </span>
         </div>
       </div>
@@ -226,9 +238,13 @@ exports[`Storyshots Component API/MultiInput Primary 1`] = `
           >
             <button
               aria-label="Show options"
-              className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+              className="fd-button fd-button--transparent fd-input-group__button"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--value-help"
+              />
+            </button>
           </span>
         </div>
       </div>
@@ -305,9 +321,13 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                       >
                         <button
                           aria-label="Show options"
-                          className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+                          className="fd-button fd-button--transparent fd-input-group__button"
                           type="button"
-                        />
+                        >
+                          <i
+                            className="sap-icon--value-help"
+                          />
+                        </button>
                       </span>
                     </div>
                   </div>
@@ -379,9 +399,13 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                       >
                         <button
                           aria-label="Show options"
-                          className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+                          className="fd-button fd-button--transparent fd-input-group__button"
                           type="button"
-                        />
+                        >
+                          <i
+                            className="sap-icon--value-help"
+                          />
+                        </button>
                       </span>
                     </div>
                   </div>
@@ -453,9 +477,13 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                       >
                         <button
                           aria-label="Show options"
-                          className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+                          className="fd-button fd-button--transparent fd-input-group__button"
                           type="button"
-                        />
+                        >
+                          <i
+                            className="sap-icon--value-help"
+                          />
+                        </button>
                       </span>
                     </div>
                   </div>
@@ -527,9 +555,13 @@ exports[`Storyshots Component API/MultiInput Validation States 1`] = `
                       >
                         <button
                           aria-label="Show options"
-                          className="fd-button fd-button--transparent sap-icon--value-help fd-input-group__button"
+                          className="fd-button fd-button--transparent fd-input-group__button"
                           type="button"
-                        />
+                        >
+                          <i
+                            className="sap-icon--value-help"
+                          />
+                        </button>
                       </span>
                     </div>
                   </div>

--- a/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
+++ b/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
@@ -34,8 +34,9 @@ exports[`Storyshots Component API/Popover Dev 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--navigation-up-arrow"
+              role="img"
             />
           </button>
         </div>
@@ -72,8 +73,9 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-up-arrow"
+            role="img"
           />
         </button>
       </div>
@@ -102,8 +104,9 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--navigation-down-arrow"
+            role="img"
           />
         </button>
       </div>
@@ -134,7 +137,7 @@ exports[`Storyshots Component API/Popover No Arrow 1`] = `
           className="sap-icon--cart"
           onClick={[Function]}
           onKeyPress={[Function]}
-          role="button"
+          role="img"
           style={
             Object {
               "fontSize": "1.5rem",
@@ -216,7 +219,7 @@ exports[`Storyshots Component API/Popover No Arrow 1`] = `
           className="sap-icon--menu2"
           onClick={[Function]}
           onKeyPress={[Function]}
-          role="button"
+          role="img"
           style={
             Object {
               "fontSize": "1.5rem",
@@ -325,8 +328,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top-Start
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-up-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -362,8 +366,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-up-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -399,8 +404,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top-End
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-up-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -442,8 +448,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left-Start
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-left-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -482,8 +489,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right-Top
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-right-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -524,8 +532,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-left-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -564,8 +573,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-right-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -606,8 +616,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left-End
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-left-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -646,8 +657,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right-End
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-right-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -689,8 +701,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom-Start
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-down-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -726,8 +739,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-down-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -763,8 +777,9 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom-End
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--navigation-down-arrow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -1006,8 +1021,9 @@ exports[`Storyshots Component API/Popover With Custom Flip Container 1`] = `
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--navigation-up-arrow"
+                role="img"
               />
             </button>
           </div>

--- a/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
+++ b/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
@@ -34,6 +34,7 @@ exports[`Storyshots Component API/Popover Dev 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--navigation-up-arrow"
             />
           </button>
@@ -71,6 +72,7 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-up-arrow"
           />
         </button>
@@ -100,6 +102,7 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--navigation-down-arrow"
           />
         </button>
@@ -322,6 +325,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top-Start
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-up-arrow"
                   />
                 </button>
@@ -358,6 +362,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-up-arrow"
                   />
                 </button>
@@ -394,6 +399,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Top-End
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-up-arrow"
                   />
                 </button>
@@ -436,6 +442,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left-Start
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-left-arrow"
                   />
                 </button>
@@ -475,6 +482,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right-Top
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-right-arrow"
                   />
                 </button>
@@ -516,6 +524,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-left-arrow"
                   />
                 </button>
@@ -555,6 +564,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-right-arrow"
                   />
                 </button>
@@ -596,6 +606,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Left-End
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-left-arrow"
                   />
                 </button>
@@ -635,6 +646,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Right-End
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-right-arrow"
                   />
                 </button>
@@ -677,6 +689,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom-Start
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-down-arrow"
                   />
                 </button>
@@ -713,6 +726,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-down-arrow"
                   />
                 </button>
@@ -749,6 +763,7 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                     Bottom-End
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--navigation-down-arrow"
                   />
                 </button>
@@ -991,6 +1006,7 @@ exports[`Storyshots Component API/Popover With Custom Flip Container 1`] = `
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--navigation-up-arrow"
               />
             </button>

--- a/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
+++ b/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
@@ -130,7 +130,7 @@ exports[`Storyshots Component API/Popover No Arrow 1`] = `
       <div
         className="fd-popover__control"
       >
-        <span
+        <i
           aria-controls="fd-mocked-short-id"
           aria-expanded={false}
           aria-haspopup={true}
@@ -212,7 +212,7 @@ exports[`Storyshots Component API/Popover No Arrow 1`] = `
       <div
         className="fd-popover__control"
       >
-        <span
+        <i
           aria-controls="fd-mocked-short-id"
           aria-expanded={false}
           aria-haspopup={true}

--- a/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
+++ b/src/Popover/__stories__/__snapshots__/Popover.stories.storyshot
@@ -26,13 +26,17 @@ exports[`Storyshots Component API/Popover Dev 1`] = `
             aria-controls="fd-mocked-short-id"
             aria-expanded={false}
             aria-haspopup={true}
-            className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+            className="fd-button fd-button--transparent"
             onClick={[Function]}
             onKeyPress={[Function]}
             role="button"
             tabIndex={0}
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--navigation-up-arrow"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -59,13 +63,17 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           aria-controls="fd-mocked-short-id"
           aria-expanded={false}
           aria-haspopup={true}
-          className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+          className="fd-button fd-button--transparent"
           onClick={[Function]}
           onKeyPress={[Function]}
           role="button"
           tabIndex={0}
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-up-arrow"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -84,13 +92,17 @@ exports[`Storyshots Component API/Popover Disable Edge Detection 1`] = `
           aria-controls="fd-mocked-short-id"
           aria-expanded={false}
           aria-haspopup={true}
-          className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+          className="fd-button fd-button--transparent"
           onClick={[Function]}
           onKeyPress={[Function]}
           role="button"
           tabIndex={0}
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--navigation-down-arrow"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -224,7 +236,11 @@ exports[`Storyshots Component API/Popover Out Of Boundaries 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Show Dialog
+    <span
+      className="fd-button__text"
+    >
+      Show Dialog
+    </span>
   </button>
 </div>
 `;
@@ -293,14 +309,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-top-start-popover-placement-story"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Top-Start
+                  <span
+                    className="fd-button__text"
+                  >
+                    Top-Start
+                  </span>
+                  <i
+                    className="sap-icon--navigation-up-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -322,14 +345,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Top
+                  <span
+                    className="fd-button__text"
+                  >
+                    Top
+                  </span>
+                  <i
+                    className="sap-icon--navigation-up-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -351,14 +381,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Top-End
+                  <span
+                    className="fd-button__text"
+                  >
+                    Top-End
+                  </span>
+                  <i
+                    className="sap-icon--navigation-up-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -386,14 +423,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-left-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Left-Start
+                  <span
+                    className="fd-button__text"
+                  >
+                    Left-Start
+                  </span>
+                  <i
+                    className="sap-icon--navigation-left-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -418,80 +462,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-right-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Right-Top
-                </button>
-              </div>
-            </div>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td />
-        <td />
-        <td />
-        <td>
-          <div
-            className="fd-popover"
-          >
-            <div
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            >
-              <div
-                className="fd-popover__control"
-              >
-                <button
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-left-arrow"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  role="button"
-                  tabIndex={0}
-                  type="button"
-                >
-                  Left
-                </button>
-              </div>
-            </div>
-          </div>
-        </td>
-        <td />
-        <td />
-        <td />
-        <td>
-          <div
-            className="fd-popover"
-          >
-            <div
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            >
-              <div
-                className="fd-popover__control"
-              >
-                <button
-                  aria-controls="fd-mocked-short-id"
-                  aria-expanded={false}
-                  aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-right-arrow"
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  role="button"
-                  tabIndex={0}
-                  type="button"
-                >
-                  Right
+                  <span
+                    className="fd-button__text"
+                  >
+                    Right-Top
+                  </span>
+                  <i
+                    className="sap-icon--navigation-right-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -518,14 +503,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-left-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Left-End
+                  <span
+                    className="fd-button__text"
+                  >
+                    Left
+                  </span>
+                  <i
+                    className="sap-icon--navigation-left-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -550,14 +542,101 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-right-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Right-End
+                  <span
+                    className="fd-button__text"
+                  >
+                    Right
+                  </span>
+                  <i
+                    className="sap-icon--navigation-right-arrow"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td />
+        <td />
+        <td />
+        <td>
+          <div
+            className="fd-popover"
+          >
+            <div
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="menu"
+                  className="fd-button fd-button--transparent"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="fd-button__text"
+                  >
+                    Left-End
+                  </span>
+                  <i
+                    className="sap-icon--navigation-left-arrow"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </td>
+        <td />
+        <td />
+        <td />
+        <td>
+          <div
+            className="fd-popover"
+          >
+            <div
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="fd-popover__control"
+              >
+                <button
+                  aria-controls="fd-mocked-short-id"
+                  aria-expanded={false}
+                  aria-haspopup="menu"
+                  className="fd-button fd-button--transparent"
+                  onClick={[Function]}
+                  onKeyPress={[Function]}
+                  role="button"
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="fd-button__text"
+                  >
+                    Right-End
+                  </span>
+                  <i
+                    className="sap-icon--navigation-right-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -585,14 +664,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Bottom-Start
+                  <span
+                    className="fd-button__text"
+                  >
+                    Bottom-Start
+                  </span>
+                  <i
+                    className="sap-icon--navigation-down-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -614,14 +700,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Bottom
+                  <span
+                    className="fd-button__text"
+                  >
+                    Bottom
+                  </span>
+                  <i
+                    className="sap-icon--navigation-down-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -643,14 +736,21 @@ exports[`Storyshots Component API/Popover Placements 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup="menu"
-                  className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
                 >
-                  Bottom-End
+                  <span
+                    className="fd-button__text"
+                  >
+                    Bottom-End
+                  </span>
+                  <i
+                    className="sap-icon--navigation-down-arrow"
+                  />
                 </button>
               </div>
             </div>
@@ -714,12 +814,16 @@ exports[`Storyshots Component API/Popover Width Sizing Types 1`] = `
           tabIndex={0}
           type="button"
         >
-          widthSizingType: 
-          <strong>
-            '
-            none
-            '
-          </strong>
+          <span
+            className="fd-button__text"
+          >
+            widthSizingType: 
+            <strong>
+              '
+              none
+              '
+            </strong>
+          </span>
         </button>
       </div>
     </div>
@@ -746,12 +850,16 @@ exports[`Storyshots Component API/Popover Width Sizing Types 1`] = `
           tabIndex={0}
           type="button"
         >
-          widthSizingType: 
-          <strong>
-            '
-            matchTarget
-            '
-          </strong>
+          <span
+            className="fd-button__text"
+          >
+            widthSizingType: 
+            <strong>
+              '
+              matchTarget
+              '
+            </strong>
+          </span>
         </button>
       </div>
     </div>
@@ -778,12 +886,16 @@ exports[`Storyshots Component API/Popover Width Sizing Types 1`] = `
           tabIndex={0}
           type="button"
         >
-          widthSizingType: 
-          <strong>
-            '
-            minTarget
-            '
-          </strong>
+          <span
+            className="fd-button__text"
+          >
+            widthSizingType: 
+            <strong>
+              '
+              minTarget
+              '
+            </strong>
+          </span>
         </button>
       </div>
     </div>
@@ -810,12 +922,16 @@ exports[`Storyshots Component API/Popover Width Sizing Types 1`] = `
           tabIndex={0}
           type="button"
         >
-          widthSizingType: 
-          <strong>
-            '
-            maxTarget
-            '
-          </strong>
+          <span
+            className="fd-button__text"
+          >
+            widthSizingType: 
+            <strong>
+              '
+              maxTarget
+              '
+            </strong>
+          </span>
         </button>
       </div>
     </div>
@@ -867,13 +983,17 @@ exports[`Storyshots Component API/Popover With Custom Flip Container 1`] = `
               aria-controls="fd-mocked-short-id"
               aria-expanded={false}
               aria-haspopup={true}
-              className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+              className="fd-button fd-button--transparent"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
               tabIndex={0}
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--navigation-up-arrow"
+              />
+            </button>
           </div>
         </div>
       </div>

--- a/src/SearchInput/SearchInput.test.js
+++ b/src/SearchInput/SearchInput.test.js
@@ -199,7 +199,7 @@ describe('<SearchInput />', () => {
         // check if searchTerm state is updated
         expect(wrapper.state(['value'])).toBe(searchData[0].text);
 
-        wrapper.find('.fd-button--transparent.sap-icon--search').simulate('click');
+        wrapper.find('.fd-button--transparent').simulate('click');
 
         expect(wrapper.state(['value'])).toBe(searchData[0].text);
     });

--- a/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
+++ b/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
@@ -53,8 +53,9 @@ exports[`Storyshots Component API/SearchInput Compact 1`] = `
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--search"
+                        role="img"
                       />
                     </button>
                   </span>
@@ -126,8 +127,9 @@ exports[`Storyshots Component API/SearchInput Dev 1`] = `
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--search"
+                        role="img"
                       />
                     </button>
                   </span>
@@ -198,8 +200,9 @@ exports[`Storyshots Component API/SearchInput Disabled 1`] = `
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--search"
+                        role="img"
                       />
                     </button>
                   </span>
@@ -336,8 +339,9 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -414,8 +418,9 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -492,8 +497,9 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -570,8 +576,9 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>

--- a/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
+++ b/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
@@ -48,10 +48,14 @@ exports[`Storyshots Component API/SearchInput Compact 1`] = `
                   >
                     <button
                       aria-label="Search"
-                      className="fd-button fd-button--transparent fd-button--compact sap-icon--search fd-input-group__button"
+                      className="fd-button fd-button--transparent fd-button--compact fd-input-group__button"
                       onClick={[Function]}
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--search"
+                      />
+                    </button>
                   </span>
                 </div>
               </div>
@@ -116,10 +120,14 @@ exports[`Storyshots Component API/SearchInput Dev 1`] = `
                   >
                     <button
                       aria-label="Search"
-                      className="fd-button fd-button--transparent sap-icon--search fd-input-group__button"
+                      className="fd-button fd-button--transparent fd-input-group__button"
                       onClick={[Function]}
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--search"
+                      />
+                    </button>
                   </span>
                 </div>
               </div>
@@ -182,11 +190,15 @@ exports[`Storyshots Component API/SearchInput Disabled 1`] = `
                   >
                     <button
                       aria-label="Search"
-                      className="fd-button fd-button--transparent sap-icon--search is-disabled fd-input-group__button"
+                      className="fd-button fd-button--transparent is-disabled fd-input-group__button"
                       disabled={true}
                       onClick={[Function]}
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--search"
+                      />
+                    </button>
                   </span>
                 </div>
               </div>
@@ -316,10 +328,14 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -389,10 +405,14 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -462,10 +482,14 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -535,10 +559,14 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>

--- a/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
+++ b/src/SearchInput/__stories__/__snapshots__/SearchInput.stories.storyshot
@@ -53,6 +53,7 @@ exports[`Storyshots Component API/SearchInput Compact 1`] = `
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--search"
                       />
                     </button>
@@ -125,6 +126,7 @@ exports[`Storyshots Component API/SearchInput Dev 1`] = `
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--search"
                       />
                     </button>
@@ -196,6 +198,7 @@ exports[`Storyshots Component API/SearchInput Disabled 1`] = `
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--search"
                       />
                     </button>
@@ -333,6 +336,7 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>
@@ -410,6 +414,7 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>
@@ -487,6 +492,7 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>
@@ -564,6 +570,7 @@ exports[`Storyshots Component API/SearchInput Validation States 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import { FORM_MESSAGE_TYPES } from '../utils/constants';
 import FormMessage from '../Forms/_FormMessage';
 import FormValidationOverlay from '../Forms/_FormValidationOverlay';
+import Icon from '../Icon/Icon';
 import keycode from 'keycode';
 import List from '../List/List';
 import Popover from '../Popover/Popover';
@@ -135,7 +136,10 @@ const Select = React.forwardRef(({
                 <span aria-label={selectAriaLabel} className={textContentClassNames}>{textContent}</span>
                 {!readOnly &&
                     <span className={triggerClassNames}>
-                        <i className='sap-icon--slim-arrow-down' />
+                        <Icon
+                            ariaHidden
+                            glyph='slim-arrow-down'
+                            isInButton />
                     </span>
                 }
             </div>

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -138,8 +138,7 @@ const Select = React.forwardRef(({
                     <span className={triggerClassNames}>
                         <Icon
                             ariaHidden
-                            glyph='slim-arrow-down'
-                            isInButton />
+                            glyph='slim-arrow-down' />
                     </span>
                 }
             </div>

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -105,7 +105,6 @@ const Select = React.forwardRef(({
     const triggerClassNames = classnames(
         'fd-button',
         'fd-button--transparent',
-        'sap-icon--slim-arrow-down',
         'fd-select__button',
         triggerClassName
     );
@@ -134,7 +133,11 @@ const Select = React.forwardRef(({
             ref={divRef}>
             <div className={selectControlClasses}>
                 <span aria-label={selectAriaLabel} className={textContentClassNames}>{textContent}</span>
-                {!readOnly && <span className={triggerClassNames} />}
+                {!readOnly &&
+                    <span className={triggerClassNames}>
+                        <i className='sap-icon--slim-arrow-down' />
+                    </span>
+                }
             </div>
         </div>
     );

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -49,8 +49,12 @@ exports[`Storyshots Component API/Select Compact 1`] = `
                     Select
                   </span>
                   <span
-                    className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                  />
+                    className="fd-button fd-button--transparent fd-select__button"
+                  >
+                    <i
+                      className="sap-icon--slim-arrow-down"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
@@ -113,8 +117,12 @@ exports[`Storyshots Component API/Select Dev 1`] = `
                     select
                   </span>
                   <span
-                    className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                  />
+                    className="fd-button fd-button--transparent fd-select__button"
+                  >
+                    <i
+                      className="sap-icon--slim-arrow-down"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
@@ -172,8 +180,12 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
                     Select
                   </span>
                   <span
-                    className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                  />
+                    className="fd-button fd-button--transparent fd-select__button"
+                  >
+                    <i
+                      className="sap-icon--slim-arrow-down"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
@@ -232,8 +244,12 @@ exports[`Storyshots Component API/Select Empty Option 1`] = `
                     className="fd-select__text-content"
                   />
                   <span
-                    className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                  />
+                    className="fd-button fd-button--transparent fd-select__button"
+                  >
+                    <i
+                      className="sap-icon--slim-arrow-down"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
@@ -294,8 +310,12 @@ exports[`Storyshots Component API/Select Primary 1`] = `
                     Select
                   </span>
                   <span
-                    className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                  />
+                    className="fd-button fd-button--transparent fd-select__button"
+                  >
+                    <i
+                      className="sap-icon--slim-arrow-down"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
@@ -415,8 +435,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       Error
                     </span>
                     <span
-                      className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                    />
+                      className="fd-button fd-button--transparent fd-select__button"
+                    >
+                      <i
+                        className="sap-icon--slim-arrow-down"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -470,8 +494,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       Warning
                     </span>
                     <span
-                      className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                    />
+                      className="fd-button fd-button--transparent fd-select__button"
+                    >
+                      <i
+                        className="sap-icon--slim-arrow-down"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -525,8 +553,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       Success
                     </span>
                     <span
-                      className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                    />
+                      className="fd-button fd-button--transparent fd-select__button"
+                    >
+                      <i
+                        className="sap-icon--slim-arrow-down"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -580,8 +612,12 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       Information
                     </span>
                     <span
-                      className="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"
-                    />
+                      className="fd-button fd-button--transparent fd-select__button"
+                    >
+                      <i
+                        className="sap-icon--slim-arrow-down"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/Select/__stories__/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__stories__/__snapshots__/Select.stories.storyshot
@@ -52,7 +52,9 @@ exports[`Storyshots Component API/Select Compact 1`] = `
                     className="fd-button fd-button--transparent fd-select__button"
                   >
                     <i
+                      aria-hidden={true}
                       className="sap-icon--slim-arrow-down"
+                      role="img"
                     />
                   </span>
                 </div>
@@ -120,7 +122,9 @@ exports[`Storyshots Component API/Select Dev 1`] = `
                     className="fd-button fd-button--transparent fd-select__button"
                   >
                     <i
+                      aria-hidden={true}
                       className="sap-icon--slim-arrow-down"
+                      role="img"
                     />
                   </span>
                 </div>
@@ -183,7 +187,9 @@ exports[`Storyshots Component API/Select Disabled 1`] = `
                     className="fd-button fd-button--transparent fd-select__button"
                   >
                     <i
+                      aria-hidden={true}
                       className="sap-icon--slim-arrow-down"
+                      role="img"
                     />
                   </span>
                 </div>
@@ -247,7 +253,9 @@ exports[`Storyshots Component API/Select Empty Option 1`] = `
                     className="fd-button fd-button--transparent fd-select__button"
                   >
                     <i
+                      aria-hidden={true}
                       className="sap-icon--slim-arrow-down"
+                      role="img"
                     />
                   </span>
                 </div>
@@ -313,7 +321,9 @@ exports[`Storyshots Component API/Select Primary 1`] = `
                     className="fd-button fd-button--transparent fd-select__button"
                   >
                     <i
+                      aria-hidden={true}
                       className="sap-icon--slim-arrow-down"
+                      role="img"
                     />
                   </span>
                 </div>
@@ -438,7 +448,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       className="fd-button fd-button--transparent fd-select__button"
                     >
                       <i
+                        aria-hidden={true}
                         className="sap-icon--slim-arrow-down"
+                        role="img"
                       />
                     </span>
                   </div>
@@ -497,7 +509,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       className="fd-button fd-button--transparent fd-select__button"
                     >
                       <i
+                        aria-hidden={true}
                         className="sap-icon--slim-arrow-down"
+                        role="img"
                       />
                     </span>
                   </div>
@@ -556,7 +570,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       className="fd-button fd-button--transparent fd-select__button"
                     >
                       <i
+                        aria-hidden={true}
                         className="sap-icon--slim-arrow-down"
+                        role="img"
                       />
                     </span>
                   </div>
@@ -615,7 +631,9 @@ exports[`Storyshots Component API/Select Validation States 1`] = `
                       className="fd-button fd-button--transparent fd-select__button"
                     >
                       <i
+                        aria-hidden={true}
                         className="sap-icon--slim-arrow-down"
+                        role="img"
                       />
                     </span>
                   </div>

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -167,10 +167,9 @@ class Shellbar extends Component {
                             control={
                                 <Button
                                     className='fd-shellbar__button--menu fd-button--menu'
-                                    option='transparent'>
-                                    <span className='fd-shellbar__title'>
-                                        {productTitle}
-                                    </span>
+                                    option='transparent'
+                                    textClassName='fd-shellbar__title'>
+                                    {productTitle}
                                 </Button>
                             }
                             noArrow

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -168,7 +168,7 @@ class Shellbar extends Component {
                                 <Button
                                     className='fd-shellbar__button--menu fd-button--menu'
                                     glyph='megamenu'
-                                    iconClassName='fd-shellbar__button--icon'
+                                    iconProps={{ className: 'fd-shellbar__button--icon' }}
                                     option='transparent'
                                     textClassName='fd-shellbar__title'>
                                     {productTitle}

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -167,6 +167,8 @@ class Shellbar extends Component {
                             control={
                                 <Button
                                     className='fd-shellbar__button--menu fd-button--menu'
+                                    glyph='megamenu'
+                                    iconClassName='fd-shellbar__button--icon'
                                     option='transparent'
                                     textClassName='fd-shellbar__title'>
                                     {productTitle}
@@ -217,7 +219,8 @@ class Shellbar extends Component {
                                                     <Button
                                                         aria-label={action.label}
                                                         className='fd-shellbar__button'
-                                                        glyph={action.glyph}>
+                                                        glyph={action.glyph}
+                                                        iconBeforeText>
                                                         {action.notificationCount > 0 && (
                                                             <Counter
                                                                 aria-label={localizedText.counterLabel}
@@ -235,8 +238,9 @@ class Shellbar extends Component {
                                                 aria-label={action.label}
                                                 className='fd-shellbar__button'
                                                 glyph={action.glyph}
+                                                iconBeforeText
                                                 key={index}
-                                                onClick={action.callback} >
+                                                onClick={action.callback}>
                                                 {action.notificationCount > 0 && (
                                                     <Counter
                                                         aria-label={localizedText.counterLabel}
@@ -261,7 +265,8 @@ class Shellbar extends Component {
                                         <Button
                                             aria-label={localizedText.notificationsButton}
                                             className='fd-shellbar__button'
-                                            glyph='bell'>
+                                            glyph='bell'
+                                            iconBeforeText>
                                             {notifications.notificationCount > 0 && (
                                                 <Counter
                                                     aria-label={localizedText.counterLabel}
@@ -280,6 +285,7 @@ class Shellbar extends Component {
                                     aria-label={localizedText.notificationsButton}
                                     className='fd-shellbar__button'
                                     glyph='bell'
+                                    iconBeforeText
                                     onClick={notifications.callback}>
                                     {notifications.notificationCount > 0 && (
                                         <Counter

--- a/src/Shellbar/Shellbar.test.js
+++ b/src/Shellbar/Shellbar.test.js
@@ -147,7 +147,7 @@ describe('<Shellbar />', () => {
 
         wrapper.find('.fd-popover__control .fd-shellbar-collapse--control').simulate('click');
 
-        wrapper.find('a.fd-menu__link span.sap-icon--grid').simulate('click');
+        wrapper.find('a.fd-menu__link i.sap-icon--grid').simulate('click');
         wrapper.find('span.fd-menu.sap-icon--nav-back').simulate('click');
 
         expect(wrapper.state(['showCollapsedProductSwitchMenu'])).toBeFalsy();

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -105,6 +105,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               className="fd-button fd-button--transparent fd-shellbar__button--menu fd-button--menu"
+              iconClassName="fd-shellbar__button--icon"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -117,8 +118,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 Corporate Portal
               </span>
               <i
-                aria-hidden="true"
-                className="sap-icon--megamenu fd-shellbar__button--icon"
+                aria-hidden={true}
+                className="sap-icon--megamenu"
+                role="img"
               />
             </button>
           </div>
@@ -196,8 +198,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -237,8 +240,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--settings"
+                  role="img"
                 />
                 <span
                   className="fd-button__text"
@@ -282,8 +286,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--bell"
+                  role="img"
                 />
                 <span
                   className="fd-button__text"
@@ -341,8 +346,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                     </span>
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--overflow"
+                    role="img"
                   />
                 </button>
               </div>
@@ -419,8 +425,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--grid"
+                    role="img"
                   />
                 </button>
               </div>
@@ -450,8 +457,9 @@ exports[`Storyshots Component API/Shellbar With Back Button 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--nav-back"
+          role="img"
         />
       </button>
       <span
@@ -549,6 +557,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               className="fd-button fd-button--transparent fd-shellbar__button--menu fd-button--menu"
+              iconClassName="fd-shellbar__button--icon"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -561,8 +570,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                 Corporate Portal
               </span>
               <i
-                aria-hidden="true"
-                className="sap-icon--megamenu fd-shellbar__button--icon"
+                aria-hidden={true}
+                className="sap-icon--megamenu"
+                role="img"
               />
             </button>
           </div>
@@ -630,8 +640,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                             type="button"
                           >
                             <i
-                              aria-hidden="true"
+                              aria-hidden={true}
                               className="sap-icon--search"
+                              role="img"
                             />
                           </button>
                         </span>
@@ -653,8 +664,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--bell"
+            role="img"
           />
           <span
             className="fd-button__text"
@@ -709,8 +721,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                     </span>
                   </span>
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--overflow"
+                    role="img"
                   />
                 </button>
               </div>

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -112,7 +112,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
               type="button"
             >
               <span
-                className="fd-shellbar__title"
+                className="fd-button__text fd-shellbar__title"
               >
                 Corporate Portal
               </span>
@@ -187,10 +187,14 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-shellbar__button fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-shellbar__button fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -220,7 +224,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Settings"
-                className="fd-button sap-icon--settings fd-shellbar__button"
+                className="fd-button fd-shellbar__button"
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 role="button"
@@ -228,11 +232,18 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 type="button"
               >
                 <span
-                  aria-label="Unread count"
-                  className="fd-counter fd-counter--notification fd-shellbar__counter--notification"
+                  className="fd-button__text"
                 >
-                  5
+                  <span
+                    aria-label="Unread count"
+                    className="fd-counter fd-counter--notification fd-shellbar__counter--notification"
+                  >
+                    5
+                  </span>
                 </span>
+                <i
+                  className="sap-icon--settings"
+                />
               </button>
             </div>
           </div>
@@ -261,15 +272,22 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
             >
               <button
                 aria-label="Notifications"
-                className="fd-button sap-icon--bell fd-shellbar__button"
+                className="fd-button fd-shellbar__button"
                 type="button"
               >
                 <span
-                  aria-label="Unread count"
-                  className="fd-counter fd-counter--notification"
+                  className="fd-button__text"
                 >
-                  2
+                  <span
+                    aria-label="Unread count"
+                    className="fd-counter fd-counter--notification"
+                  >
+                    2
+                  </span>
                 </span>
+                <i
+                  className="sap-icon--bell"
+                />
               </button>
             </div>
           </div>
@@ -300,17 +318,24 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 tabIndex={0}
               >
                 <button
-                  className="fd-button sap-icon--overflow fd-shellbar__button"
+                  className="fd-button fd-shellbar__button"
                   type="button"
                 >
                   <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
+                    className="fd-button__text"
                   >
-                     
-                    7
-                     
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      7
+                       
+                    </span>
                   </span>
+                  <i
+                    className="sap-icon--overflow"
+                  />
                 </button>
               </div>
             </div>
@@ -378,13 +403,17 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                   aria-expanded={false}
                   aria-haspopup={true}
                   aria-label="Product Switch"
-                  className="fd-button sap-icon--grid fd-product-switch__control fd-shellbar__button"
+                  className="fd-button fd-product-switch__control fd-shellbar__button"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--grid"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -407,10 +436,14 @@ exports[`Storyshots Component API/Shellbar With Back Button 1`] = `
     >
       <button
         aria-label="Back button"
-        className="fd-button fd-button--transparent sap-icon--nav-back fd-shellbar__button"
+        className="fd-button fd-button--transparent fd-shellbar__button"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--nav-back"
+        />
+      </button>
       <span
         className="fd-shellbar__logo"
       >
@@ -513,7 +546,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               type="button"
             >
               <span
-                className="fd-shellbar__title"
+                className="fd-button__text fd-shellbar__title"
               >
                 Corporate Portal
               </span>
@@ -578,10 +611,14 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                         >
                           <button
                             aria-label="Search"
-                            className="fd-button fd-button--transparent sap-icon--search fd-shellbar__button fd-input-group__button"
+                            className="fd-button fd-button--transparent fd-shellbar__button fd-input-group__button"
                             onClick={[Function]}
                             type="button"
-                          />
+                          >
+                            <i
+                              className="sap-icon--search"
+                            />
+                          </button>
                         </span>
                       </div>
                     </div>
@@ -597,15 +634,22 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
       >
         <button
           aria-label="Notifications"
-          className="fd-button sap-icon--bell fd-shellbar__button"
+          className="fd-button fd-shellbar__button"
           type="button"
         >
           <span
-            aria-label="Unread count"
-            className="fd-counter fd-counter--notification"
+            className="fd-button__text"
           >
-            2
+            <span
+              aria-label="Unread count"
+              className="fd-counter fd-counter--notification"
+            >
+              2
+            </span>
           </span>
+          <i
+            className="sap-icon--bell"
+          />
         </button>
       </div>
       <div
@@ -633,17 +677,24 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                 tabIndex={0}
               >
                 <button
-                  className="fd-button sap-icon--overflow fd-shellbar__button"
+                  className="fd-button fd-shellbar__button"
                   type="button"
                 >
                   <span
-                    aria-label="Unread count"
-                    className="fd-counter fd-counter--notification"
+                    className="fd-button__text"
                   >
-                     
-                    2
-                     
+                    <span
+                      aria-label="Unread count"
+                      className="fd-counter fd-counter--notification"
+                    >
+                       
+                      2
+                       
+                    </span>
                   </span>
+                  <i
+                    className="sap-icon--overflow"
+                  />
                 </button>
               </div>
             </div>

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -105,7 +105,6 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               className="fd-button fd-button--transparent fd-shellbar__button--menu fd-button--menu"
-              iconClassName="fd-shellbar__button--icon"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -119,7 +118,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
               </span>
               <i
                 aria-hidden={true}
-                className="sap-icon--megamenu"
+                className="sap-icon--megamenu fd-shellbar__button--icon"
                 role="img"
               />
             </button>
@@ -557,7 +556,6 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               className="fd-button fd-button--transparent fd-shellbar__button--menu fd-button--menu"
-              iconClassName="fd-shellbar__button--icon"
               onClick={[Function]}
               onKeyPress={[Function]}
               role="button"
@@ -571,7 +569,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               </span>
               <i
                 aria-hidden={true}
-                className="sap-icon--megamenu"
+                className="sap-icon--megamenu fd-shellbar__button--icon"
                 role="img"
               />
             </button>

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -116,6 +116,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
               >
                 Corporate Portal
               </span>
+              <i
+                className="sap-icon--megamenu fd-shellbar__button--icon"
+              />
             </button>
           </div>
         </div>
@@ -231,6 +234,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 tabIndex={0}
                 type="button"
               >
+                <i
+                  className="sap-icon--settings"
+                />
                 <span
                   className="fd-button__text"
                 >
@@ -241,9 +247,6 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                     5
                   </span>
                 </span>
-                <i
-                  className="sap-icon--settings"
-                />
               </button>
             </div>
           </div>
@@ -275,6 +278,9 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 className="fd-button fd-shellbar__button"
                 type="button"
               >
+                <i
+                  className="sap-icon--bell"
+                />
                 <span
                   className="fd-button__text"
                 >
@@ -285,9 +291,6 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                     2
                   </span>
                 </span>
-                <i
-                  className="sap-icon--bell"
-                />
               </button>
             </div>
           </div>
@@ -550,6 +553,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               >
                 Corporate Portal
               </span>
+              <i
+                className="sap-icon--megamenu fd-shellbar__button--icon"
+              />
             </button>
           </div>
         </div>
@@ -637,6 +643,9 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
           className="fd-button fd-shellbar__button"
           type="button"
         >
+          <i
+            className="sap-icon--bell"
+          />
           <span
             className="fd-button__text"
           >
@@ -647,9 +656,6 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
               2
             </span>
           </span>
-          <i
-            className="sap-icon--bell"
-          />
         </button>
       </div>
       <div

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -117,6 +117,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 Corporate Portal
               </span>
               <i
+                aria-hidden="true"
                 className="sap-icon--megamenu fd-shellbar__button--icon"
               />
             </button>
@@ -195,6 +196,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>
@@ -235,6 +237,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--settings"
                 />
                 <span
@@ -279,6 +282,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--bell"
                 />
                 <span
@@ -337,6 +341,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                     </span>
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--overflow"
                   />
                 </button>
@@ -414,6 +419,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--grid"
                   />
                 </button>
@@ -444,6 +450,7 @@ exports[`Storyshots Component API/Shellbar With Back Button 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--nav-back"
         />
       </button>
@@ -554,6 +561,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                 Corporate Portal
               </span>
               <i
+                aria-hidden="true"
                 className="sap-icon--megamenu fd-shellbar__button--icon"
               />
             </button>
@@ -622,6 +630,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                             type="button"
                           >
                             <i
+                              aria-hidden="true"
                               className="sap-icon--search"
                             />
                           </button>
@@ -644,6 +653,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--bell"
           />
           <span
@@ -699,6 +709,7 @@ exports[`Storyshots Component API/Shellbar With Product Menu 1`] = `
                     </span>
                   </span>
                   <i
+                    aria-hidden="true"
                     className="sap-icon--overflow"
                   />
                 </button>

--- a/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
+++ b/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
@@ -29,6 +29,7 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -46,6 +47,7 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -85,6 +87,7 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -104,6 +107,7 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -144,6 +148,7 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -163,6 +168,7 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -202,6 +208,7 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -219,6 +226,7 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -258,6 +266,7 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -275,6 +284,7 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -314,6 +324,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -332,6 +343,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -364,6 +376,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -382,6 +395,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -414,6 +428,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -432,6 +447,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>
@@ -464,6 +480,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--less"
             />
           </button>
@@ -482,6 +499,7 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
+              aria-hidden="true"
               className="sap-icon--add"
             />
           </button>

--- a/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
+++ b/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
@@ -29,8 +29,9 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -47,8 +48,9 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -87,8 +89,9 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -107,8 +110,9 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -148,8 +152,9 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -168,8 +173,9 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -208,8 +214,9 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -226,8 +233,9 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -266,8 +274,9 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -284,8 +293,9 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -324,8 +334,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -343,8 +354,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -376,8 +388,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -395,8 +408,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -428,8 +442,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -447,8 +462,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>
@@ -480,8 +496,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--less"
+              role="img"
             />
           </button>
           <input
@@ -499,8 +516,9 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
             type="button"
           >
             <i
-              aria-hidden="true"
+              aria-hidden={true}
               className="sap-icon--add"
+              role="img"
             />
           </button>
         </div>

--- a/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
+++ b/src/StepInput/__stories__/__snapshots__/StepInput.stories.storyshot
@@ -23,11 +23,15 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent fd-button--compact sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-button--compact fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -36,11 +40,15 @@ exports[`Storyshots Component API/StepInput Compact 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent fd-button--compact sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-button--compact fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -71,11 +79,15 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             disabled={false}
@@ -86,11 +98,15 @@ exports[`Storyshots Component API/StepInput Dev 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -121,12 +137,16 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less is-disabled fd-step-input__button"
+            className="fd-button fd-button--transparent is-disabled fd-step-input__button"
             disabled={true}
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             disabled={true}
@@ -136,12 +156,16 @@ exports[`Storyshots Component API/StepInput Disabled 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add is-disabled fd-step-input__button"
+            className="fd-button fd-button--transparent is-disabled fd-step-input__button"
             disabled={true}
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -172,11 +196,15 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -185,11 +213,15 @@ exports[`Storyshots Component API/StepInput Primary 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -220,11 +252,15 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -233,11 +269,15 @@ exports[`Storyshots Component API/StepInput Read Only 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -268,11 +308,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -282,11 +326,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -310,11 +358,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -324,11 +376,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -352,11 +408,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -366,11 +426,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>
@@ -394,11 +458,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
         >
           <button
             aria-label="Step Down"
-            className="fd-button fd-button--transparent sap-icon--less fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--less"
+            />
+          </button>
           <input
             className="fd-input fd-input--no-number-spinner fd-step-input__input"
             onChange={[Function]}
@@ -408,11 +476,15 @@ exports[`Storyshots Component API/StepInput Validation States 1`] = `
           />
           <button
             aria-label="Step Up"
-            className="fd-button fd-button--transparent sap-icon--add fd-step-input__button"
+            className="fd-button fd-button--transparent fd-step-input__button"
             onClick={[Function]}
             tabIndex="-1"
             type="button"
-          />
+          >
+            <i
+              className="sap-icon--add"
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/src/Table/__stories__/__snapshots__/Table.stories.storyshot
+++ b/src/Table/__stories__/__snapshots__/Table.stories.storyshot
@@ -249,6 +249,7 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--vertical-grip"
                   />
                 </button>
@@ -346,6 +347,7 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--vertical-grip"
                   />
                 </button>
@@ -443,6 +445,7 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--vertical-grip"
                   />
                 </button>
@@ -540,6 +543,7 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--vertical-grip"
                   />
                 </button>

--- a/src/Table/__stories__/__snapshots__/Table.stories.storyshot
+++ b/src/Table/__stories__/__snapshots__/Table.stories.storyshot
@@ -249,8 +249,9 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--vertical-grip"
+                    role="img"
                   />
                 </button>
               </div>
@@ -347,8 +348,9 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--vertical-grip"
+                    role="img"
                   />
                 </button>
               </div>
@@ -445,8 +447,9 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--vertical-grip"
+                    role="img"
                   />
                 </button>
               </div>
@@ -543,8 +546,9 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--vertical-grip"
+                    role="img"
                   />
                 </button>
               </div>

--- a/src/Table/__stories__/__snapshots__/Table.stories.storyshot
+++ b/src/Table/__stories__/__snapshots__/Table.stories.storyshot
@@ -241,13 +241,17 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup={true}
-                  className="fd-button fd-button--transparent sap-icon--vertical-grip"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--vertical-grip"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -334,13 +338,17 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup={true}
-                  className="fd-button fd-button--transparent sap-icon--vertical-grip"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--vertical-grip"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -427,13 +435,17 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup={true}
-                  className="fd-button fd-button--transparent sap-icon--vertical-grip"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--vertical-grip"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -520,13 +532,17 @@ exports[`Storyshots Component API/Table Rich Table 1`] = `
                   aria-controls="fd-mocked-short-id"
                   aria-expanded={false}
                   aria-haspopup={true}
-                  className="fd-button fd-button--transparent sap-icon--vertical-grip"
+                  className="fd-button fd-button--transparent"
                   onClick={[Function]}
                   onKeyPress={[Function]}
                   role="button"
                   tabIndex={0}
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--vertical-grip"
+                  />
+                </button>
               </div>
             </div>
           </div>

--- a/src/Time/Time.test.js
+++ b/src/Time/Time.test.js
@@ -20,9 +20,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual('12');
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
 
@@ -30,9 +30,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual('00');
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').minute).toEqual(1);
     });
@@ -44,9 +44,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(22);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(23);
 
@@ -54,22 +54,22 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(34);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').minute).toEqual(35);
     });
-    //TO DO: what is this test even trying to test?
-    xtest('time number down click on merdiem time', () => {
+
+    test('time number down click on merdiem time', () => {
         const wrapper = mount(meridiemTime);
         // hour timer click down
-        expect(wrapper.state('time').hour).toEqual(12);
+        expect(wrapper.state('time').hour).toEqual('12');
         // 3 down clicks
         for (let i = 0; i < 3; i += 1) {
             wrapper
                 .find(
-                    'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                    'button.fd-button--transparent'
                 )
                 .at(0)
                 .simulate('click');
@@ -77,12 +77,12 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(9);
 
         // minute timer click down
-        expect(wrapper.state('time').minute).toEqual(0);
+        expect(wrapper.state('time').minute).toEqual('00');
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(2)
             .simulate('click');
         expect(wrapper.state('time').minute).toEqual(59);
     });
@@ -94,7 +94,7 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual('12');
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
             .at(0)
             .simulate('click');
@@ -104,9 +104,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual('00');
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(2)
             .simulate('click');
         expect(wrapper.state('time').minute).toEqual(59);
     });
@@ -122,9 +122,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(3)
+            .at(7)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -141,7 +141,7 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
             .at(0)
             .simulate('click');
@@ -158,7 +158,7 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(1);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
             .at(0)
             .simulate('click');
@@ -176,7 +176,7 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(12);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
             .at(0)
             .simulate('click');
@@ -196,9 +196,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(2)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -213,9 +213,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(2)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -231,9 +231,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(2)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(11);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -251,9 +251,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(4)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(23);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -268,9 +268,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(4)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -286,9 +286,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(4)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(11);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -307,9 +307,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(3)
+            .at(6)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -326,9 +326,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -343,9 +343,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(23);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
 
@@ -358,9 +358,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(1);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(2);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -376,9 +376,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(12);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -394,9 +394,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').hour).toEqual(11);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(0)
+            .at(1)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').meridiem).toEqual(1);
@@ -412,9 +412,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(1);
@@ -429,9 +429,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(59);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -445,9 +445,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(1);
@@ -465,9 +465,9 @@ describe('<Time />', () => {
 
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -483,9 +483,9 @@ describe('<Time />', () => {
 
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -500,9 +500,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(1);
@@ -518,9 +518,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').minute).toEqual(59);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(1)
+            .at(3)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -538,9 +538,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(59);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(4)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(58);
@@ -555,9 +555,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(59);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(5)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(1);
         expect(wrapper.state('time').minute).toEqual(0);
@@ -566,9 +566,9 @@ describe('<Time />', () => {
         // expect(wrapper.state('time').second).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-up-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(4)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(0);
         expect(wrapper.state('time').minute).toEqual(59);
@@ -584,9 +584,9 @@ describe('<Time />', () => {
         expect(wrapper.state('time').second).toEqual(0);
         wrapper
             .find(
-                'button.fd-button--transparent.sap-icon--navigation-down-arrow'
+                'button.fd-button--transparent'
             )
-            .at(2)
+            .at(5)
             .simulate('click');
         expect(wrapper.state('time').hour).toEqual(12);
         expect(wrapper.state('time').minute).toEqual(0);

--- a/src/Time/__stories__/__snapshots__/Time.stories.storyshot
+++ b/src/Time/__stories__/__snapshots__/Time.stories.storyshot
@@ -24,8 +24,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -116,8 +117,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -137,8 +139,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -158,8 +161,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -179,8 +183,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -200,8 +205,9 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -234,8 +240,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -327,8 +334,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -349,8 +357,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -371,8 +380,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -393,8 +403,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -415,8 +426,9 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -449,8 +461,9 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -541,8 +554,9 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -562,8 +576,9 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -583,8 +598,9 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -616,8 +632,9 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -708,8 +725,9 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -730,8 +748,9 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -751,8 +770,9 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -784,8 +804,9 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -876,8 +897,9 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -897,8 +919,9 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -918,8 +941,9 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -953,8 +977,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1045,8 +1070,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1066,8 +1092,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1087,8 +1114,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1108,8 +1136,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1129,8 +1158,9 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1162,8 +1192,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1254,8 +1285,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1275,8 +1307,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1296,8 +1329,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1317,8 +1351,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1338,8 +1373,9 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1371,8 +1407,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1463,8 +1500,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1484,8 +1522,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1505,8 +1544,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1526,8 +1566,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1547,8 +1588,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1567,8 +1609,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1588,8 +1631,9 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1621,8 +1665,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1713,8 +1758,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1734,8 +1780,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1755,8 +1802,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1776,8 +1824,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1797,8 +1846,9 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1830,8 +1880,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1922,8 +1973,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1943,8 +1995,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -1964,8 +2017,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -1985,8 +2039,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -2006,8 +2061,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>
@@ -2026,8 +2082,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-up-arrow"
+          role="img"
         />
       </button>
       <div
@@ -2047,8 +2104,9 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className="sap-icon--navigation-down-arrow"
+          role="img"
         />
       </button>
     </div>

--- a/src/Time/__stories__/__snapshots__/Time.stories.storyshot
+++ b/src/Time/__stories__/__snapshots__/Time.stories.storyshot
@@ -24,6 +24,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -115,6 +116,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -135,6 +137,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -155,6 +158,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -175,6 +179,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -195,6 +200,7 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -228,6 +234,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -320,6 +327,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -341,6 +349,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -362,6 +371,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -383,6 +393,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -404,6 +415,7 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -437,6 +449,7 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -528,6 +541,7 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -548,6 +562,7 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -568,6 +583,7 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -600,6 +616,7 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -691,6 +708,7 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -712,6 +730,7 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -732,6 +751,7 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -764,6 +784,7 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -855,6 +876,7 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -875,6 +897,7 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -895,6 +918,7 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -929,6 +953,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1020,6 +1045,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1040,6 +1066,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1060,6 +1087,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1080,6 +1108,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1100,6 +1129,7 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1132,6 +1162,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1223,6 +1254,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1243,6 +1275,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1263,6 +1296,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1283,6 +1317,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1303,6 +1338,7 @@ exports[`Storyshots Component API/Time Primary 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1335,6 +1371,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1426,6 +1463,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1446,6 +1484,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1466,6 +1505,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1486,6 +1526,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1506,6 +1547,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1525,6 +1567,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1545,6 +1588,7 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1577,6 +1621,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1668,6 +1713,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1688,6 +1734,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1708,6 +1755,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1728,6 +1776,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1748,6 +1797,7 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1780,6 +1830,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1871,6 +1922,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1891,6 +1943,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1911,6 +1964,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1931,6 +1985,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1951,6 +2006,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>
@@ -1970,6 +2026,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-up-arrow"
         />
       </button>
@@ -1990,6 +2047,7 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
         type="button"
       >
         <i
+          aria-hidden="true"
           className="sap-icon--navigation-down-arrow"
         />
       </button>

--- a/src/Time/__stories__/__snapshots__/Time.stories.storyshot
+++ b/src/Time/__stories__/__snapshots__/Time.stories.storyshot
@@ -19,10 +19,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -106,10 +110,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -122,10 +130,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -138,10 +150,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -154,10 +170,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -170,10 +190,14 @@ exports[`Storyshots Component API/Time Custom Time 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -198,11 +222,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -286,11 +314,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -303,11 +335,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -320,11 +356,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -337,11 +377,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -354,11 +398,15 @@ exports[`Storyshots Component API/Time Disabled Time 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow is-disabled"
+        className="fd-button fd-button--transparent is-disabled"
         disabled={true}
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -384,10 +432,14 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -471,10 +523,14 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -487,10 +543,14 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -503,10 +563,14 @@ exports[`Storyshots Component API/Time Hide Hours 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -531,10 +595,14 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -618,10 +686,14 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
     <div
@@ -635,10 +707,14 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -651,10 +727,14 @@ exports[`Storyshots Component API/Time Hide Minutes 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -679,10 +759,14 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -766,10 +850,14 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -782,10 +870,14 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -798,10 +890,14 @@ exports[`Storyshots Component API/Time Hide Seconds 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
     
@@ -828,10 +924,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -915,10 +1015,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -931,10 +1035,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -947,10 +1055,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -963,10 +1075,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -979,10 +1095,14 @@ exports[`Storyshots Component API/Time Meridiem Time 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -1007,10 +1127,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -1094,10 +1218,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1110,10 +1238,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1126,10 +1258,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1142,10 +1278,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1158,10 +1298,14 @@ exports[`Storyshots Component API/Time Primary 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -1186,10 +1330,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -1273,10 +1421,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1289,10 +1441,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1305,10 +1461,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1321,10 +1481,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1337,10 +1501,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1352,10 +1520,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </label>
       <button
         aria-label="Increase period"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--meridian"
       >
@@ -1368,10 +1540,14 @@ exports[`Storyshots Component API/Time Time 12 Set 1`] = `
       </div>
       <button
         aria-label="Decrease period"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
   </div>
 </div>
@@ -1396,10 +1572,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -1483,10 +1663,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1499,10 +1683,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1515,10 +1703,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1531,10 +1723,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1547,10 +1743,14 @@ exports[`Storyshots Component API/Time Time Meridiem Set 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     
   </div>
@@ -1575,10 +1775,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </label>
       <button
         aria-label="Increase hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--active"
       >
@@ -1662,10 +1866,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1678,10 +1886,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </label>
       <button
         aria-label="Increase minutes"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1694,10 +1906,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </div>
       <button
         aria-label="Decrease hours"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1710,10 +1926,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </label>
       <button
         aria-label="Increase seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper"
       >
@@ -1726,10 +1946,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </div>
       <button
         aria-label="Decrease seconds"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
     <div
       className="fd-time__col"
@@ -1741,10 +1965,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </label>
       <button
         aria-label="Increase period"
-        className="fd-button fd-button--transparent sap-icon--navigation-up-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-up-arrow"
+        />
+      </button>
       <div
         className="fd-time__wrapper fd-time__wrapper--meridian"
       >
@@ -1757,10 +1985,14 @@ exports[`Storyshots Component API/Time Twelve Hour 1`] = `
       </div>
       <button
         aria-label="Decrease period"
-        className="fd-button fd-button--transparent sap-icon--navigation-down-arrow"
+        className="fd-button fd-button--transparent"
         onClick={[Function]}
         type="button"
-      />
+      >
+        <i
+          className="sap-icon--navigation-down-arrow"
+        />
+      </button>
     </div>
   </div>
 </div>

--- a/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
+++ b/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
@@ -54,8 +54,9 @@ exports[`Storyshots Component API/TimePicker Disabled 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--time-entry-request"
+                  role="img"
                 />
               </button>
             </span>
@@ -119,8 +120,9 @@ exports[`Storyshots Component API/TimePicker Format 12 Hours 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--time-entry-request"
+                  role="img"
                 />
               </button>
             </span>
@@ -184,8 +186,9 @@ exports[`Storyshots Component API/TimePicker Hide Seconds 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--time-entry-request"
+                  role="img"
                 />
               </button>
             </span>
@@ -249,8 +252,9 @@ exports[`Storyshots Component API/TimePicker Initial Value 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--time-entry-request"
+                  role="img"
                 />
               </button>
             </span>
@@ -314,8 +318,9 @@ exports[`Storyshots Component API/TimePicker Primary 1`] = `
                 type="button"
               >
                 <i
-                  aria-hidden="true"
+                  aria-hidden={true}
                   className="sap-icon--time-entry-request"
+                  role="img"
                 />
               </button>
             </span>

--- a/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
+++ b/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
@@ -48,11 +48,15 @@ exports[`Storyshots Component API/TimePicker Disabled 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Show/hide time picker"
-                className="fd-button fd-button--transparent sap-icon--time-entry-request is-disabled fd-input-group__button"
+                className="fd-button fd-button--transparent is-disabled fd-input-group__button"
                 disabled={true}
                 id="timepickerDisabledExample-button"
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--time-entry-request"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -109,10 +113,14 @@ exports[`Storyshots Component API/TimePicker Format 12 Hours 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Show/hide time picker"
-                className="fd-button fd-button--transparent sap-icon--time-entry-request fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 id="timepicker12HrExample-button"
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--time-entry-request"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -169,10 +177,14 @@ exports[`Storyshots Component API/TimePicker Hide Seconds 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Show/hide time picker"
-                className="fd-button fd-button--transparent sap-icon--time-entry-request fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 id="timepickerHideSecondExample-button"
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--time-entry-request"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -229,10 +241,14 @@ exports[`Storyshots Component API/TimePicker Initial Value 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Show/hide time picker"
-                className="fd-button fd-button--transparent sap-icon--time-entry-request fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 id="timepickerInitExample-button"
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--time-entry-request"
+                />
+              </button>
             </span>
           </div>
         </div>
@@ -289,10 +305,14 @@ exports[`Storyshots Component API/TimePicker Primary 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Show/hide time picker"
-                className="fd-button fd-button--transparent sap-icon--time-entry-request fd-input-group__button"
+                className="fd-button fd-button--transparent fd-input-group__button"
                 id="timepickerPrimaryExample-button"
                 type="button"
-              />
+              >
+                <i
+                  className="sap-icon--time-entry-request"
+                />
+              </button>
             </span>
           </div>
         </div>

--- a/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
+++ b/src/TimePicker/__stories__/__snapshots__/TimePicker.stories.storyshot
@@ -54,6 +54,7 @@ exports[`Storyshots Component API/TimePicker Disabled 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--time-entry-request"
                 />
               </button>
@@ -118,6 +119,7 @@ exports[`Storyshots Component API/TimePicker Format 12 Hours 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--time-entry-request"
                 />
               </button>
@@ -182,6 +184,7 @@ exports[`Storyshots Component API/TimePicker Hide Seconds 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--time-entry-request"
                 />
               </button>
@@ -246,6 +249,7 @@ exports[`Storyshots Component API/TimePicker Initial Value 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--time-entry-request"
                 />
               </button>
@@ -310,6 +314,7 @@ exports[`Storyshots Component API/TimePicker Primary 1`] = `
                 type="button"
               >
                 <i
+                  aria-hidden="true"
                   className="sap-icon--time-entry-request"
                 />
               </button>

--- a/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
+++ b/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
@@ -1640,9 +1640,11 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
         />
         <span
           className="sap-icon--e-care fd-tree__icon"
+          role="img"
         />
         <span
           className="sap-icon--activate fd-tree__icon"
+          role="img"
         />
         <div
           className="fd-tree__content"
@@ -1660,8 +1662,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--edit"
+            role="img"
           />
         </button>
         <button
@@ -1670,8 +1673,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--decline"
+            role="img"
           />
         </button>
       </div>
@@ -1701,6 +1705,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
             />
             <span
               className="sap-icon--account fd-tree__icon"
+              role="img"
             />
             <div
               className="fd-tree__content"
@@ -1718,8 +1723,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--edit"
+                role="img"
               />
             </button>
             <button
@@ -1728,8 +1734,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--decline"
+                role="img"
               />
             </button>
           </div>
@@ -1759,6 +1766,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                 />
                 <span
                   className="sap-icon--product fd-tree__icon"
+                  role="img"
                 />
                 <div
                   className="fd-tree__content"
@@ -1776,8 +1784,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--edit"
+                    role="img"
                   />
                 </button>
                 <button
@@ -1786,8 +1795,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--decline"
+                    role="img"
                   />
                 </button>
               </div>
@@ -1809,6 +1819,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   >
                     <span
                       className="sap-icon--wrench fd-tree__icon"
+                      role="img"
                     />
                     <div
                       className="fd-tree__content"
@@ -1826,8 +1837,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--edit"
+                        role="img"
                       />
                     </button>
                     <button
@@ -1836,8 +1848,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                       type="button"
                     >
                       <i
-                        aria-hidden="true"
+                        aria-hidden={true}
                         className="sap-icon--decline"
+                        role="img"
                       />
                     </button>
                   </div>
@@ -1856,6 +1869,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               >
                 <span
                   className="sap-icon--history fd-tree__icon"
+                  role="img"
                 />
                 <div
                   className="fd-tree__content"
@@ -1873,8 +1887,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--edit"
+                    role="img"
                   />
                 </button>
                 <button
@@ -1883,8 +1898,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
-                    aria-hidden="true"
+                    aria-hidden={true}
                     className="sap-icon--decline"
+                    role="img"
                   />
                 </button>
               </div>
@@ -1903,6 +1919,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           >
             <span
               className="sap-icon--competitor fd-tree__icon"
+              role="img"
             />
             <div
               className="fd-tree__content"
@@ -1920,8 +1937,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--edit"
+                role="img"
               />
             </button>
             <button
@@ -1930,8 +1948,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
-                aria-hidden="true"
+                aria-hidden={true}
                 className="sap-icon--decline"
+                role="img"
               />
             </button>
           </div>
@@ -1950,6 +1969,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
       >
         <span
           className="sap-icon--batch-payments fd-tree__icon"
+          role="img"
         />
         <div
           className="fd-tree__content"
@@ -1962,6 +1982,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
         </div>
         <span
           className="sap-icon--bell fd-tree__icon"
+          role="img"
         />
         <button
           aria-label="Edit"
@@ -1969,8 +1990,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--edit"
+            role="img"
           />
         </button>
         <button
@@ -1979,8 +2001,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--decline"
+            role="img"
           />
         </button>
       </div>
@@ -1997,6 +2020,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
       >
         <span
           className="sap-icon--favorite fd-tree__icon"
+          role="img"
         />
         <div
           className="fd-tree__content"
@@ -2014,8 +2038,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--edit"
+            role="img"
           />
         </button>
         <button
@@ -2024,8 +2049,9 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
-            aria-hidden="true"
+            aria-hidden={true}
             className="sap-icon--decline"
+            role="img"
           />
         </button>
       </div>

--- a/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
+++ b/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
@@ -825,7 +825,11 @@ exports[`Storyshots Component API/Tree Dev 1`] = `
                   }
                   type="button"
                 >
-                  Test
+                  <span
+                    className="fd-button__text"
+                  >
+                    Test
+                  </span>
                 </button>
               </span>
             </div>
@@ -1652,14 +1656,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
         
         <button
           aria-label="Edit"
-          className="fd-button fd-button--transparent sap-icon--edit"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--edit"
+          />
+        </button>
         <button
           aria-label="Decline"
-          className="fd-button fd-button--transparent sap-icon--decline"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--decline"
+          />
+        </button>
       </div>
       <ul
         aria-hidden={true}
@@ -1700,14 +1712,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
             
             <button
               aria-label="Edit"
-              className="fd-button fd-button--transparent sap-icon--edit"
+              className="fd-button fd-button--transparent"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--edit"
+              />
+            </button>
             <button
               aria-label="Decline"
-              className="fd-button fd-button--transparent sap-icon--decline"
+              className="fd-button fd-button--transparent"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--decline"
+              />
+            </button>
           </div>
           <ul
             aria-hidden={true}
@@ -1748,14 +1768,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                 
                 <button
                   aria-label="Edit"
-                  className="fd-button fd-button--transparent sap-icon--edit"
+                  className="fd-button fd-button--transparent"
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--edit"
+                  />
+                </button>
                 <button
                   aria-label="Decline"
-                  className="fd-button fd-button--transparent sap-icon--decline"
+                  className="fd-button fd-button--transparent"
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--decline"
+                  />
+                </button>
               </div>
               <ul
                 aria-hidden={true}
@@ -1788,14 +1816,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                     
                     <button
                       aria-label="Edit"
-                      className="fd-button fd-button--transparent sap-icon--edit"
+                      className="fd-button fd-button--transparent"
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--edit"
+                      />
+                    </button>
                     <button
                       aria-label="Decline"
-                      className="fd-button fd-button--transparent sap-icon--decline"
+                      className="fd-button fd-button--transparent"
                       type="button"
-                    />
+                    >
+                      <i
+                        className="sap-icon--decline"
+                      />
+                    </button>
                   </div>
                 </li>
               </ul>
@@ -1825,14 +1861,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                 
                 <button
                   aria-label="Edit"
-                  className="fd-button fd-button--transparent sap-icon--edit"
+                  className="fd-button fd-button--transparent"
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--edit"
+                  />
+                </button>
                 <button
                   aria-label="Decline"
-                  className="fd-button fd-button--transparent sap-icon--decline"
+                  className="fd-button fd-button--transparent"
                   type="button"
-                />
+                >
+                  <i
+                    className="sap-icon--decline"
+                  />
+                </button>
               </div>
             </li>
           </ul>
@@ -1862,14 +1906,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
             
             <button
               aria-label="Edit"
-              className="fd-button fd-button--transparent sap-icon--edit"
+              className="fd-button fd-button--transparent"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--edit"
+              />
+            </button>
             <button
               aria-label="Decline"
-              className="fd-button fd-button--transparent sap-icon--decline"
+              className="fd-button fd-button--transparent"
               type="button"
-            />
+            >
+              <i
+                className="sap-icon--decline"
+              />
+            </button>
           </div>
         </li>
       </ul>
@@ -1901,14 +1953,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
         />
         <button
           aria-label="Edit"
-          className="fd-button fd-button--transparent sap-icon--edit"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--edit"
+          />
+        </button>
         <button
           aria-label="Decline"
-          className="fd-button fd-button--transparent sap-icon--decline"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--decline"
+          />
+        </button>
       </div>
     </li>
     <li
@@ -1936,14 +1996,22 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
         
         <button
           aria-label="Edit"
-          className="fd-button fd-button--transparent sap-icon--edit"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--edit"
+          />
+        </button>
         <button
           aria-label="Decline"
-          className="fd-button fd-button--transparent sap-icon--decline"
+          className="fd-button fd-button--transparent"
           type="button"
-        />
+        >
+          <i
+            className="sap-icon--decline"
+          />
+        </button>
       </div>
     </li>
   </ul>

--- a/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
+++ b/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
@@ -1638,11 +1638,11 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           id="fd-mocked-short-id-expansion-toggle-button"
           onClick={[Function]}
         />
-        <span
+        <i
           className="sap-icon--e-care fd-tree__icon"
           role="img"
         />
-        <span
+        <i
           className="sap-icon--activate fd-tree__icon"
           role="img"
         />
@@ -1703,7 +1703,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               id="fd-mocked-short-id-expansion-toggle-button"
               onClick={[Function]}
             />
-            <span
+            <i
               className="sap-icon--account fd-tree__icon"
               role="img"
             />
@@ -1764,7 +1764,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   id="fd-mocked-short-id-expansion-toggle-button"
                   onClick={[Function]}
                 />
-                <span
+                <i
                   className="sap-icon--product fd-tree__icon"
                   role="img"
                 />
@@ -1817,7 +1817,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   <div
                     className="fd-tree__item-container"
                   >
-                    <span
+                    <i
                       className="sap-icon--wrench fd-tree__icon"
                       role="img"
                     />
@@ -1867,7 +1867,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               <div
                 className="fd-tree__item-container"
               >
-                <span
+                <i
                   className="sap-icon--history fd-tree__icon"
                   role="img"
                 />
@@ -1917,7 +1917,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           <div
             className="fd-tree__item-container"
           >
-            <span
+            <i
               className="sap-icon--competitor fd-tree__icon"
               role="img"
             />
@@ -1967,7 +1967,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
       <div
         className="fd-tree__item-container"
       >
-        <span
+        <i
           className="sap-icon--batch-payments fd-tree__icon"
           role="img"
         />
@@ -1980,7 +1980,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
             Level 1
           </span>
         </div>
-        <span
+        <i
           className="sap-icon--bell fd-tree__icon"
           role="img"
         />
@@ -2018,7 +2018,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
       <div
         className="fd-tree__item-container"
       >
-        <span
+        <i
           className="sap-icon--favorite fd-tree__icon"
           role="img"
         />

--- a/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
+++ b/src/Tree/__stories__/__snapshots__/Tree.stories.storyshot
@@ -1660,6 +1660,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--edit"
           />
         </button>
@@ -1669,6 +1670,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--decline"
           />
         </button>
@@ -1716,6 +1718,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--edit"
               />
             </button>
@@ -1725,6 +1728,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--decline"
               />
             </button>
@@ -1772,6 +1776,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--edit"
                   />
                 </button>
@@ -1781,6 +1786,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--decline"
                   />
                 </button>
@@ -1820,6 +1826,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--edit"
                       />
                     </button>
@@ -1829,6 +1836,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                       type="button"
                     >
                       <i
+                        aria-hidden="true"
                         className="sap-icon--decline"
                       />
                     </button>
@@ -1865,6 +1873,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--edit"
                   />
                 </button>
@@ -1874,6 +1883,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
                   type="button"
                 >
                   <i
+                    aria-hidden="true"
                     className="sap-icon--decline"
                   />
                 </button>
@@ -1910,6 +1920,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--edit"
               />
             </button>
@@ -1919,6 +1930,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
               type="button"
             >
               <i
+                aria-hidden="true"
                 className="sap-icon--decline"
               />
             </button>
@@ -1957,6 +1969,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--edit"
           />
         </button>
@@ -1966,6 +1979,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--decline"
           />
         </button>
@@ -2000,6 +2014,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--edit"
           />
         </button>
@@ -2009,6 +2024,7 @@ exports[`Storyshots Component API/Tree Icons, Node Actions, and No Borders on Le
           type="button"
         >
           <i
+            aria-hidden="true"
             className="sap-icon--decline"
           />
         </button>


### PR DESCRIPTION
### Description
BREAKING CHANGE
- Implements breaking changes from fundamental-styles up to 0.12.0-rc.44
    - rc.21 - moving icons from pseudoelements to `<i>` tag in button
        - icons now in a `<i>` tag in `Icon` and button text moved into a `<span>` with class ‘fd-button__text’
- adds `iconBeforeText`, `iconProps`, and `textClassName` prop to `Button`
- adds `ariaHidden` and `ariaLabel` props to `Icon`
