### PR TITLE
fix: add title to index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,5 +49,6 @@ export { default as Tile } from './Tile/Tile';
 export { default as Tree } from './Tree/Tree';
 export { default as Time } from './Time/Time';
 export { default as TimePicker } from './TimePicker/TimePicker';
+export { default as Title } from './Title/Title';
 export { default as Shellbar } from './Shellbar/Shellbar';
 export { default as StepInput } from './StepInput/StepInput';


### PR DESCRIPTION
### Description
Add the missing `Title`-Component to the `index.js`
