### PR TITLE
feat: Hide the DatePicker button when readOnly is true

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -401,8 +401,6 @@ class DatePicker extends Component {
             footerButtonProps?.className
         );
 
-        const disableButton = disabled || readOnly;
-
         const inputGroup = (
             <InputGroup
                 {...inputGroupProps}
@@ -422,16 +420,18 @@ class DatePicker extends Component {
                     placeholder={this.getPlaceHolder(dateFormat)}
                     readOnly={readOnly}
                     value={this.state.formattedDate} />
-                <InputGroup.Addon
-                    {...addonProps}
-                    isButton>
-                    <Button {...buttonProps}
-                        aria-label={buttonLabel}
-                        disabled={disableButton}
-                        glyph='appointment-2'
-                        onClick={this.handleClickButton}
-                        option='transparent' />
-                </InputGroup.Addon>
+                {!readOnly && (
+                    <InputGroup.Addon
+                        {...addonProps}
+                        isButton>
+                        <Button {...buttonProps}
+                            aria-label={buttonLabel}
+                            disabled={disabled}
+                            glyph='appointment-2'
+                            onClick={this.handleClickButton}
+                            option='transparent' />
+                    </InputGroup.Addon>
+                )}
             </InputGroup>
         );
 
@@ -509,7 +509,7 @@ class DatePicker extends Component {
                     control={inputGroup}
                     disableKeyPressHandler
                     disableTriggerOnClick
-                    disabled={disableButton}
+                    disabled={disabled || readOnly}
                     modalManager={modalManager}
                     noArrow
                     onClickOutside={this.handleOutsideClickAndEscape}

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -657,7 +657,6 @@ describe('<DatePicker />', () => {
         });
 
         test('should disabled the popover when readOnly is true', () => {
-            // document.body.innerHTML = '';
             wrapper = mount(<DatePicker readOnly />);
             expect(wrapper.find('Popover').props().disabled).toBe(true);
 
@@ -670,7 +669,6 @@ describe('<DatePicker />', () => {
         });
 
         test('should keep the popover when readOnly is true', () => {
-            // document.body.innerHTML = '';
             wrapper = mount(<DatePicker />);
             expect(wrapper.find('Popover').props().disabled).not.toBeDefined();
         });

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -650,6 +650,31 @@ describe('<DatePicker />', () => {
             expect(wrapper.find('.fd-list__message').length).toBe(1);
         });
     });
+    describe('readOnly', () => {
+        test('should not render an inputGroup.Addon button if it is readOnly', () => {
+            wrapper = mount(<DatePicker readOnly />);
+            expect(wrapper.find('button').length).toBe(0);
+        });
+
+        test('should disabled the popover when readOnly is true', () => {
+            // document.body.innerHTML = '';
+            wrapper = mount(<DatePicker readOnly />);
+            expect(wrapper.find('Popover').props().disabled).toBe(true);
+
+            expect(wrapper.find('button').length).toBe(0);
+        });
+
+        test('should render an inputGroup.Addon button if it is not readOnly', () => {
+            wrapper = mount(<DatePicker />);
+            expect(wrapper.find('button').length).toBe(1);
+        });
+
+        test('should keep the popover when readOnly is true', () => {
+            // document.body.innerHTML = '';
+            wrapper = mount(<DatePicker />);
+            expect(wrapper.find('Popover').props().disabled).not.toBeDefined();
+        });
+    });
 });
 function simulateBlur() {
     let event = new MouseEvent('mousedown', { target: document.querySelector('body') });

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -82,7 +82,7 @@ export const disabled = () => (
 disabled.storyName = 'Disabled';
 
 export const readOnly = () => (
-    <DatePicker readOnly />
+    <DatePicker defaultValue='12/12/2012' readOnly />
 );
 
 

--- a/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
+++ b/src/DatePicker/__stories__/__snapshots__/DatePicker.stories.storyshot
@@ -1259,7 +1259,7 @@ exports[`Storyshots Component API/DatePicker ReadOnly 1`] = `
   dir="ltr"
 >
   <div
-    defaultValue=""
+    defaultValue="12/12/2012"
     onChange={[Function]}
   >
     <div
@@ -1287,25 +1287,8 @@ exports[`Storyshots Component API/DatePicker ReadOnly 1`] = `
               placeholder="MM/DD/YYYY"
               readOnly={true}
               type="text"
-              value=""
+              value="12/12/2012"
             />
-            <span
-              className="fd-input-group__addon fd-input-group__addon--button"
-            >
-              <button
-                aria-label="Choose date"
-                className="fd-button fd-button--transparent is-disabled fd-input-group__button"
-                disabled={true}
-                onClick={[Function]}
-                type="button"
-              >
-                <i
-                  aria-hidden={true}
-                  className="sap-icon--appointment-2"
-                  role="img"
-                />
-              </button>
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description

A readOnly DatePicker field should not have a button

<img width="176" alt="Screen Shot 2020-10-05 at 3 13 55 PM" src="https://user-images.githubusercontent.com/5314713/95127381-8282fa80-071d-11eb-83b7-448254682e5d.png">

Breaking Change: A readOnly DatePicker field does not have an InputGroup Button

IE11
<img width="1199" alt="Screen Shot 2020-10-06 at 8 46 22 AM" src="https://user-images.githubusercontent.com/5314713/95209925-84e26480-07b0-11eb-99f8-02cd8b648ee0.png">
