### PR TITLE
fix: focus manager use with grid manager

### DIFF
--- a/src/utils/focusManager/focusManager.js
+++ b/src/utils/focusManager/focusManager.js
@@ -15,7 +15,7 @@ export default class FocusManager {
     }
 
     isFocusContained = (e) => {
-        return (e.target === window && this.container && !this.container.contains(document.activeElement));
+        return (e.target === window && this.container && this.container.contains(document.activeElement));
     }
 
     keyHandler = (e) => {
@@ -38,7 +38,19 @@ export default class FocusManager {
             }
 
             this.tabbableNodes = tabbable(this.container);
-            const currentIndex = this.tabbableNodes.indexOf(e.target);
+            let currentIndex = this.tabbableNodes.indexOf(e.target);
+            if (currentIndex === -1 ) {
+                // if the event target is not within the tabbable nodes, then
+                // chances are it is a nested descendent of one of the tabbable node.
+                // For example, it could be button within a grid cell, where that grid cell is tabbable
+                // Hence we should check if any of the tabbable nodes contain our target.
+                this.tabbableNodes.forEach((eachNode, index) => {
+                    if (eachNode?.contains(e.target)) {
+                        // if a tabbable node contains our target, that was the node with the current index.
+                        currentIndex = index;
+                    }
+                });
+            }
             const lastNode = this.tabbableNodes[this.tabbableNodes.length - 1];
             const firstNode = this.tabbableNodes[0];
 

--- a/src/utils/focusManager/focusManager.js
+++ b/src/utils/focusManager/focusManager.js
@@ -15,7 +15,7 @@ export default class FocusManager {
     }
 
     isFocusContained = (e) => {
-        return (e.target === window && this.container && this.container.contains(document.activeElement));
+        return (e.target === window && this.container && !this.container.contains(document.activeElement));
     }
 
     keyHandler = (e) => {


### PR DESCRIPTION
### Description
In this change, we fix an issue with the focus manager which prevented focus from traveling into a tabbable element positioned after a focus-manged grid inside a popover. Using a grid, with controls in its cells, inside a popover (DatePicker) caused tabbable nodes expected by the focus manager to be changed by the grid manager. This is seen in Datepicker where it was not possible to navigate to the today footer button with keyboard tabbing.

## Before
![fd-react-datepicker-tabing](https://user-images.githubusercontent.com/43764832/94717441-2ecf7600-0305-11eb-8978-c2f7de466920.gif)


## After
![fd-react-datepicker-tabing-fixed](https://user-images.githubusercontent.com/43764832/94717473-3bec6500-0305-11eb-8bd3-7cf5294500c1.gif)
