### PR TITLE
fix: Datepicker today actions props interface

### DIFF
--- a/devtools/buildVisualStories.js
+++ b/devtools/buildVisualStories.js
@@ -1,57 +1,73 @@
+/* eslint-disable no-console */
 const { lstatSync, readdirSync, writeFileSync } = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 
-const srcPath = path.join(__dirname, '../src');
 
-const isComponentDirectory = (source) => {
-    const ignoredDirectories = ['utils', 'Docs'];
-    return lstatSync(source).isDirectory() && !ignoredDirectories.some(ignored => source.includes(ignored));
-};
+console.info('Trying to clean/remove all visual stories. 🗑 ');
 
-const componentDirs = readdirSync(srcPath).map(name => path.join(srcPath, name)).filter(isComponentDirectory).map(directory => {
-    return {
-        path: `${directory}/__stories__/`,
-        fileNames: readdirSync(`${directory}/__stories__/`)
+rimraf('**/*.visual.js', (rimRafError) => {
+    if (rimRafError) {
+        console.error('Unable to clean all visual stories!! ❌', rimRafError);
+    } else {
+        console.info('Removed all visual stories. 🗑 ✅');
+    }
+
+    console.info('Trying to build all visual stories. 🏗');
+
+    const srcPath = path.join(__dirname, '../src');
+
+    const isComponentDirectory = (source) => {
+        const ignoredDirectories = ['utils', 'Docs'];
+        return lstatSync(source).isDirectory() && !ignoredDirectories.some(ignored => source.includes(ignored));
     };
-});
 
-// For every component directory.
-componentDirs.map((directory) => {
-    // Loop through its files.
-    directory.fileNames.map((fileName) => {
-        // get only stories.js files
-        if (fileName.includes('.stories.js')) {
-            // Grab the component name
-            const componentName = fileName.substr(0, fileName.indexOf('.'));
-            // TODO: reenable storyshots for examples using hooks in storybook@6
-            // https://github.com/storybookjs/storybook/releases/tag/v6.0.0-alpha.43
-            if (componentName === 'Calendar'
-                || componentName === 'Dialog') {
-                return;
+    const componentDirs = readdirSync(srcPath).map(name => path.join(srcPath, name)).filter(isComponentDirectory).map(directory => {
+        return {
+            path: `${directory}/__stories__/`,
+            fileNames: readdirSync(`${directory}/__stories__/`)
+        };
+    });
+
+    // For every component directory.
+    componentDirs.map((directory) => {
+        // Loop through its files.
+        directory.fileNames.map((fileName) => {
+            // get only stories.js files
+            if (fileName.includes('.stories.js')) {
+                // Grab the component name
+                const componentName = fileName.substr(0, fileName.indexOf('.'));
+                // TODO: reenable storyshots for examples using hooks in storybook@6
+                // https://github.com/storybookjs/storybook/releases/tag/v6.0.0-alpha.43
+                if (componentName === 'Calendar'
+                    || componentName === 'Dialog') {
+                    return;
+                }
+
+                const fileContents = `
+    import React from 'react';
+    import * as stories from './${componentName}.stories';
+
+    export default {
+        title: 'Visual'
+    };
+
+    export const ${componentName} = () => {
+        let storyNames = Object.keys(stories).filter(story => {
+            return story !== 'default' && story !== 'dev';
+        });
+
+        return (<>{storyNames.map((item, index) => <div key={index}>{stories[item]()}</div>)}</>);
+    };
+    ${componentName}.parameters = {
+        docs: { disable: true }
+    };
+    `;
+                // write the visual story file into the directory.
+                let visualPath = path.join(directory.path, `${componentName}.visual.js`);
+                writeFileSync(visualPath, fileContents);
             }
-
-            const fileContents = `
-import React from 'react';
-import * as stories from './${componentName}.stories';
-
-export default {
-    title: 'Visual'
-};
-
-export const ${componentName} = () => {
-    let storyNames = Object.keys(stories).filter(story => {
-        return story !== 'default' && story !== 'dev';
+        });
     });
 
-    return (<>{storyNames.map((item, index) => <div key={index}>{stories[item]()}</div>)}</>);
-};
-${componentName}.parameters = {
-    docs: { disable: true }
-};
-`;
-            // write the visual story file into the directory.
-            let visualPath = path.join(directory.path, `${componentName}.visual.js`);
-            writeFileSync(visualPath, fileContents);
-        }
-    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11271,6 +11271,17 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "cache-base": {
@@ -12462,6 +12473,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -15320,6 +15342,17 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }
@@ -16359,6 +16392,17 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "function-bind": {
@@ -20441,6 +20485,15 @@
             "supports-color": "^2.0.0"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -24326,6 +24379,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -24476,6 +24540,15 @@
         "which": "1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -26715,6 +26788,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -28909,10 +28991,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-overlays": "^3.2.0",
     "react-popper": "^2.2.3",
     "react-required-if": "^1.0.3",
+    "rimraf": "^3.0.2",
     "shortid": "^2.2.14",
     "tabbable": "^4.0.0"
   },

--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -819,7 +819,7 @@ Calendar.propTypes = {
         show12NextYears: PropTypes.string,
         /** aria-label for previous button when years are displayed */
         show12PreviousYears: PropTypes.string,
-        /** aria-label for Today button if included */
+        /** Label for Today button if showToday is true */
         todayLabel: PropTypes.string
     }),
     /** Additional props to be spread to the month\'s `<table>` element */

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -7,10 +7,9 @@ import InputGroup from '../InputGroup/InputGroup';
 import moment from 'moment';
 import Popover from '../Popover/Popover';
 import PropTypes from 'prop-types';
-import requiredIf from 'react-required-if';
 import { validDateLookup } from './_validDateLookup';
 import withStyles from '../utils/withStyles';
-import { DATEPICKER_TODAY_ACTIONS_TYPES, FORM_MESSAGE_TYPES, ISO_DATE_FORMAT } from '../utils/constants';
+import { FORM_MESSAGE_TYPES, ISO_DATE_FORMAT } from '../utils/constants';
 import { isDateEnabled, resolveFormat } from '../utils/dateUtils';
 import React, { Component } from 'react';
 import barStyles from 'fundamental-styles/dist/bar.css';
@@ -321,21 +320,17 @@ class DatePicker extends Component {
     };
 
     showTodayHeader = () => {
-        const { todayAction: { label: todayLabel, type: todayType } } = this.props;
-        return todayType === 'navigate'
-                && todayLabel
-                && typeof todayLabel === 'string'
-                && todayLabel.trim().length > 0;
+        const { todayActionType, localizedText: { todayLabel } } = this.props;
+        return todayActionType === 'navigate'
+                && todayLabel?.trim().length > 0;
     }
 
     showTodayFooter = () => {
-        const { enableRangeSelection, todayAction: { label: todayLabel, type: todayType } } = this.props;
-        return todayType === 'select'
+        const { enableRangeSelection, todayActionType, localizedText: { todayLabel } } = this.props;
+        return todayActionType === 'select'
                 && !enableRangeSelection
                 && isDateEnabled(moment(), this.props)
-                && todayLabel
-                && typeof todayLabel === 'string'
-                && todayLabel.trim().length > 0;
+                && todayLabel?.trim().length > 0;
     };
 
     setTodayDate = () => {
@@ -375,7 +370,7 @@ class DatePicker extends Component {
             readOnly,
             showToday,
             specialDays,
-            todayAction,
+            todayActionType,
             validationOverlayProps,
             validationState,
             weekdayStart,
@@ -485,8 +480,8 @@ class DatePicker extends Component {
                                 focusOnInit
                                 locale={locale}
                                 localizedText={{
-                                    ...localizedText,
-                                    todayLabel: todayAction.label
+                                    ...Calendar.defaultProps.localizedText,
+                                    ...localizedText
                                 }}
                                 onChange={ (date, todayNavigated) => {
                                     this.updateDate(date, todayNavigated, todayNavigated ? 'todayNavigated' : 'calendarDateClicked');
@@ -505,7 +500,7 @@ class DatePicker extends Component {
                                                 className={footerButtonClassnames}
                                                 compact={compact}
                                                 onClick={this.setTodayDate}>
-                                                {todayAction.label}
+                                                {localizedText.todayLabel}
                                             </Button>
                                         </div>
                                     </div>
@@ -573,28 +568,22 @@ DatePicker.propTypes = {
     /** Object with special dates and special date types in shape of `{'YYYYMMDD': type}`. Type must be a number between 1-20 */
     specialDays: PropTypes.object,
     /** Config object for DatePicker's today action button.
-     *  For example, ```todayAction={type: 'select', label: 'Today'}```
+     *  For example, ```todayActionType='select'```
      *
-     * **todayAction.type** is a string indicating the type of today button
+     * **todayActionType** is a string indicating the type of today button
      *
      * - `'none'` today button won't be shown
      * - `'select'` today button as footer action that selects today's date and closes datepicker
      * - `'navigate'` today button as header action that navigates (i.e. sets focus) to today's date
      *
-     * **todayAction.label** is a localized string label for the today action button.
+     * **localizedText.todayLabel** should be a localized string label for the today action button.
      *
      * The button will only be rendered if:
      *
-     * - `todayAction.type` is `'select'` or `'navigate'`
-     * - AND `todayAction.label` is a valid non-empty string
+     * - `todayActionType` is `'select'` or `'navigate'`
+     * - AND `localizedText.todayLabel` is a valid non-empty string
     */
-    todayAction: PropTypes.shape({
-        type: PropTypes.oneOf(DATEPICKER_TODAY_ACTIONS_TYPES),
-        label: requiredIf(PropTypes.string, todayAction => {
-            const todayActionType = todayAction?.type?.trim();
-            return todayActionType === 'select' || todayActionType === 'navigate';
-        })
-    }),
+    todayActionType: PropTypes.oneOf(['none', 'select', 'navigate']),
     /** Additional props to be spread to the ValidationOverlay */
     validationOverlayProps: PropTypes.shape({
         /** Additional classes to apply to validation popover's outermost `<div>` element  */
@@ -662,9 +651,7 @@ DatePicker.defaultProps = {
     ...Calendar.defaultProps,
     buttonLabel: 'Choose date',
     defaultValue: '',
-    todayAction: {
-        type: 'none'
-    },
+    todayActionType: 'none',
     onInputBlur: () => {},
     onDatePickerClose: () => {},
     onInputFocus: () => {}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -1,6 +1,7 @@
 import Button from '../Button/Button';
 import Calendar from '../Calendar/Calendar';
 import classnamesBind from 'classnames/bind';
+import CustomPropTypes from '../utils/CustomPropTypes/CustomPropTypes';
 import FormInput from '../Forms/FormInput';
 import FormMessage from '../Forms/_FormMessage';
 import InputGroup from '../InputGroup/InputGroup';
@@ -559,6 +560,27 @@ DatePicker.propTypes = {
     inputGroupProps: PropTypes.object,
     /** Additional props to be spread to the `<input>` element */
     inputProps: PropTypes.object,
+    /** Localized text to be updated based on location/language */
+    localizedText: CustomPropTypes.i18n({
+        /** Localized string informing screen reader users the calendar can be navigated by arrow keys while in day view */
+        dayInstructions: PropTypes.string,
+        /** Localized string informing screen reader users the calendar can be navigated by arrow keys while in month view */
+        monthInstructions: PropTypes.string,
+        /** Localized string informing screen reader users the calendar can be navigated by arrow keys while in year view */
+        yearInstructions: PropTypes.string,
+        /** Localized string informing screen reader users to select a second date when in range selection */
+        rangeInstructions: PropTypes.string,
+        /** aria-label for next button */
+        nextMonth: PropTypes.string,
+        /** aria-label for previous button */
+        previousMonth: PropTypes.string,
+        /** aria-label for next button when years are displayed */
+        show12NextYears: PropTypes.string,
+        /** aria-label for previous button when years are displayed */
+        show12PreviousYears: PropTypes.string,
+        /** Label for Today button if showToday is true */
+        todayLabel: PropTypes.string
+    }),
     /** If DatePicker is to be rendered in a modal, the parent modal manager can be passed as a prop */
     modalManager: PropTypes.object,
     /** Additional props to be spread to the Popover component */
@@ -567,9 +589,7 @@ DatePicker.propTypes = {
     readOnly: PropTypes.bool,
     /** Object with special dates and special date types in shape of `{'YYYYMMDD': type}`. Type must be a number between 1-20 */
     specialDays: PropTypes.object,
-    /** Config object for DatePicker's today action button.
-     *  For example, ```todayActionType='select'```
-     *
+    /**
      * **todayActionType** is a string indicating the type of today button
      *
      * - `'none'` today button won't be shown

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -578,7 +578,7 @@ DatePicker.propTypes = {
         show12NextYears: PropTypes.string,
         /** aria-label for previous button when years are displayed */
         show12PreviousYears: PropTypes.string,
-        /** Label for Today button if showToday is true */
+        /** Label for Today button which is shown if todayActionType is 'select' or 'navigate' */
         todayLabel: PropTypes.string
     }),
     /** If DatePicker is to be rendered in a modal, the parent modal manager can be passed as a prop */

--- a/src/DatePicker/DatePicker.test.js
+++ b/src/DatePicker/DatePicker.test.js
@@ -330,27 +330,27 @@ describe('<DatePicker />', () => {
 
     describe('With today footer button', () => {
 
-        test('renders today button when todayAction.type=\'select\' AND valid todayAction.label is specified', () => {
+        test('renders today button when todayActionType=\'select\' AND valid localizedText.todayLabel is specified', () => {
             wrapper = mount(
                 <DatePicker
-                    todayAction={{
-                        type: 'select',
-                        label: 'Today'
-                    }} />);
+                    localizedText={{
+                        todayLabel: 'Today'
+                    }}
+                    todayActionType='select' />);
             wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(true);
             expect(todayButtonWrapper.text()).toBe('Today');
         });
 
-        test('doesn\'t render today button when todayAction.type=\'select\' AND valid todayAction.label is specified but date range selection is enabled', () => {
+        test('doesn\'t render today button when todayActionType=\'select\' AND valid localizedText.todayLabel is specified but date range selection is enabled', () => {
             wrapper = mount(
                 <DatePicker
                     enableRangeSelection
-                    todayAction={{
-                        type: 'select',
-                        label: 'Today'
-                    }} />);
+                    localizedText={{
+                        todayLabel: 'Today'
+                    }}
+                    todayActionType='select' />);
             wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(false);
@@ -359,10 +359,10 @@ describe('<DatePicker />', () => {
         test('sets todays date when today button is pressed', () => {
             wrapper = mount(
                 <DatePicker
-                    todayAction={{
-                        type: 'select',
-                        label: 'Today'
-                    }} />);
+                    localizedText={{
+                        todayLabel: 'Today'
+                    }}
+                    todayActionType='select' />);
             wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             expect(todayButtonWrapper.exists()).toBe(true);
@@ -375,11 +375,11 @@ describe('<DatePicker />', () => {
             wrapper = mount(
                 <DatePicker
                     dateFormat='YYYY/MM/DD'
+                    localizedText={{
+                        todayLabel: 'Today'
+                    }}
                     onChange={change}
-                    todayAction={{
-                        type: 'select',
-                        label: 'Today'
-                    }} />);
+                    todayActionType='select' />);
             wrapper.find('button.fd-button--transparent').simulate('click');
             const todayButtonWrapper = wrapper.find('button.fd-dialog__decisive-button');
             todayButtonWrapper.simulate('click');

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -297,8 +297,8 @@ weekdayStartEx.storyName = 'Weekday Start (Monday Start)';
 /**
  * Setting
  *
- * - `todayAction.type` to `'select'`
- * - And localized non-empty string value for `todayAction.label`
+ * - `todayActionType` to `'select'`
+ * - And localized non-empty string value for `localizedText.todayLabel`
  *
  * will show a footer action in the DatePicker popover.
  * Clicking this button selects today's date and closes the popover.
@@ -324,10 +324,10 @@ export const localizedTodayFooterButton = () => (
                             inputProps={{
                                 id: 'englishTodayButtonDP'
                             }}
-                            todayAction={{
-                                type: 'select',
-                                label: 'Today'
-                            }} />
+                            localizedText={{
+                                todayLabel: 'Today'
+                            }}
+                            todayActionType='select' />
                     </div>
                 </Column>
                 <Column>
@@ -342,10 +342,10 @@ export const localizedTodayFooterButton = () => (
                                 id: 'hindiTodayButtonDP'
                             }}
                             locale='hi'
-                            todayAction={{
-                                type: 'select',
-                                label: 'आज'
-                            }} />
+                            localizedText={{
+                                todayLabel: 'आज'
+                            }}
+                            todayActionType='select' />
                     </div>
                 </Column>
             </Row>
@@ -357,8 +357,8 @@ export const localizedTodayFooterButton = () => (
 /**
  * Setting
  *
- * - `todayAction.type` to `'navigate'`
- * - And localized non-empty string value for `todayAction.label`
+ * - `todayActionType` to `'navigate'`
+ * - And localized non-empty string value for `localizedText.todayLabel`
  *
  * will show a header action in the DatePicker popover.
  *
@@ -380,10 +380,10 @@ export const localizedTodayHeaderButton = () => (
                         inputProps={{
                             id: 'englishTodayButtonDP'
                         }}
-                        todayAction={{
-                            type: 'navigate',
-                            label: 'Today'
-                        }} />
+                        localizedText={{
+                            todayLabel: 'Today'
+                        }}
+                        todayActionType='navigate' />
                 </div>
             </Column>
             <Column>
@@ -398,10 +398,10 @@ export const localizedTodayHeaderButton = () => (
                             id: 'hindiTodayButtonDP'
                         }}
                         locale='hi'
-                        todayAction={{
-                            type: 'navigate',
-                            label: 'आज'
-                        }} />
+                        localizedText={{
+                            todayLabel: 'आज'
+                        }}
+                        todayActionType='navigate' />
                 </div>
             </Column>
         </Row>
@@ -460,21 +460,21 @@ export const dev = () => (
         disabledDates={[dateKnobToDate('disable date', disabledDateDefault)]}
         enableRangeSelection={boolean('enableRangeSelection', true)}
         locale={text('locale', 'en')}
+        localizedText={{
+            todayLabel: text('localizedText.todayLabel', 'Today')
+        }}
         onChange={action('on-change')}
         onDatePickerClose={action('on-date-picker-close')}
         onInputBlur={action('on-input-blur')}
         onInputFocus={action('on-input-focus')}
         openToDate={dateKnobToDate('open to date', new Date())}
-        todayAction={{
-            type: select('Today Action Type',
-                {
-                    'none': 'none',
-                    'select': 'select',
-                    'navigate': 'navigate'
-                }
-            ),
-            label: text('Today Action Label', 'Today')
-        }}
+        todayActionType={select('Today Action Type',
+            {
+                'none': 'none',
+                'select': 'select',
+                'navigate': 'navigate'
+            }
+        )}
         validationState={select('Validation State',
             {
                 'none': '',
@@ -518,13 +518,13 @@ export const localizedTodayFooterButtonVisualStoryShotOnly = () => (
                             inputProps={{
                                 id: 'englishTodayButtonDP'
                             }}
+                            localizedText={{
+                                todayLabel: 'Today'
+                            }}
                             popoverProps={{
                                 show: true
                             }}
-                            todayAction={{
-                                type: 'select',
-                                label: 'Today'
-                            }} />
+                            todayActionType='select' />
                     </div>
                 </Column>
                 <Column>
@@ -539,13 +539,13 @@ export const localizedTodayFooterButtonVisualStoryShotOnly = () => (
                                 id: 'hindiTodayButtonDP'
                             }}
                             locale='hi'
+                            localizedText={{
+                                todayLabel: 'आज'
+                            }}
                             popoverProps={{
                                 show: true
                             }}
-                            todayAction={{
-                                type: 'select',
-                                label: 'आज'
-                            }} />
+                            todayActionType='select' />
                     </div>
                 </Column>
             </Row>
@@ -572,13 +572,13 @@ export const localizedTodayHeaderButtonVisualStoryShotOnly = () => (
                             inputProps={{
                                 id: 'englishTodayButtonDP'
                             }}
+                            localizedText={{
+                                todayLabel: 'Today'
+                            }}
                             popoverProps={{
                                 show: true
                             }}
-                            todayAction={{
-                                type: 'navigate',
-                                label: 'Today'
-                            }} />
+                            todayActionType='navigate' />
                     </div>
                 </Column>
                 <div>
@@ -592,13 +592,13 @@ export const localizedTodayHeaderButtonVisualStoryShotOnly = () => (
                             id: 'hindiTodayButtonDP'
                         }}
                         locale='hi'
+                        localizedText={{
+                            todayLabel: 'आज'
+                        }}
                         popoverProps={{
                             show: true
                         }}
-                        todayAction={{
-                            type: 'navigate',
-                            label: 'आज'
-                        }} />
+                        todayActionType='navigate' />
                 </div>
                 <Column />
             </Row>


### PR DESCRIPTION
### Description

BREAKING CHANGE:
* Remove `todayAction` property from Datepicker
* Add `todayActionType` property to Datepicker to configure the type of today action.
* Update Datepicker to use a label for the Today action button from `localizedText.todayLabel`.

chore:
clean old visual stories before building new ones.

#### Before
```jsx
<DatePicker
    todayAction={{
        type: 'select',
        label: 'Today'
    }}
/>
```

#### After
```jsx
<DatePicker
    localizedText={{
        todayLabel: 'Today'
    }}
    todayActionType= 'select'
/>
```