### PR TITLE
docs: add base font size to html in readme instructions

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -1,3 +1,7 @@
+html {
+    font-size: 16px;
+}
+
 body {
     font-family: '72', 'Open Sans', sans-serif;
 }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ For an existing react application, follow the steps below:
 
 Additionally, edit your webpack configuration to load font and icon fonts - see [file-loader](https://webpack.js.org/loaders/file-loader/).
 
+1. All styles are based on `rem` units. Include the following in your css to ensure components are sized correctly:
+
+```css
+    html {
+        font-size: 16px;
+    }
+```
+
 ## Versioning
 
 The `fundamental-react` library follows [Semantic Versioning](https://semver.org/). These components strictly adhere to the `[MAJOR].[MINOR].[PATCH]` numbering system (also known as `[BREAKING].[FEATURE].[FIX]`).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For an existing react application, follow the steps below:
 
 Additionally, edit your webpack configuration to load font and icon fonts - see [file-loader](https://webpack.js.org/loaders/file-loader/).
 
-1. All styles are based on `rem` units. Include the following in your css to ensure components are sized correctly:
+All styles are based on `rem` units. Include the following in your CSS to ensure components are sized correctly:
 
 ```css
     html {


### PR DESCRIPTION
### Description
css from fundamental-styles uses rems. 1rem equals the font size of the html element. While most browsers have 16px as the base, we might want to explicitly call it out. I'm not sure if this pr is necessary 🤷‍♂️ 


fixes #1236 