### PR TITLE
fix: Select selectedKey behavior

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -8,7 +8,7 @@ import List from '../List/List';
 import Popover from '../Popover/Popover';
 import PropTypes from 'prop-types';
 import withStyles from '../utils/withStyles';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import buttonStyles from 'fundamental-styles/dist/button.css';
 import listStyles from 'fundamental-styles/dist/list.css';
 import selectStyles from 'fundamental-styles/dist/select.css';
@@ -55,6 +55,10 @@ const Select = React.forwardRef(({
     const ulRef = useRef(null);
 
     let [selectedOptionKey, setSelectedOptionKey] = useState(selectedKey);
+
+    useEffect(() => {
+        setSelectedOptionKey(selectedKey);
+    }, [selectedKey, options]);
 
     const handleClick = (e) => {
         if (!disabled && !readOnly) {

--- a/src/Select/Select.test.js
+++ b/src/Select/Select.test.js
@@ -329,7 +329,7 @@ describe('<Select />', () => {
             expect(blurSpy).toHaveBeenCalledTimes(0);
         });
 
-        test('should select the "selectedKey" when it or "options" prop change', async() => {
+        test('should select the "selectedKey" when it or "options" prop change', () => {
             const wrapper = setup({
                 selectedKey: '4'
             });

--- a/src/Select/Select.test.js
+++ b/src/Select/Select.test.js
@@ -328,6 +328,28 @@ describe('<Select />', () => {
 
             expect(blurSpy).toHaveBeenCalledTimes(0);
         });
+
+        test('should select the "selectedKey" when it or "options" prop change', async() => {
+            const wrapper = setup({
+                selectedKey: '4'
+            });
+
+            wrapper.setProps({
+                options: [
+                    ...options,
+                    { key: '5', text: 'List Item 5' }
+                ],
+                selectedKey: '5'
+            });
+
+            expect(wrapper.find('span.fd-select__text-content').getDOMNode().innerHTML).toBe('List Item 5');
+
+            wrapper.setProps({
+                selectedKey: '1'
+            });
+
+            expect(wrapper.find('span.fd-select__text-content').getDOMNode().innerHTML).toBe('List Item 1');
+        });
     });
 
     test('forwards the ref to the div role="button"', () => {


### PR DESCRIPTION

### Description
Fixes an issue where the select component did not set the `selectedKey` when new options were set.
This change should cause select to set the `selectedKey` when it or `options` prop change
