### PR TITLE
feat: add an option to fire onclick event on actions menu, revert compact option for product switch

### DIFF
--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -424,7 +424,7 @@ class Shellbar extends Component {
                                     )}
                                     glyph='megamenu'
                                     iconProps={{ className: classnames(`${cssNamespace}-shellbar__button--icon`) }}
-                                    onClick={productSwitch.callback}
+                                    onClick={productSwitch.onClick}
                                     option='transparent'
                                     textClassName={classnames(`${cssNamespace}-shellbar__title`)}>
                                     {productSwitch.label}
@@ -534,7 +534,7 @@ class Shellbar extends Component {
                                         aria-label={productSwitch.label}
                                         className={classnames(`${cssNamespace}-product-switch__control`, `${cssNamespace}-shellbar__button`, { [`${cssNamespace}-button`]: isUsingCssModules })}
                                         glyph='grid'
-                                        onClick={productSwitch.callback} />}
+                                        onClick={productSwitch.onClick} />}
                                     disableEdgeDetection
                                     popperProps={{ id: `${cssNamespace}-shellbar-product-switch-popover` }} />
                             </div>
@@ -594,7 +594,7 @@ Shellbar.propTypes = {
         /** Renders the switch in a form of a dropdown */
         compact: PropTypes.bool,
         /** A function called when opening a switch */
-        callback: PropTypes.func
+        onClick: PropTypes.func
     }),
     /** Array of objects containing data about the products.
      * Callback and title are required; selected, glyph and subtitle are optional. */

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -424,6 +424,7 @@ class Shellbar extends Component {
                                     )}
                                     glyph='megamenu'
                                     iconProps={{ className: classnames(`${cssNamespace}-shellbar__button--icon`) }}
+                                    onClick={productSwitch.callback}
                                     option='transparent'
                                     textClassName={classnames(`${cssNamespace}-shellbar__title`)}>
                                     {productSwitch.label}
@@ -532,7 +533,8 @@ class Shellbar extends Component {
                                     control={<Button
                                         aria-label={productSwitch.label}
                                         className={classnames(`${cssNamespace}-product-switch__control`, `${cssNamespace}-shellbar__button`, { [`${cssNamespace}-button`]: isUsingCssModules })}
-                                        glyph='grid' />}
+                                        glyph='grid'
+                                        onClick={productSwitch.callback} />}
                                     disableEdgeDetection
                                     popperProps={{ id: `${cssNamespace}-shellbar-product-switch-popover` }} />
                             </div>
