### PR TITLE
fix: restore scroll position after dialog closes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ storybook-static
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -105,6 +105,7 @@ class Dialog extends Component {
         return ReactDOM.createPortal(
             <FocusLock as='div' className={backdropClassName}
                 lockProps={{ ...rest }}
+                returnFocus
                 whiteList={allowListForLockFocus}>
                 <span data-autofocus tabIndex='-1' />
                 <div


### PR DESCRIPTION
### Description

Restore scroll position after a dialog closes

Fixes #1395 