### PR TITLE
feat: make shellbar popovers customizable

### DIFF
--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -112,6 +112,7 @@ class Shellbar extends Component {
             productSwitchList,
             profile,
             profileMenu,
+            popoverPropsFor,
             className,
             backAction
         } = this.props;
@@ -143,6 +144,7 @@ class Shellbar extends Component {
                     {productTitle && !productMenu && <span className='fd-shellbar__title'>{productTitle}</span>}
                     {productMenu && (
                         <Popover
+                            {...popoverPropsFor?.productMenu}
                             body={
                                 productMenu && (
                                     <Menu>
@@ -218,6 +220,8 @@ class Shellbar extends Component {
                                     <div className='fd-shellbar__action fd-shellbar__action--desktop' key={index}>
                                         {action.menu ? (
                                             <Popover
+                                                placement='bottom-end'
+                                                {...popoverPropsFor?.actionMenu}
                                                 body={action.menu}
                                                 control={
                                                     <Button
@@ -235,7 +239,6 @@ class Shellbar extends Component {
                                                         )}
                                                     </Button>
                                                 }
-                                                placement='bottom-end'
                                                 popperProps={{ id: `fd-shellbar-actions-popover-${index}` }} />
                                         ) : (
                                             <Button
@@ -260,6 +263,8 @@ class Shellbar extends Component {
                     {notifications && (
                         (notifications.notificationsBody || notifications.noNotificationsBody) ? (
                             <Popover
+                                placement='bottom-end'
+                                {...popoverPropsFor?.notifications}
                                 body={
                                     ((notifications.notificationCount > 0) && notifications.notificationsBody) ||
                                         ((notifications.notificationCount <= 0) && notifications.noNotificationsBody)
@@ -281,7 +286,6 @@ class Shellbar extends Component {
                                         </Button>
                                     </div>
                                 }
-                                placement='bottom-end'
                                 popperProps={{ id: 'fd-shellbar-notifications-popover' }} />
                         ) : (
                             <div className='fd-shellbar__action fd-shellbar__action--desktop'>
@@ -305,6 +309,8 @@ class Shellbar extends Component {
                     {
                         (actions || searchInput || notifications) && <div className='fd-shellbar__action fd-shellbar__action--mobile'>
                             <Popover
+                                placement='bottom-end'
+                                {...popoverPropsFor?.collapsedMobileMenu}
                                 body={
                                     <Menu>
                                         {!this.state.showCollapsedProductSwitchMenu ? (
@@ -356,7 +362,6 @@ class Shellbar extends Component {
                                         </Button>
                                     </div>
                                 }
-                                placement='bottom-end'
                                 popperProps={{ id: 'fd-shellbar-mobile-action-popover' }} />
                         </div>
                     }
@@ -364,6 +369,8 @@ class Shellbar extends Component {
                         <div className='fd-shellbar__action fd-shellbar__action--show-always'>
                             <div className='fd-user-menu'>
                                 <Popover
+                                    placement='bottom-end'
+                                    {...popoverPropsFor?.profileMenu}
                                     body={
                                         profileMenu && (
                                             <Menu>
@@ -412,7 +419,6 @@ class Shellbar extends Component {
                                         </button>
                                     }
                                     noArrow
-                                    placement='bottom-end'
                                     popperProps={{ id: 'fd-shellbar-profile-popover' }} />
                             </div>
                         </div>
@@ -421,6 +427,8 @@ class Shellbar extends Component {
                         <div className='fd-shellbar__action fd-shellbar__action--desktop'>
                             <div className='fd-product-switch'>
                                 <Popover
+                                    placement='bottom-end'
+                                    {...popoverPropsFor?.productSwitch}
                                     body={
                                         <div className='fd-product-switch__body'>
                                             <ul className='fd-product-switch__list'>
@@ -452,7 +460,6 @@ class Shellbar extends Component {
                                         className='fd-product-switch__control fd-shellbar__button'
                                         glyph='grid' />}
                                     disableEdgeDetection
-                                    placement='bottom-end'
                                     popperProps={{ id: 'fd-shellbar-product-switch-popover' }} />
                             </div>
                         </div>
@@ -490,6 +497,18 @@ Shellbar.propTypes = {
     logoSAP: PropTypes.bool,
     /** Information about pending notifications */
     notifications: PropTypes.object,
+    /**
+     * Additional props to be spread to the popovers of the action menu, collapsed mobile menu, notifications menu, product menu,
+     * product switch popover and the profile menu.
+     * */
+    popoverPropsFor: {
+        actionMenu: PropTypes.object,
+        collapsedMobileMenu: PropTypes.object,
+        notifications: PropTypes.object,
+        productMenu: PropTypes.object,
+        productSwitch: PropTypes.object,
+        profileMenu: PropTypes.object
+    },
     /** Holds product titles and navigation */
     productMenu: PropTypes.array,
     /** For navigating between products. An object that contains an accessible and localized label for product switch button. */

--- a/src/Shellbar/__stories__/Shellbar.stories.js
+++ b/src/Shellbar/__stories__/Shellbar.stories.js
@@ -246,6 +246,26 @@ export const dev = () => (
                 </Menu>
             )
         }}
+        popoverPropsFor={{
+            actionMenu: {
+                placement: 'bottom'
+            },
+            collapsedMobileMenu: {
+                placement: 'bottom'
+            },
+            notifications: {
+                placement: 'bottom'
+            },
+            productSwitch: {
+                placement: 'bottom-start'
+            },
+            productMenu: {
+                placement: 'bottom'
+            },
+            profileMenu: {
+                placement: 'bottom'
+            }
+        }}
         productMenu={productMenu}
         productSwitch={{
             label: 'Product Switch'


### PR DESCRIPTION
### Description
 
In this change, we update the Shellbar component to accept props to be spread to the Popovers of the action menu, collapsed mobile menu, notifications menu, product menu, product switch popover, and the profile menu. This will allow consumers to customize these; for example, set the `placement`.


fixes #919 