@@ -590,7 +592,9 @@ Shellbar.propTypes = {
         /** Accessible and localized label for product switch button */
         label: PropTypes.string.isRequired,
         /** Renders the switch in a form of a dropdown */
-        compact: PropTypes.bool
+        compact: PropTypes.bool,
+        /** A function called when opening a switch */
+        callback: PropTypes.func
     }),
     /** Array of objects containing data about the products.
      * Callback and title are required; selected, glyph and subtitle are optional. */

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -249,7 +249,8 @@ class Shellbar extends Component {
                                                         aria-label={action.label}
                                                         className={classnames(`${cssNamespace}-shellbar__button`, { [`${cssNamespace}-button`]: isUsingCssModules })}
                                                         glyph={action.glyph}
-                                                        iconBeforeText>
+                                                        iconBeforeText
+                                                        onClick={action.callback}>
                                                         {action.notificationCount > 0 && (
                                                             <Counter
                                                                 aria-label={localizedText.counterLabel}
@@ -258,6 +259,7 @@ class Shellbar extends Component {
                                                                 {action.notificationCount}
                                                             </Counter>
                                                         )}
+                                                        {action.label}
                                                     </Button>
                                                 }
                                                 popperProps={{ id: `${cssNamespace}-shellbar-actions-popover-${index}` }} />
@@ -386,53 +388,6 @@ class Shellbar extends Component {
                                 popperProps={{ id: `${cssNamespace}-shellbar-mobile-action-popover` }} />
                         </div>
                     }
-                    {productSwitch && productSwitch.compact && (
-                        <Popover
-                            {...popoverPropsFor?.[productSwitch]}
-                            body={
-                                productSwitchList && (
-                                    <Menu>
-                                        <Menu.List>
-                                            {productSwitchList.map((item, index) => {
-                                                return (
-                                                    <Menu.Item
-                                                        key={index}
-                                                        onClick={item.callback}>
-                                                        {item.glyph && (
-                                                            <>
-                                                                <Icon glyph={item.glyph} size={item.size} />
-                                                                    &nbsp;&nbsp;&nbsp;
-                                                            </>
-                                                        )}
-                                                        {item.title}
-                                                    </Menu.Item>
-                                                );
-                                            })}
-                                        </Menu.List>
-                                    </Menu>
-                                )
-                            }
-                            control={
-                                <Button
-                                    className={classnames(
-                                        `${cssNamespace}-shellbar__button--menu`,
-                                        `${cssNamespace}-button--menu`,
-                                        {
-                                            [`${cssNamespace}-button`]: isUsingCssModules,
-                                            [buttonClassnames(`${cssNamespace}-button--menu`)]: isUsingCssModules
-                                        }
-                                    )}
-                                    glyph='megamenu'
-                                    iconProps={{ className: classnames(`${cssNamespace}-shellbar__button--icon`) }}
-                                    onClick={productSwitch.onClick}
-                                    option='transparent'
-                                    textClassName={classnames(`${cssNamespace}-shellbar__title`)}>
-                                    {productSwitch.label}
-                                </Button>
-                            }
-                            noArrow
-                            popperProps={{ id: `${cssNamespace}-shellbar-product-popover` }} />
-                    )}
                     {profile && (
                         <div className={classnames(`${cssNamespace}-shellbar__action`, `${cssNamespace}-shellbar__action--show-always`)}>
                             <div className={classnames(`${cssNamespace}-user-menu`)}>
@@ -498,7 +453,7 @@ class Shellbar extends Component {
                             </div>
                         </div>
                     )}
-                    {productSwitch && !productSwitch.compact && (
+                    {productSwitch && (
                         <div className={classnames(`${cssNamespace}-shellbar__action`, `${cssNamespace}-shellbar__action--desktop`)}>
                             <div className={classnames(`${cssNamespace}-product-switch`)}>
                                 <Popover
@@ -591,8 +546,6 @@ Shellbar.propTypes = {
     productSwitch: PropTypes.shape({
         /** Accessible and localized label for product switch button */
         label: PropTypes.string.isRequired,
-        /** Renders the switch in a form of a dropdown */
-        compact: PropTypes.bool,
         /** A function called when opening a switch */
         onClick: PropTypes.func
     }),

--- a/src/Shellbar/Shellbar.js
+++ b/src/Shellbar/Shellbar.js
@@ -488,8 +488,7 @@ class Shellbar extends Component {
                                     control={<Button
                                         aria-label={productSwitch.label}
                                         className={classnames(`${cssNamespace}-product-switch__control`, `${cssNamespace}-shellbar__button`, { [`${cssNamespace}-button`]: isUsingCssModules })}
-                                        glyph='grid'
-                                        onClick={productSwitch.onClick} />}
+                                        glyph='grid' />}
                                     disableEdgeDetection
                                     popperProps={{ id: `${cssNamespace}-shellbar-product-switch-popover` }} />
                             </div>
@@ -545,9 +544,7 @@ Shellbar.propTypes = {
     /** For navigating between products. An object that contains an accessible and localized label for product switch button. */
     productSwitch: PropTypes.shape({
         /** Accessible and localized label for product switch button */
-        label: PropTypes.string.isRequired,
-        /** A function called when opening a switch */
-        onClick: PropTypes.func
+        label: PropTypes.string.isRequired
     }),
     /** Array of objects containing data about the products.
      * Callback and title are required; selected, glyph and subtitle are optional. */

--- a/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
+++ b/src/Shellbar/__stories__/__snapshots__/Shellbar.stories.storyshot
@@ -245,6 +245,7 @@ exports[`Storyshots Component API/Shellbar Co Pilot 1`] = `
                 >
                   5
                 </span>
+                Settings
               </span>
             </button>
           </div>
@@ -609,6 +610,7 @@ exports[`Storyshots Component API/Shellbar Dev 1`] = `
                 >
                   5
                 </span>
+                Settings
               </span>
             </button>
           </div>

--- a/src/SideNavigation/_SideNavListItem.js
+++ b/src/SideNavigation/_SideNavListItem.js
@@ -166,8 +166,8 @@ SideNavListItem.propTypes = {
     id: PropTypes.string,
     /** Internal use only */
     isSubItem: PropTypes.bool,
-    /** Localized text for the item (when `url` is provided) */
-    name: PropTypes.string,
+    /** Localized text or React element for the item (when `url` is provided) */
+    name: PropTypes.oneOf[PropTypes.string, PropTypes.node],
     /** Internal use only */
     selected: PropTypes.bool,
     /** Internal use only */

--- a/src/SideNavigation/__stories__/SideNav.stories.js
+++ b/src/SideNavigation/__stories__/SideNav.stories.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-multi-comp */
+import Icon from '../../Icon/Icon';
 import React from 'react';
 import SideNav from '../SideNav';
 import SideNavList from '../_SideNavList';
@@ -38,7 +39,8 @@ export const primary = () => (
                 url='#' />
             <SideNav.ListItem
                 id='item-5'
-                name='Link Item'
+                name={<>External Link Item <Icon glyph='action' /></>}
+                onClick={() => alert('Redirection')}
                 url='#' />
         </SideNav.List>
     </SideNav>

--- a/src/SideNavigation/__stories__/__snapshots__/SideNav.stories.storyshot
+++ b/src/SideNavigation/__stories__/__snapshots__/SideNav.stories.storyshot
@@ -541,7 +541,11 @@ exports[`Storyshots Component API/SideNav Primary 1`] = `
           <span
             className="fd-nested-list__title"
           >
-            Link Item
+            External Link Item 
+            <i
+              className="sap-icon--action"
+              role="img"
+            />
           </span>
         </a>
       </li>


### PR DESCRIPTION
### Description

- revert compact option from product switch - the same thing can be done using actions when we'll add some features there
- add label and onclick to actions
- add a possibility to use nodes instead of just strings to sidensv